### PR TITLE
Phase1 iter-10: Option B split heavy deferred execution

### DIFF
--- a/admin-app/components/layout/DeferredProviders.tsx
+++ b/admin-app/components/layout/DeferredProviders.tsx
@@ -69,6 +69,8 @@ export function DeferredProviders() {
   const afterLcp = useAfterLCP({ postLcpDelayMs: 300 });
   // Stage 2: additional delay gate to move non-critical providers to idle/interaction.
   const [ready, setReady] = useState(false);
+  // Stage 3: heavy modules gate (source path for long tasks / bootup / unused-js hot spots).
+  const [heavyReady, setHeavyReady] = useState(false);
 
   useEffect(() => {
     if (!afterLcp) {
@@ -144,16 +146,91 @@ export function DeferredProviders() {
     };
   }, [afterLcp]);
 
+  useEffect(() => {
+    if (!ready) {
+      setHeavyReady(false);
+      return;
+    }
+
+    let done = false;
+    let interacted = false;
+    let idleReached = false;
+
+    let engageTimeout: ReturnType<typeof setTimeout> | null = null;
+    let idleTimeout: ReturnType<typeof setTimeout> | null = null;
+    let idleId: number | null = null;
+
+    const markHeavyReady = () => {
+      if (done) return;
+      done = true;
+      setHeavyReady(true);
+    };
+
+    const tryHeavyReady = () => {
+      if (done) return;
+      if (interacted && idleReached) {
+        markHeavyReady();
+      }
+    };
+
+    const onInteraction = () => {
+      interacted = true;
+      tryHeavyReady();
+    };
+
+    engageTimeout = setTimeout(() => {
+      interacted = true;
+      tryHeavyReady();
+    }, 6000);
+
+    if ('requestIdleCallback' in window) {
+      idleId = window.requestIdleCallback(
+        () => {
+          idleReached = true;
+          tryHeavyReady();
+        },
+        { timeout: 3500 }
+      );
+    } else {
+      idleTimeout = setTimeout(() => {
+        idleReached = true;
+        tryHeavyReady();
+      }, 1800);
+    }
+
+    window.addEventListener('pointerdown', onInteraction, { once: true, passive: true });
+    window.addEventListener('keydown', onInteraction, { once: true, passive: true });
+    window.addEventListener('touchstart', onInteraction, { once: true, passive: true });
+    window.addEventListener('scroll', onInteraction, { once: true, passive: true });
+
+    return () => {
+      done = true;
+      if (engageTimeout) clearTimeout(engageTimeout);
+      if (idleTimeout) clearTimeout(idleTimeout);
+      if (idleId !== null && 'cancelIdleCallback' in window) {
+        window.cancelIdleCallback(idleId);
+      }
+      window.removeEventListener('pointerdown', onInteraction);
+      window.removeEventListener('keydown', onInteraction);
+      window.removeEventListener('touchstart', onInteraction);
+      window.removeEventListener('scroll', onInteraction);
+    };
+  }, [ready]);
+
   if (!ready) return null;
 
   return (
     <>
-      <PostLCPAnalytics />
-      <ExperimentProvider />
-      <ScrollReveal />
       <FloatingWhatsAppCTA />
       <StickyMobileCTA />
       <CookieConsent />
+      {heavyReady ? (
+        <>
+          <PostLCPAnalytics />
+          <ExperimentProvider />
+          <ScrollReveal />
+        </>
+      ) : null}
     </>
   );
 }

--- a/ops/STATE.md
+++ b/ops/STATE.md
@@ -1,7 +1,7 @@
 # ops/STATE.md (STATE-LOCK)
 
 - CurrentPhase: A+B=PASS, Phase1=FAIL, Phase2=BLOCKED, Phase3=BLOCKED, Phase4=BLOCKED, Phase5=BLOCKED
-- CurrentIteration: phase1-iter-09 (evidence collected)
+- CurrentIteration: phase1-iter-10 (patch prepared: option B)
 - MainlineStatus: RUNNING
 - LatestEvidence: ops/logs/phase1/
   - cf-headers.txt (2026-02-25 06:31:33)
@@ -21,5 +21,5 @@
   - Lighthouse truth model: use simulated LCP (`audits[largest-contentful-paint].numericValue`) as truth; observed is supporting note only
   - Lighthouse gates: mobile>=92, desktop>=97, CLS=0, DOM<900, hydrationSignals=0
   - Avoid evidence bloat: evidence PR should prefer lh-*.{txt,json}, hydration.txt, cf-headers.txt, ops/STATE.md (attempt files only if necessary)
-- NextAction: phase1-iter-10 — Evidence Pack + A/B options first (STRICT), prioritize Mobile TBT<=200 and LCP reduction while holding Desktop median >=97
-- LastResultSummary: Phase1 PARTIAL (iter-09 post-deploy) — desktop median perf=97 LCP=1232ms TBT=0ms (PASS, no-regression achieved); mobile median perf=79 LCP=4635ms TBT=231ms (FAIL: perf<92, lcp>2500, tbt>200)
+- NextAction: Open PR for phase1-iter-10 Option B patch (defer heavy DeferredProviders modules tied to 4bd1/3794 path to post-interaction+idle), merge+deploy, then CF verify + production lh:gate, then evidence-only PR
+- LastResultSummary: Phase1 PARTIAL (iter-09 post-deploy) — desktop median perf=97 LCP=1232ms TBT=0ms (PASS, no-regression achieved); mobile median perf=79 LCP=4635ms TBT=231ms (FAIL: perf<92, lcp>2500, tbt>200). Iter-10 decision: Option B selected (mobile-first with desktop guard)


### PR DESCRIPTION
﻿Iter-10 Option B (STRICT one patch)

Changed files:
- admin-app/components/layout/DeferredProviders.tsx
- ops/STATE.md

Source path tied to heavy chunks on home route:
- `DeferredProviders` dynamically imports and mounts these modules together: PostLCPAnalytics, ExperimentProvider, ScrollReveal, FloatingWhatsAppCTA, StickyMobileCTA, CookieConsent.
- This mount burst aligns with evidence hot spots from median-run logs:
  - bootup-time top: heavy execution in JS chunks (notably paths associated with 3794 + 4bd1)
  - long-tasks top: 4bd1/3794-linked execution spikes on mobile
  - unused-javascript top: 4bd1 chunk wasted bytes on both mobile/desktop

Patch strategy:
- Keep SSR output unchanged.
- Keep pre-LCP network behavior unchanged (all deferred modules still gated post-LCP).
- Split deferred providers into light vs heavy stage:
  - Light stage mounts CTA/cookie after existing post-LCP gate.
  - Heavy stage (analytics/experiment/reveal) waits for interaction + idle (with timeout fallback).
- Goal: cut/shift execution on 4bd1/3794 path away from critical mobile window.

Build:
- admin-app `npm run build` passed.
