### PR TITLE
Phase1 iter-06: wait for LCP quiet window

### DIFF
--- a/admin-app/components/perf/useAfterLCP.ts
+++ b/admin-app/components/perf/useAfterLCP.ts
@@ -5,6 +5,8 @@ import { useEffect, useState } from 'react';
 type UseAfterLCPOptions = {
   /** Hard fallback in case LCP cannot be observed (older browsers / blocked APIs). */
   fallbackMs?: number;
+  /** Debounce window: wait for LCP to stop updating before enabling deferred work. */
+  quietWindowMs?: number;
 };
 
 /**
@@ -13,7 +15,11 @@ type UseAfterLCPOptions = {
  * Purpose: move non-critical client work (analytics, observers, CTAs) out of the
  * LCP window so it cannot block the LCP paint under Lighthouse CPU throttling.
  */
-export function useAfterLCP({ fallbackMs = 15000 }: UseAfterLCPOptions = {}) {
+export function useAfterLCP(options: UseAfterLCPOptions = {}) {
+  const fallbackMs = typeof options.fallbackMs === 'number' ? options.fallbackMs : 15000;
+  const quietWindowMs =
+    typeof options.quietWindowMs === 'number' ? options.quietWindowMs : 1200;
+
   const [afterLcp, setAfterLcp] = useState(false);
 
   useEffect(() => {
@@ -25,6 +31,20 @@ export function useAfterLCP({ fallbackMs = 15000 }: UseAfterLCPOptions = {}) {
     };
 
     const fallbackTimer = setTimeout(mark, fallbackMs);
+    let quietTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const scheduleAfterQuietWindow = (quietWindowMs: number) => {
+      if (done) return;
+      if (quietTimer) clearTimeout(quietTimer);
+      quietTimer = setTimeout(mark, quietWindowMs);
+    };
+
+    const onVisibilityChange = () => {
+      // When the page is hidden, LCP is finalized — safe to enable deferred work.
+      if (document.visibilityState === 'hidden') mark();
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
 
     // Prefer observing LCP directly.
     try {
@@ -33,9 +53,9 @@ export function useAfterLCP({ fallbackMs = 15000 }: UseAfterLCPOptions = {}) {
           // Any LCP entry means the metric was recorded.
           const entries = list.getEntries();
           if (entries.length > 0) {
-            // Ensure we run after the entry is processed.
-            setTimeout(mark, 0);
-            po.disconnect();
+            // LCP can update multiple times; wait for a short quiet window so we
+            // don't enable deferred work during the real (final) LCP window.
+            scheduleAfterQuietWindow(quietWindowMs);
           }
         });
 
@@ -45,7 +65,9 @@ export function useAfterLCP({ fallbackMs = 15000 }: UseAfterLCPOptions = {}) {
         po.observe({ type: 'largest-contentful-paint', buffered: true } as any);
 
         return () => {
+          document.removeEventListener('visibilitychange', onVisibilityChange);
           clearTimeout(fallbackTimer);
+          if (quietTimer) clearTimeout(quietTimer);
           po.disconnect();
         };
       }
@@ -54,9 +76,11 @@ export function useAfterLCP({ fallbackMs = 15000 }: UseAfterLCPOptions = {}) {
     }
 
     return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
       clearTimeout(fallbackTimer);
+      if (quietTimer) clearTimeout(quietTimer);
     };
-  }, [fallbackMs]);
+  }, [fallbackMs, quietWindowMs]);
 
   return afterLcp;
 }

--- a/ops/STATE.md
+++ b/ops/STATE.md
@@ -1,7 +1,7 @@
 # ops/STATE.md (STATE-LOCK)
 
 - CurrentPhase: A+B=PASS, Phase1=FAIL, Phase2=BLOCKED, Phase3=BLOCKED, Phase4=BLOCKED, Phase5=BLOCKED
-- CurrentIteration: phase1-iter-06 (evidence pending)
+- CurrentIteration: phase1-iter-06 (patch prepared)
 - MainlineStatus: RUNNING
 - LatestEvidence: ops/logs/phase1/
   - cf-headers.txt (2026-02-24 20:51:36)
@@ -21,5 +21,5 @@
   - Lighthouse truth model: use simulated LCP (`audits[largest-contentful-paint].numericValue`) as truth; observed is supporting note only
   - Lighthouse gates: mobile>=92, desktop>=97, CLS=0, DOM<900, hydrationSignals=0
   - Avoid evidence bloat: evidence PR should prefer lh-*.{txt,json}, hydration.txt, cf-headers.txt, ops/STATE.md (attempt files only if necessary)
-- NextAction: Build Evidence Pack for phase1-iter-06 from ops/logs/phase1 (main), propose Options A/B, choose 1 patch ≤300LOC ≤5files, build → PR → merge+deploy → production evidence → evidence PR
-- LastResultSummary: Phase1 FAIL — mobile median perf=78 LCP=4963ms TBT=210ms CLS=0 DOM=687; desktop median perf=96 LCP=1401ms TBT=1ms CLS=0 DOM=687
+- NextAction: Open PR for phase1-iter-06 patch (useAfterLCP waits for LCP quiet window), merge+deploy, then collect production evidence (lh-*.{txt,json}, hydration.txt, cf-headers.txt) and update ops/STATE.md in the evidence PR
+- LastResultSummary: Phase1 FAIL (baseline) — suspected culprit: DeferredProviders mounting too early due to first LCP entry; patch changes useAfterLCP to debounce until LCP stabilizes


### PR DESCRIPTION
# Evidence Pack (Phase1 iter-06)  STRICT (simulated LCP numericValue only)

URL under test: https://amppattaya.com/en/
Ground truth: Lighthouse `audits[largest-contentful-paint].numericValue` (simulated LCP). Observed LCP is not used for decisions.

## Baseline (ops/logs/phase1)

### Mobile (5-run median)
- PerfScoreMed: 78 (gate >= 92)  FAIL
- Simulated LCP Med: 4963.21 ms (gate <= 2500)  FAIL
- TBT Med: 209.53 ms (gate <= 200)  FAIL (borderline)
- CLS Med: 0 (gate = 0)  PASS
- DOM Med: 687 (gate < 900)  PASS
- HydrationSignals: 0  PASS

### Desktop (5-run median)
- PerfScoreMed: 96 (gate >= 97)  FAIL
- Simulated LCP Med: 1400.84 ms (gate <= 2500)  PASS
- TBT Med: 1 ms (gate <= 200)  PASS
- CLS Med: 0 (gate = 0)  PASS
- DOM Med: 687 (gate < 900)  PASS
- HydrationSignals: 0  PASS

## Top Culprits (median-run report)

### bootup-time (JS execution time)  Top URLs
Mobile median-run: ops/logs/phase1/lh-mobile-run05.json
- https://amppattaya.com/_next/static/chunks/3794-87906f1e0012bc6c.js  854.50 ms
- Unattributable  447.14 ms
- https://amppattaya.com/en/ (LH run URL)  437.68 ms

Desktop median-run: ops/logs/phase1/lh-desktop-run02.json
- https://amppattaya.com/_next/static/chunks/3794-87906f1e0012bc6c.js  167.71 ms
- https://amppattaya.com/en/ (LH run URL)  132.09 ms
- Unattributable  110.74 ms

### unused-javascript  Top URLs
Mobile median-run:
- https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js  22,918 bytes

Desktop median-run:
- https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js  22,843 bytes

### long-tasks  Top URLs
Mobile median-run:
- https://amppattaya.com/_next/static/chunks/3794-87906f1e0012bc6c.js  238 ms
- https://amppattaya.com/_next/static/chunks/3794-87906f1e0012bc6c.js  94 ms
- Unattributable  94 ms

Desktop median-run:
- (no long-tasks items reported)

## Root cause  Patch idea  Expected metric movement (reasoning only)

Root cause hypothesis (from audits above):
- A heavy client chunk (`/chunks/3794-...js`) dominates JS execution time on mobile and produces long main-thread tasks.
- If deferred client providers mount too early (triggered immediately on the first LCP entry), additional non-critical client work can overlap the true/final LCP window under CPU throttling, inflating simulated LCP and slightly pushing TBT over the gate.

Patch idea (iter-06):
- `useAfterLCP` should not unlock deferred providers on the first LCP entry; instead wait for a short LCP quiet window (debounce) so deferred work begins only after LCP stabilizes/finalizes.

Expected improvements:
- Mobile: Simulated LCP should drop (less main-thread contention during LCP window), TBT should drop below 200 ms, raising PerfScore toward >= 92.
- Desktop: May gain +1 PerfScore (to >= 97) by reducing any residual early JS work, though desktop is already LCP/TBT clean.

---

# Patch
One patch / iteration: ONLY `useAfterLCP.ts` + `ops/STATE.md`.