### PR TITLE
perf(phase1): code-split post-LCP analytics

### DIFF
--- a/admin-app/components/analytics/PostLCPAnalytics.tsx
+++ b/admin-app/components/analytics/PostLCPAnalytics.tsx
@@ -1,8 +1,24 @@
 'use client';
 
-import { SiteAnalytics } from '@/components/analytics/SiteAnalytics';
-import { LinkClickTracker } from '@/components/analytics/LinkClickTracker';
+import dynamic from 'next/dynamic';
+
 import { useAfterLCP } from '@/components/perf/useAfterLCP';
+
+const SiteAnalytics = dynamic(
+  () =>
+    import('@/components/analytics/SiteAnalytics').then((m) => ({
+      default: m.SiteAnalytics,
+    })),
+  { ssr: false }
+);
+
+const LinkClickTracker = dynamic(
+  () =>
+    import('@/components/analytics/LinkClickTracker').then((m) => ({
+      default: m.LinkClickTracker,
+    })),
+  { ssr: false }
+);
 
 /**
  * Mount analytics only after LCP.


### PR DESCRIPTION
Evidence (ops/logs/phase1 latest, mobile median run05):\n- Long tasks top: 235ms attributed to /_next/static/chunks/4bd1b696-...js; main-thread Script Evaluation ~678ms; Style & Layout ~471ms.\n- observedLCP ~832ms but simulated LCP ~5357ms  CPU/main-thread work dominates under throttling.\n\nChange (1 file):\n- admin-app/components/analytics/PostLCPAnalytics.tsx now loads SiteAnalytics + LinkClickTracker via next/dynamic (ssr:false) to keep post-LCP analytics code out of the main chunk.\n\nExpected impact:\n- Reduce main chunk JS parse/eval and long tasks attributed to 4bd1 chunk, improving Mobile TBT/LCP and Desktop perf.\n\nBuild: cd admin-app; npm run build