### PR TITLE
Phase1 iter-08: remove reveal fallback delay

### DIFF
--- a/admin-app/app/globals.css
+++ b/admin-app/app/globals.css
@@ -2260,7 +2260,7 @@ summary.mobile-nav__trigger::-webkit-details-marker {
 }
 
 .reveal:not(.reveal--in) {
-  animation: reveal-fallback 0s 3s forwards;
+  animation: reveal-fallback 0s 0s forwards;
 }
 
 /* ======================== SKELETON LOADING ======================== */

--- a/ops/STATE.md
+++ b/ops/STATE.md
@@ -1,7 +1,7 @@
 # ops/STATE.md (STATE-LOCK)
 
 - CurrentPhase: A+B=PASS, Phase1=FAIL, Phase2=BLOCKED, Phase3=BLOCKED, Phase4=BLOCKED, Phase5=BLOCKED
-- CurrentIteration: phase1-iter-07 (evidence collected)
+- CurrentIteration: phase1-iter-08 (patch prepared)
 - MainlineStatus: RUNNING
 - LatestEvidence: ops/logs/phase1/
   - cf-headers.txt (2026-02-24 23:35:04)
@@ -21,5 +21,5 @@
   - Lighthouse truth model: use simulated LCP (`audits[largest-contentful-paint].numericValue`) as truth; observed is supporting note only
   - Lighthouse gates: mobile>=92, desktop>=97, CLS=0, DOM<900, hydrationSignals=0
   - Avoid evidence bloat: evidence PR should prefer lh-*.{txt,json}, hydration.txt, cf-headers.txt, ops/STATE.md (attempt files only if necessary)
-- NextAction: phase1-iter-08 — build new Evidence Pack from latest ops/logs/phase1 (simulated LCP truth), propose Options A/B, choose 1 patch ≤300LOC ≤5files, PR → merge+deploy → production lh:gate → evidence PR
+- NextAction: Open PR for phase1-iter-08 patch (make .reveal fallback immediate to avoid paint delay when ScrollReveal is deferred), merge+deploy, then run CF verify + `npm run lh:gate` and open evidence-only PR
 - LastResultSummary: Phase1 FAIL (iter-07 post-deploy) — mobile median perf=77 LCP=5042ms TBT=211ms CLS=0 DOM=717; desktop median perf=96 LCP=1349ms TBT=1ms CLS=0 DOM=681 (fail: mobile perf+lcp+tbt; desktop perf)


### PR DESCRIPTION
﻿# Evidence Pack (Phase1 iter-08)  STRICT (simulated LCP numericValue only)

URL under test: https://amppattaya.com/en/
Ground truth: Lighthouse audits[largest-contentful-paint].numericValue (simulated LCP).

## Baseline (latest ops/logs/phase1)

Mobile (5-run median)
- PerfScoreMed: 77 (gate >= 92)  FAIL
- Simulated LCP Med: 5042 ms (gate <= 2500)  FAIL
- TBT Med: 211 ms (gate <= 200)  FAIL (borderline)
- CLS Med: 0  PASS
- DOM Med: 717  PASS

Desktop (5-run median)
- PerfScoreMed: 96 (gate >= 97)  FAIL
- Simulated LCP Med: 1349 ms  PASS
- TBT Med: 1 ms  PASS
- CLS Med: 0  PASS
- DOM Med: 681  PASS

## Top 3 culprits (bootup-time / unused-javascript / long-tasks)
- bootup-time: heavy Next.js chunks still dominate execution (notably /_next/static/chunks/3794-js)
- unused-javascript: /_next/static/chunks/4bd1js ~22KB wasted
- long-tasks: long main-thread tasks include webpack runtime + the same chunks above

## Root cause  patch idea  expected metric movement (reasoning only)

Root cause hypothesis
- Hero image download is fast (preloaded, high priority) yet simulated LCP remains ~5s, implying a paint/visibility delay rather than network.
- `.reveal` elements start `opacity:0` and are only shown by JS (ScrollReveal) or a CSS fallback after 3s. Since ScrollReveal is intentionally deferred (Phase1), above-the-fold content that uses `.reveal` can stay invisible long enough to inflate simulated LCP.

Patch idea (iter-08)
- Make the CSS fallback immediate so `.reveal` elements are not held invisible while deferred JS initializes.

Expected improvements
- Mobile: simulated LCP down; PerfScore up; reduce risk of LCP being pegged to reveal fallback timing.

---

# Patch scope
One patch / iteration.
Files changed:
- admin-app/app/globals.css
- ops/STATE.md
