### PR TITLE
Phase1 iter-09: Option A post-LCP idle/interaction gate

### DIFF
--- a/admin-app/components/layout/DeferredProviders.tsx
+++ b/admin-app/components/layout/DeferredProviders.tsx
@@ -12,6 +12,7 @@
  * modules are excluded from the initial SSR HTML and fetched lazily.
  */
 import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
 
 import { useAfterLCP } from '@/components/perf/useAfterLCP';
 
@@ -64,9 +65,86 @@ const StickyMobileCTA = dynamic(
 );
 
 export function DeferredProviders() {
-  // Deterministic: only mount after LCP is observed (or a hard fallback).
-  const enabled = useAfterLCP();
-  if (!enabled) return null;
+  // Stage 1: deterministic gate after LCP settles.
+  const afterLcp = useAfterLCP({ postLcpDelayMs: 300 });
+  // Stage 2: additional delay gate to move non-critical providers to idle/interaction.
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!afterLcp) {
+      setReady(false);
+      return;
+    }
+
+    let done = false;
+    let minDelayPassed = false;
+    let idleReached = false;
+    let interacted = false;
+
+    let minDelayTimer: ReturnType<typeof setTimeout> | null = null;
+    let hardTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+    let idleId: number | null = null;
+
+    const markReady = () => {
+      if (done) return;
+      done = true;
+      setReady(true);
+    };
+
+    const tryReady = () => {
+      if (done) return;
+      if (minDelayPassed && (idleReached || interacted)) {
+        markReady();
+      }
+    };
+
+    const onInteraction = () => {
+      interacted = true;
+      tryReady();
+    };
+
+    minDelayTimer = setTimeout(() => {
+      minDelayPassed = true;
+      tryReady();
+    }, 900);
+
+    hardTimeoutTimer = setTimeout(markReady, 4000);
+
+    if ('requestIdleCallback' in window) {
+      idleId = window.requestIdleCallback(
+        () => {
+          idleReached = true;
+          tryReady();
+        },
+        { timeout: 2500 }
+      );
+    } else {
+      setTimeout(() => {
+        idleReached = true;
+        tryReady();
+      }, 1200);
+    }
+
+    window.addEventListener('pointerdown', onInteraction, { once: true, passive: true });
+    window.addEventListener('keydown', onInteraction, { once: true, passive: true });
+    window.addEventListener('touchstart', onInteraction, { once: true, passive: true });
+    window.addEventListener('scroll', onInteraction, { once: true, passive: true });
+
+    return () => {
+      done = true;
+      if (minDelayTimer) clearTimeout(minDelayTimer);
+      if (hardTimeoutTimer) clearTimeout(hardTimeoutTimer);
+      if (idleId !== null && 'cancelIdleCallback' in window) {
+        window.cancelIdleCallback(idleId);
+      }
+      window.removeEventListener('pointerdown', onInteraction);
+      window.removeEventListener('keydown', onInteraction);
+      window.removeEventListener('touchstart', onInteraction);
+      window.removeEventListener('scroll', onInteraction);
+    };
+  }, [afterLcp]);
+
+  if (!ready) return null;
 
   return (
     <>

--- a/admin-app/components/perf/useAfterLCP.ts
+++ b/admin-app/components/perf/useAfterLCP.ts
@@ -7,6 +7,8 @@ type UseAfterLCPOptions = {
   fallbackMs?: number;
   /** Debounce window: wait for LCP to stop updating before enabling deferred work. */
   quietWindowMs?: number;
+  /** Optional minimum delay after LCP is finalized before enabling deferred work. */
+  postLcpDelayMs?: number;
 };
 
 /**
@@ -19,15 +21,26 @@ export function useAfterLCP(options: UseAfterLCPOptions = {}) {
   const fallbackMs = typeof options.fallbackMs === 'number' ? options.fallbackMs : 15000;
   const quietWindowMs =
     typeof options.quietWindowMs === 'number' ? options.quietWindowMs : 1200;
+  const postLcpDelayMs =
+    typeof options.postLcpDelayMs === 'number' ? options.postLcpDelayMs : 0;
 
   const [afterLcp, setAfterLcp] = useState(false);
 
   useEffect(() => {
     let done = false;
-    const mark = () => {
+    const markNow = () => {
       if (done) return;
       done = true;
       setAfterLcp(true);
+    };
+
+    const mark = () => {
+      if (done) return;
+      if (postLcpDelayMs > 0) {
+        setTimeout(markNow, postLcpDelayMs);
+        return;
+      }
+      markNow();
     };
 
     const fallbackTimer = setTimeout(mark, fallbackMs);
@@ -80,7 +93,7 @@ export function useAfterLCP(options: UseAfterLCPOptions = {}) {
       clearTimeout(fallbackTimer);
       if (quietTimer) clearTimeout(quietTimer);
     };
-  }, [fallbackMs, quietWindowMs]);
+  }, [fallbackMs, quietWindowMs, postLcpDelayMs]);
 
   return afterLcp;
 }

--- a/ops/STATE.md
+++ b/ops/STATE.md
@@ -1,7 +1,7 @@
 # ops/STATE.md (STATE-LOCK)
 
 - CurrentPhase: A+B=PASS, Phase1=FAIL, Phase2=BLOCKED, Phase3=BLOCKED, Phase4=BLOCKED, Phase5=BLOCKED
-- CurrentIteration: phase1-iter-08 (evidence collected)
+- CurrentIteration: phase1-iter-09 (patch prepared: option A, ready for PR)
 - MainlineStatus: RUNNING
 - LatestEvidence: ops/logs/phase1/
   - cf-headers.txt (2026-02-24 23:44:47)
@@ -21,5 +21,5 @@
   - Lighthouse truth model: use simulated LCP (`audits[largest-contentful-paint].numericValue`) as truth; observed is supporting note only
   - Lighthouse gates: mobile>=92, desktop>=97, CLS=0, DOM<900, hydrationSignals=0
   - Avoid evidence bloat: evidence PR should prefer lh-*.{txt,json}, hydration.txt, cf-headers.txt, ops/STATE.md (attempt files only if necessary)
-- NextAction: phase1-iter-09 — build new Evidence Pack from latest ops/logs/phase1 (simulated LCP truth), propose Options A/B, choose 1 patch ≤300LOC ≤5files, PR → merge+deploy → production lh:gate → evidence PR
-- LastResultSummary: Phase1 FAIL (iter-08 post-deploy) — mobile median perf=78 LCP=4823ms TBT=255ms CLS=0 DOM=687; desktop median perf=94 LCP=1579ms TBT=6ms CLS=0 DOM=687 (fail: mobile perf+lcp+tbt; desktop perf)
+- NextAction: Open PR for phase1-iter-09 Option A patch (post-LCP delay gate + idle/interaction gate in DeferredProviders), merge+deploy, then CF verify + production lh:gate, then evidence-only PR
+- LastResultSummary: Phase1 FAIL (iter-08 post-deploy) — mobile median perf=78 LCP=4823ms TBT=255ms CLS=0 DOM=687; desktop median perf=94 LCP=1579ms TBT=6ms CLS=0 DOM=687 (fail: mobile perf+lcp+tbt; desktop perf). Iter-09 decision: Option A selected (desktop recovery priority, no-regression guard)


### PR DESCRIPTION
﻿Iter-09 Option A patch (STRICT):

Scope (3 files only):
- admin-app/components/layout/DeferredProviders.tsx
- admin-app/components/perf/useAfterLCP.ts
- ops/STATE.md

What changed:
- Added a second delay gate after LCP: DeferredProviders now waits for:
  1) after-LCP signal,
  2) minimum post-LCP delay,
  3) idle callback or user interaction (with hard timeout fallback)
- Added optional postLcpDelayMs support in useAfterLCP.

Safety constraints:
- No SSR output change.
- No extra network requests before LCP (deferred providers still mount only after post-LCP gate).
- Intended to reduce early non-critical client init pressure and recover desktop perf.

Build:
- admin-app build passed (`npm run build`).
