### PR TITLE
phase1-iter-15: OPS stability for lighthouse + desktop-only gate

### DIFF
--- a/ops/lighthouse/lh-gate.mjs
+++ b/ops/lighthouse/lh-gate.mjs
@@ -1,6 +1,23 @@
 import { spawnSync } from 'node:child_process';
 import process from 'node:process';
 
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const k = a.slice(2);
+    const v = argv[i + 1];
+    if (v && !v.startsWith('--')) {
+      out[k] = v;
+      i += 1;
+    } else {
+      out[k] = true;
+    }
+  }
+  return out;
+}
+
 function run(args) {
   const res = spawnSync(process.execPath, args, { stdio: 'inherit' });
   if (res.error) {
@@ -14,8 +31,24 @@ function run(args) {
 const outDir = 'ops/logs/phase1';
 const url = process.env.LH_URL ?? 'https://amppattaya.com/en/';
 const runs = process.env.LH_RUNS ?? '5';
+const args = parseArgs(process.argv);
+const mode = String(args.preset ?? process.env.LH_PRESET ?? 'both').toLowerCase();
 
-const mobile = run(['ops/lighthouse/run-lh.mjs', '--url', url, '--runs', runs, '--preset', 'mobile', '--outDir', outDir]);
-const desktop = run(['ops/lighthouse/run-lh.mjs', '--url', url, '--runs', runs, '--preset', 'desktop', '--outDir', outDir]);
+if (!['mobile', 'desktop', 'both'].includes(mode)) {
+  console.error(`Invalid preset mode: ${mode}. Expected mobile|desktop|both`);
+  process.exit(2);
+}
 
+const shouldRunMobile = mode === 'both' || mode === 'mobile';
+const shouldRunDesktop = mode === 'both' || mode === 'desktop';
+
+let mobile = 0;
+let desktop = 0;
+
+if (shouldRunMobile) {
+  mobile = run(['ops/lighthouse/run-lh.mjs', '--url', url, '--runs', runs, '--preset', 'mobile', '--outDir', outDir]);
+}
+if (shouldRunDesktop) {
+  desktop = run(['ops/lighthouse/run-lh.mjs', '--url', url, '--runs', runs, '--preset', 'desktop', '--outDir', outDir]);
+}
 process.exit(mobile === 0 && desktop === 0 ? 0 : 1);

--- a/ops/lighthouse/run-lh.mjs
+++ b/ops/lighthouse/run-lh.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
@@ -93,17 +93,28 @@ function runOne({ url, preset, outPath }) {
 
   const npxBin = process.platform === 'win32' ? 'npx.cmd' : 'npx';
   const res = spawnSync(npxBin, args, {
-    stdio: 'inherit',
+    stdio: 'pipe',
+    encoding: 'utf8',
     cwd: process.cwd(),
     shell: process.platform === 'win32',
   });
 
+  const stdout = typeof res.stdout === 'string' ? res.stdout : '';
+  const stderr = typeof res.stderr === 'string' ? res.stderr : '';
+  if (stdout) process.stdout.write(stdout);
+  if (stderr) process.stderr.write(stderr);
+
   if (res.error) {
     // eslint-disable-next-line no-console
     console.error(`Failed to spawn lighthouse via ${npxBin}:`, res.error.message);
-    return 1;
+    return { status: 1, output: res.error.message };
   }
-  return res.status ?? 1;
+  return { status: res.status ?? 1, output: `${stdout}\n${stderr}`.trim() };
+}
+
+function isTransientError(message) {
+  if (!message || typeof message !== 'string') return false;
+  return /CSS\.enable|NO_NAVSTART|Status code:\s*522|Status code:\s*502|Status code:\s*503|Status code:\s*504|net::|ERR_|ECONNRESET|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket hang up|timed out/i.test(message);
 }
 
 function gateFailReasons(meds, gates) {
@@ -146,8 +157,25 @@ function main() {
 
   const perRun = [];
   const attemptErrors = [];
+  const maxAttempts = Number(args.maxAttempts ?? (runs + 15));
+
+  const warmupTmpPath = path.join(outDir, `lh-${preset}-warmup.json`);
+  const warmupBust = Date.now();
+  const warmupUrl = url.includes('?') ? `${url}&lhwarm=${warmupBust}` : `${url}?lhwarm=${warmupBust}`;
+  const warmup = runOne({ url: warmupUrl, preset, outPath: warmupTmpPath });
+  if (existsSync(warmupTmpPath)) {
+    try {
+      unlinkSync(warmupTmpPath);
+    } catch {
+      // ignore cleanup failure
+    }
+  }
+  if (warmup.status !== 0) {
+    attemptErrors.push({ attempt: 0, status: warmup.status, runtimeError: 'warmup failed (ignored)', transient: isTransientError(warmup.output) });
+  }
+
   let attempt = 0;
-  const maxAttempts = runs + 10;
+  let hardFailure = null;
 
   while (perRun.length < runs && attempt < maxAttempts) {
     attempt += 1;
@@ -157,21 +185,58 @@ function main() {
     const tmpPath = path.join(outDir, tmpFile);
     const runUrl = url.includes('?') ? `${url}&lh=${bust}` : `${url}?lh=${bust}`;
 
-    const status = runOne({ url: runUrl, preset, outPath: tmpPath });
+    const run = runOne({ url: runUrl, preset, outPath: tmpPath });
+    const status = run.status;
     if (!existsSync(tmpPath)) {
-      attemptErrors.push({ attempt, status, runtimeError: `lighthouse did not write output (exit=${status})` });
+      const runtimeError = `lighthouse did not write output (exit=${status})`;
+      const transient = isTransientError(run.output) || isTransientError(runtimeError);
+      attemptErrors.push({ attempt, status, runtimeError, transient });
+      if (!transient) {
+        hardFailure = runtimeError;
+        break;
+      }
       continue;
     }
 
-    const json = JSON.parse(readFileSync(tmpPath, 'utf8'));
+    let json;
+    try {
+      json = JSON.parse(readFileSync(tmpPath, 'utf8'));
+    } catch {
+      const runtimeError = 'invalid lighthouse JSON output';
+      attemptErrors.push({ attempt, status, runtimeError, file: tmpFile, transient: true });
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        // ignore cleanup failure
+      }
+      continue;
+    }
     if (json?.runtimeError) {
-      attemptErrors.push({ attempt, status, runtimeError: json.runtimeError?.message ?? 'runtimeError', file: tmpFile });
+      const runtimeError = json.runtimeError?.message ?? 'runtimeError';
+      const transient = isTransientError(runtimeError);
+      attemptErrors.push({ attempt, status, runtimeError, file: tmpFile, transient });
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        // ignore cleanup failure
+      }
+      if (!transient) {
+        hardFailure = runtimeError;
+        break;
+      }
       continue;
     }
     const m = extractMetrics(json);
     if (!Number.isFinite(m.perfScore) || !Number.isFinite(m.lcp) || !Number.isFinite(m.tbt) || !Number.isFinite(m.cls) || !Number.isFinite(m.dom)) {
-      attemptErrors.push({ attempt, status, runtimeError: 'missing required metrics', file: tmpFile });
-      continue;
+      const runtimeError = 'missing required metrics';
+      attemptErrors.push({ attempt, status, runtimeError, file: tmpFile, transient: false });
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        // ignore cleanup failure
+      }
+      hardFailure = runtimeError;
+      break;
     }
 
     const consoleErrors = extractConsoleErrors(json);
@@ -179,12 +244,20 @@ function main() {
 
     const file = `lh-${preset}-run${runIdx}.json`;
     const outPath = path.join(outDir, file);
+    if (existsSync(outPath)) {
+      try {
+        unlinkSync(outPath);
+      } catch {
+        // ignore cleanup failure
+      }
+    }
     renameSync(tmpPath, outPath);
     perRun.push({ file, status, ...m, consoleErrorsCount: consoleErrors.length, hydrationSignals, consoleErrors });
   }
 
   if (perRun.length < runs) {
-    console.error(`Not enough valid runs: ${perRun.length}/${runs}`);
+    const suffix = hardFailure ? `; stopped on non-transient error: ${hardFailure}` : '';
+    console.error(`Not enough valid runs: ${perRun.length}/${runs}${suffix}`);
     process.exit(1);
   }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "lh:gate": "node ops/lighthouse/lh-gate.mjs"
+    "lh:gate": "node ops/lighthouse/lh-gate.mjs",
+    "lh:gate:desktop": "node ops/lighthouse/lh-gate.mjs --preset desktop"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
## Summary\n- add 1 warm-up Lighthouse run before counting valid runs\n- retry only transient failures (CSS.enable, NO_NAVSTART, 522/5xx, network transient errors) until valid runs reach target or maxAttempts\n- preserve existing gate thresholds and pass/fail logic\n- add desktop-only gate mode and npm script: lh:gate:desktop\n\n## Scope\n- ops/lighthouse/run-lh.mjs\n- ops/lighthouse/lh-gate.mjs\n- package.json\n\n## Notes\n- no changes to globals/SSR/hero\n- no threshold changes\n