### PR TITLE
Phase1 iter-11 repair: revert #201 deferred split

### DIFF
--- a/admin-app/components/layout/DeferredProviders.tsx
+++ b/admin-app/components/layout/DeferredProviders.tsx
@@ -69,8 +69,6 @@ export function DeferredProviders() {
   const afterLcp = useAfterLCP({ postLcpDelayMs: 300 });
   // Stage 2: additional delay gate to move non-critical providers to idle/interaction.
   const [ready, setReady] = useState(false);
-  // Stage 3: heavy modules gate (source path for long tasks / bootup / unused-js hot spots).
-  const [heavyReady, setHeavyReady] = useState(false);
 
   useEffect(() => {
     if (!afterLcp) {
@@ -146,91 +144,16 @@ export function DeferredProviders() {
     };
   }, [afterLcp]);
 
-  useEffect(() => {
-    if (!ready) {
-      setHeavyReady(false);
-      return;
-    }
-
-    let done = false;
-    let interacted = false;
-    let idleReached = false;
-
-    let engageTimeout: ReturnType<typeof setTimeout> | null = null;
-    let idleTimeout: ReturnType<typeof setTimeout> | null = null;
-    let idleId: number | null = null;
-
-    const markHeavyReady = () => {
-      if (done) return;
-      done = true;
-      setHeavyReady(true);
-    };
-
-    const tryHeavyReady = () => {
-      if (done) return;
-      if (interacted && idleReached) {
-        markHeavyReady();
-      }
-    };
-
-    const onInteraction = () => {
-      interacted = true;
-      tryHeavyReady();
-    };
-
-    engageTimeout = setTimeout(() => {
-      interacted = true;
-      tryHeavyReady();
-    }, 6000);
-
-    if ('requestIdleCallback' in window) {
-      idleId = window.requestIdleCallback(
-        () => {
-          idleReached = true;
-          tryHeavyReady();
-        },
-        { timeout: 3500 }
-      );
-    } else {
-      idleTimeout = setTimeout(() => {
-        idleReached = true;
-        tryHeavyReady();
-      }, 1800);
-    }
-
-    window.addEventListener('pointerdown', onInteraction, { once: true, passive: true });
-    window.addEventListener('keydown', onInteraction, { once: true, passive: true });
-    window.addEventListener('touchstart', onInteraction, { once: true, passive: true });
-    window.addEventListener('scroll', onInteraction, { once: true, passive: true });
-
-    return () => {
-      done = true;
-      if (engageTimeout) clearTimeout(engageTimeout);
-      if (idleTimeout) clearTimeout(idleTimeout);
-      if (idleId !== null && 'cancelIdleCallback' in window) {
-        window.cancelIdleCallback(idleId);
-      }
-      window.removeEventListener('pointerdown', onInteraction);
-      window.removeEventListener('keydown', onInteraction);
-      window.removeEventListener('touchstart', onInteraction);
-      window.removeEventListener('scroll', onInteraction);
-    };
-  }, [ready]);
-
   if (!ready) return null;
 
   return (
     <>
+      <PostLCPAnalytics />
+      <ExperimentProvider />
+      <ScrollReveal />
       <FloatingWhatsAppCTA />
       <StickyMobileCTA />
       <CookieConsent />
-      {heavyReady ? (
-        <>
-          <PostLCPAnalytics />
-          <ExperimentProvider />
-          <ScrollReveal />
-        </>
-      ) : null}
     </>
   );
 }

--- a/ops/STATE.md
+++ b/ops/STATE.md
@@ -1,7 +1,7 @@
 # ops/STATE.md (STATE-LOCK)
 
 - CurrentPhase: A+B=PASS, Phase1=FAIL, Phase2=BLOCKED, Phase3=BLOCKED, Phase4=BLOCKED, Phase5=BLOCKED
-- CurrentIteration: phase1-iter-10 (evidence collected)
+- CurrentIteration: phase1-iter-11 (repair patch prepared: option A)
 - MainlineStatus: RUNNING
 - LatestEvidence: ops/logs/phase1/
   - cf-headers.txt (2026-02-25 06:44:12)
@@ -21,5 +21,5 @@
   - Lighthouse truth model: use simulated LCP (`audits[largest-contentful-paint].numericValue`) as truth; observed is supporting note only
   - Lighthouse gates: mobile>=92, desktop>=97, CLS=0, DOM<900, hydrationSignals=0
   - Avoid evidence bloat: evidence PR should prefer lh-*.{txt,json}, hydration.txt, cf-headers.txt, ops/STATE.md (attempt files only if necessary)
-- NextAction: phase1-iter-11 — Evidence Pack + A/B options first (STRICT). Priority: recover Desktop to >=97 while preserving Mobile gains from iter-10 (TBT now <=200), then continue reducing Mobile LCP
-- LastResultSummary: Phase1 FAIL (iter-10 post-deploy) — mobile median perf=84 LCP=4090ms TBT=167ms CLS=0 DOM=717 (improved, but perf/lcp still fail); desktop median perf=92 LCP=1779ms TBT=0ms CLS=0 DOM=717 (regressed, fail: perf<97)
+- NextAction: Open PR for phase1-iter-11 repair Option A (revert PR #201 DeferredProviders split), merge+deploy, then production CF verify + lh:gate; if desktop>=97 then open/merge new evidence-only PR
+- LastResultSummary: Desktop regression observed after PR #201 split-heavy gate (post-#201 median desktop perf=92). Repair decision: Option A revert to restore desktop guard ASAP.


### PR DESCRIPTION
﻿Iter-11 Repair (Option A)  revert PR #201 split-heavy DeferredProviders

Why repair now:
- Desktop guard failed post-#201 (desktop median perf dropped to 92).
- Mainline freeze requested until desktop guard is restored.

Short desktop regression evidence (post-#201 logs):
- baseline summary: ops/logs/phase1/lh-desktop.json => median perf 92, median LCP 1778.6
- bootup-time top (desktop median-run): hot path still includes 3794 and 4bd1 chunks
- unused-javascript top: 4bd1 chunk remains top wasted bytes
- mainthread-work-breakdown: script evaluation and style/layout remain dominant buckets
- long-tasks (desktop): minimal, indicates overhead is likely from scheduling/init pattern rather than pure long-task spikes

Root-cause hypothesis:
- split-heavy gate introduced extra client scheduling/listener/render coordination on desktop path, degrading perf score despite low TBT.

Patch:
- Revert DeferredProviders split-heavy staging from #201 to restore previous stable behavior quickly.
- Keep scope minimal (code + STATE only).

Build:
- admin-app build passed.
