### PR TITLE
phase1-iter-16: desktop probe + metric bisect helper

### DIFF
--- a/ops/STATE.md
+++ b/ops/STATE.md
@@ -1,7 +1,7 @@
 # ops/STATE.md (STATE-LOCK)
 
 - CurrentPhase: A+B=PASS, Phase1=FAIL, Phase2=BLOCKED, Phase3=BLOCKED, Phase4=BLOCKED, Phase5=BLOCKED
-- CurrentIteration: phase1-iter-14 (explicit revert of first bad commit in DeferredProviders)
+- CurrentIteration: phase1-iter-16 (desktop probe + metric-based bisect helper)
 - MainlineStatus: RUNNING
 - LatestEvidence: ops/logs/phase1/
   - cf-headers.txt (2026-02-25 07:46:52)
@@ -21,5 +21,5 @@
   - Lighthouse truth model: use simulated LCP (`audits[largest-contentful-paint].numericValue`) as truth; observed is supporting note only
   - Lighthouse gates: mobile>=92, desktop>=97, CLS=0, DOM<900, hydrationSignals=0
   - Avoid evidence bloat: evidence PR should prefer lh-*.{txt,json}, hydration.txt, cf-headers.txt, ops/STATE.md (attempt files only if necessary)
-- NextAction: Open/merge Iter-14 evidence-only PR allowlist (exclude lh-*-run*.json), then proceed to next repair iteration because desktop gate still fails
-- LastResultSummary: Iter-14 explicit parent-based revert completed and deployed; CF verify passed, but Lighthouse medians still failed (desktop perf=88, mobile perf=78)
+- NextAction: Merge Iter-16 OPS-only patch, run lh:probe:desktop to find good-enough anchor (perf median >=96), then start bisect using lh:bisect:desktop helper
+- LastResultSummary: No production commit currently passes desktop>=97 with lh:gate:desktop; Iter-16 adds non-enforcing desktop probe and metric-based bisect decision to unblock bisect workflow

--- a/ops/bisect/desktop_probe.mjs
+++ b/ops/bisect/desktop_probe.mjs
@@ -1,0 +1,63 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import process from 'node:process';
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const k = a.slice(2);
+    const v = argv[i + 1];
+    if (v && !v.startsWith('--')) {
+      out[k] = v;
+      i += 1;
+    } else {
+      out[k] = true;
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv);
+const threshold = Number(args.threshold ?? process.env.LH_BISECT_PERF_THRESHOLD ?? 96);
+const url = String(args.url ?? process.env.LH_URL ?? 'https://amppattaya.com/en/');
+const outDir = String(args.outDir ?? 'ops/logs/phase1');
+const summaryPath = `${outDir}/lh-desktop-probe.json`;
+
+const runArgs = [
+  'ops/lighthouse/run-lh.mjs',
+  '--url', url,
+  '--runs', '5',
+  '--preset', 'desktop',
+  '--outDir', outDir,
+  '--enforceGates', 'false',
+  '--summaryBaseName', 'lh-desktop-probe',
+];
+
+const run = spawnSync(process.execPath, runArgs, { stdio: 'inherit' });
+if (run.error) {
+  console.error(`desktop_probe spawn error: ${run.error.message}`);
+  process.exit(1);
+}
+if ((run.status ?? 1) !== 0) {
+  console.error(`desktop_probe run-lh failed with exit=${run.status ?? 1}`);
+  process.exit(1);
+}
+
+if (!existsSync(summaryPath)) {
+  console.error(`desktop_probe missing summary file: ${summaryPath}`);
+  process.exit(1);
+}
+
+const summary = JSON.parse(readFileSync(summaryPath, 'utf8'));
+const perfMed = Number(summary?.medians?.perfScoreMed);
+if (!Number.isFinite(perfMed)) {
+  console.error('desktop_probe missing medians.perfScoreMed');
+  process.exit(1);
+}
+
+const isGood = perfMed >= threshold;
+const decision = isGood ? 'GOOD' : 'BAD';
+console.log(`desktop_probe perfMed=${Math.round(perfMed)} threshold=${threshold} decision=${decision}`);
+process.exit(isGood ? 0 : 1);

--- a/ops/lighthouse/run-lh.mjs
+++ b/ops/lighthouse/run-lh.mjs
@@ -26,6 +26,15 @@ function toNum(x) {
   return typeof x === 'number' && Number.isFinite(x) ? x : null;
 }
 
+function toBool(x, fallback = true) {
+  if (typeof x === 'boolean') return x;
+  if (typeof x !== 'string') return fallback;
+  const v = x.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(v)) return true;
+  if (['0', 'false', 'no', 'off'].includes(v)) return false;
+  return fallback;
+}
+
 function extractMetrics(json) {
   const perfScore = toNum(json?.categories?.performance?.score);
   const lcp = toNum(json?.audits?.['largest-contentful-paint']?.numericValue);
@@ -138,6 +147,8 @@ function main() {
 
   const runs = Number(args.runs ?? 5);
   const preset = String(args.preset ?? 'mobile');
+  const enforceGates = toBool(args.enforceGates, true);
+  const summaryBaseName = String(args.summaryBaseName ?? `lh-${preset}`);
   if (!['mobile', 'desktop'].includes(preset)) {
     console.error(`Invalid --preset: ${preset}`);
     process.exit(2);
@@ -277,6 +288,7 @@ function main() {
     url,
     preset,
     runs,
+    enforceGates,
     gates,
     medians: meds,
     ok,
@@ -285,7 +297,7 @@ function main() {
     attemptErrors,
   };
 
-  const summaryPath = path.join(outDir, `lh-${preset}.json`);
+  const summaryPath = path.join(outDir, `${summaryBaseName}.json`);
   writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
 
   // Hydration evidence (shared file required by Phase 1 gate contract)
@@ -317,9 +329,12 @@ function main() {
   for (const r of perRun) {
     lines.push(`- ${r.file} perf=${Math.round(r.perfScore)} lcp=${Math.round(r.lcp)} tbt=${Math.round(r.tbt)} cls=${r.cls} dom=${Math.round(r.dom)}`);
   }
-  writeFileSync(path.join(outDir, `lh-${preset}.txt`), lines.join('\n') + '\n');
+  if (!enforceGates) {
+    lines.push('ProbeMode: gates evaluated but NOT enforced for exit code');
+  }
+  writeFileSync(path.join(outDir, `${summaryBaseName}.txt`), lines.join('\n') + '\n');
 
-  process.exit(ok ? 0 : 1);
+  process.exit(enforceGates ? (ok ? 0 : 1) : 0);
 }
 
 main();

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "lh:gate": "node ops/lighthouse/lh-gate.mjs",
-    "lh:gate:desktop": "node ops/lighthouse/lh-gate.mjs --preset desktop"
+    "lh:gate:desktop": "node ops/lighthouse/lh-gate.mjs --preset desktop",
+    "lh:probe:desktop": "node ops/lighthouse/run-lh.mjs --url https://amppattaya.com/en/ --runs 5 --preset desktop --outDir ops/logs/phase1 --enforceGates false --summaryBaseName lh-desktop-probe",
+    "lh:bisect:desktop": "node ops/bisect/desktop_probe.mjs --threshold 96"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
## Summary\n- add desktop probe mode without enforcing lighthouse gates\n- add metric-based bisect helper for desktop median threshold decision\n- keep existing lh:gate and thresholds unchanged\n\n## Scope\n- ops/lighthouse/run-lh.mjs\n- package.json\n- ops/bisect/desktop_probe.mjs\n- ops/STATE.md\n\n## New scripts\n- npm run lh:probe:desktop\n- npm run lh:bisect:desktop\n\n## Decision rule\n- helper prints perfScoreMed and returns exit 0 when perfScoreMed >= 96, otherwise exit 1\n