### PR TITLE
phase1-iter-18: desktop evidence-only (FAIL perfMed=91)

### DIFF
--- a/ops/STATE.md
+++ b/ops/STATE.md
@@ -1,7 +1,7 @@
 # ops/STATE.md (STATE-LOCK)
 
 - CurrentPhase: A+B=PASS, Phase1=FAIL, Phase2=BLOCKED, Phase3=BLOCKED, Phase4=BLOCKED, Phase5=BLOCKED
-- CurrentIteration: phase1-iter-18 (restore Stage2 idle/interaction gate in DeferredProviders — exact 9132ed3 baseline)
+- CurrentIteration: phase1-iter-18 (restore Stage2 idle/interaction gate — deployed, FAIL)
 - MainlineStatus: RUNNING
 - LatestEvidence: ops/logs/phase1/
   - cf-headers.txt (2026-02-25 11:04:34)
@@ -21,5 +21,5 @@
   - Lighthouse truth model: use simulated LCP (`audits[largest-contentful-paint].numericValue`) as truth; observed is supporting note only
   - Lighthouse gates: mobile>=92, desktop>=97, CLS=0, DOM<900, hydrationSignals=0
   - Avoid evidence bloat: evidence PR should prefer lh-*.{txt,json}, hydration.txt, cf-headers.txt, ops/STATE.md (attempt files only if necessary)
-- NextAction: merge → deploy → CF verify → lh:gate:desktop → evidence-only PR
-- LastResultSummary: Iter-18 patch applied. Restoring Stage2 (900ms minDelay + requestIdleCallback + 4000ms hardTimeout) in DeferredProviders — exact state of 9132ed3 which scored perfMed=97. Previous Iter-17 simplified too aggressively; Stage2 ensures deferred providers do not activate during LH CPU-throttled measurement window.
+- NextAction: Iter-19 Evidence Pack (desktop-first): LCP bimodal (4/5 slow ~1900ms, 1/5 fast ~1100ms) — root cause is CDN/server-side TTFB variance, not DeferredProviders staging. Need investigation into TTFB reduction: check ISR streaming impact on TTFB, API fetch latency on home page, CF edge warming strategy.
+- LastResultSummary: Iter-18 patch merged (PR #213) — Stage2 restored (exact 9132ed3 baseline). Deployment PASS (GH Actions succeeded 04:46 UTC). CF invariants PASS. Desktop gate STILL FAIL: perfMed=91 (<97). Runs: 84/90/92/91/97 LCP: 2179/1958/1796/1904/1099ms. Bimodal: 4/5 slow (LCP>1700ms), 1/5 fast (LCP<1200ms). DeferredProviders timing NOT the root cause — LCP variance is server/CDN-side.

--- a/ops/logs/phase1/cf-headers.txt
+++ b/ops/logs/phase1/cf-headers.txt
@@ -133,3 +133,21 @@
 [2026-02-25T11:04:34] STATIC round2 url=https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js cf=HIT age=57335 server=cloudflare set-cookie=
 [2026-02-25T11:04:34] PASS static age increased on round2
 [2026-02-25T11:04:34] VERIFY end
+[2026-02-25T11:41:07] VERIFY start
+[2026-02-25T11:41:08] HTML /en/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T11:41:09] HTML /en/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T11:41:09] HTML /th/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T11:41:10] HTML /th/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T11:41:13] STATIC round1 url=https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js cf=HIT age=59532 server=cloudflare set-cookie=
+[2026-02-25T11:41:13] STATIC round2 url=https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js cf=HIT age=44684 server=cloudflare set-cookie=
+[2026-02-25T11:41:13] INFO static age did not increase on round2 (soft signal; may be different edge)
+[2026-02-25T11:41:13] VERIFY end
+[2026-02-25T12:34:23] VERIFY start
+[2026-02-25T12:34:25] HTML /en/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T12:34:26] HTML /en/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T12:34:26] HTML /th/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T12:34:26] HTML /th/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T12:34:31] STATIC round1 url=https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js cf=HIT age=20416 server=cloudflare set-cookie=
+[2026-02-25T12:34:31] STATIC round2 url=https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js cf=HIT age=47882 server=cloudflare set-cookie=
+[2026-02-25T12:34:31] PASS static age increased on round2
+[2026-02-25T12:34:31] VERIFY end

--- a/ops/logs/phase1/hydration.txt
+++ b/ops/logs/phase1/hydration.txt
@@ -621,3 +621,28 @@ hydrationSignals(total): 0
   - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
   - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/?lh=1771992366074:0:0
 ### END PRESET: desktop
+### PRESET: desktop
+timestamp: 2026-02-25T05:30:32.723Z
+url: https://amppattaya.com/en/
+preset: desktop
+runs: 5
+hydrationSignals(total): 0
+- lh-desktop-run01.json consoleErrors=3 hydrationSignals=0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/?lh=1771997336611:0:0
+- lh-desktop-run02.json consoleErrors=3 hydrationSignals=0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/?lh=1771997357855:0:0
+- lh-desktop-run03.json consoleErrors=3 hydrationSignals=0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/?lh=1771997376207:0:0
+- lh-desktop-run04.json consoleErrors=1 hydrationSignals=0
+  - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/?lh=1771997394371:0:0
+- lh-desktop-run05.json consoleErrors=3 hydrationSignals=0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/?lh=1771997412216:0:0
+### END PRESET: desktop

--- a/ops/logs/phase1/lh-desktop.json
+++ b/ops/logs/phase1/lh-desktop.json
@@ -12,8 +12,8 @@
   },
   "medians": {
     "perfScoreMed": 91,
-    "lcpMed": 1907.0010000000009,
-    "tbtMed": 0,
+    "lcpMed": 1903.6709999999998,
+    "tbtMed": 11,
     "clsMed": 0,
     "domMed": 681,
     "hydrationSignals": 0
@@ -26,28 +26,9 @@
     {
       "file": "lh-desktop-run01.json",
       "status": 0,
-      "perfScore": 90,
-      "lcp": 1907.0010000000009,
-      "tbt": 3,
-      "cls": 0,
-      "dom": 717,
-      "consoleErrorsCount": 1,
-      "hydrationSignals": 0,
-      "consoleErrors": [
-        {
-          "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
-          "url": "https://amppattaya.com/en/?lh=1771992292160",
-          "line": 0,
-          "col": 0
-        }
-      ]
-    },
-    {
-      "file": "lh-desktop-run02.json",
-      "status": 0,
-      "perfScore": 97,
-      "lcp": 1165.02,
-      "tbt": 40,
+      "perfScore": 84,
+      "lcp": 2179.304,
+      "tbt": 11,
       "cls": 0,
       "dom": 681,
       "consoleErrorsCount": 3,
@@ -67,7 +48,38 @@
         },
         {
           "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
-          "url": "https://amppattaya.com/en/?lh=1771992309502",
+          "url": "https://amppattaya.com/en/?lh=1771997336611",
+          "line": 0,
+          "col": 0
+        }
+      ]
+    },
+    {
+      "file": "lh-desktop-run02.json",
+      "status": 0,
+      "perfScore": 90,
+      "lcp": 1957.5220000000006,
+      "tbt": 11,
+      "cls": 0,
+      "dom": 676,
+      "consoleErrorsCount": 3,
+      "hydrationSignals": 0,
+      "consoleErrors": [
+        {
+          "description": "Failed to load resource: the server responded with a status of 422 ()",
+          "url": "https://amppattaya.com/api/v1/events",
+          "line": 0,
+          "col": 0
+        },
+        {
+          "description": "Failed to load resource: the server responded with a status of 422 ()",
+          "url": "https://amppattaya.com/api/v1/events",
+          "line": 0,
+          "col": 0
+        },
+        {
+          "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
+          "url": "https://amppattaya.com/en/?lh=1771997357855",
           "line": 0,
           "col": 0
         }
@@ -76,17 +88,29 @@
     {
       "file": "lh-desktop-run03.json",
       "status": 0,
-      "perfScore": 91,
-      "lcp": 1928.9109999999998,
-      "tbt": 0,
+      "perfScore": 92,
+      "lcp": 1796.4604999999997,
+      "tbt": 19,
       "cls": 0,
       "dom": 676,
-      "consoleErrorsCount": 1,
+      "consoleErrorsCount": 3,
       "hydrationSignals": 0,
       "consoleErrors": [
         {
+          "description": "Failed to load resource: the server responded with a status of 422 ()",
+          "url": "https://amppattaya.com/api/v1/events",
+          "line": 0,
+          "col": 0
+        },
+        {
+          "description": "Failed to load resource: the server responded with a status of 422 ()",
+          "url": "https://amppattaya.com/api/v1/events",
+          "line": 0,
+          "col": 0
+        },
+        {
           "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
-          "url": "https://amppattaya.com/en/?lh=1771992328432",
+          "url": "https://amppattaya.com/en/?lh=1771997376207",
           "line": 0,
           "col": 0
         }
@@ -95,41 +119,17 @@
     {
       "file": "lh-desktop-run04.json",
       "status": 0,
-      "perfScore": 88,
-      "lcp": 1930.7124999999996,
-      "tbt": 0,
-      "cls": 0.0001594469995967866,
-      "dom": 715,
-      "consoleErrorsCount": 5,
+      "perfScore": 91,
+      "lcp": 1903.6709999999998,
+      "tbt": 7,
+      "cls": 0,
+      "dom": 717,
+      "consoleErrorsCount": 1,
       "hydrationSignals": 0,
       "consoleErrors": [
         {
-          "description": "Failed to load resource: the server responded with a status of 404 ()",
-          "url": "https://amppattaya.com/images/property-interior.png",
-          "line": 0,
-          "col": 0
-        },
-        {
-          "description": "Failed to load resource: the server responded with a status of 404 ()",
-          "url": "https://amppattaya.com/images/condo-view.png",
-          "line": 0,
-          "col": 0
-        },
-        {
-          "description": "Failed to load resource: the server responded with a status of 422 ()",
-          "url": "https://amppattaya.com/api/v1/events",
-          "line": 0,
-          "col": 0
-        },
-        {
-          "description": "Failed to load resource: the server responded with a status of 422 ()",
-          "url": "https://amppattaya.com/api/v1/events",
-          "line": 0,
-          "col": 0
-        },
-        {
           "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
-          "url": "https://amppattaya.com/en/?lh=1771992345433",
+          "url": "https://amppattaya.com/en/?lh=1771997394371",
           "line": 0,
           "col": 0
         }
@@ -138,12 +138,12 @@
     {
       "file": "lh-desktop-run05.json",
       "status": 0,
-      "perfScore": 98,
-      "lcp": 1042.238,
+      "perfScore": 97,
+      "lcp": 1099.289,
       "tbt": 0,
       "cls": 0,
-      "dom": 676,
-      "consoleErrorsCount": 2,
+      "dom": 681,
+      "consoleErrorsCount": 3,
       "hydrationSignals": 0,
       "consoleErrors": [
         {
@@ -153,8 +153,14 @@
           "col": 0
         },
         {
+          "description": "Failed to load resource: the server responded with a status of 422 ()",
+          "url": "https://amppattaya.com/api/v1/events",
+          "line": 0,
+          "col": 0
+        },
+        {
           "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
-          "url": "https://amppattaya.com/en/?lh=1771992366074",
+          "url": "https://amppattaya.com/en/?lh=1771997412216",
           "line": 0,
           "col": 0
         }

--- a/ops/logs/phase1/lh-desktop.txt
+++ b/ops/logs/phase1/lh-desktop.txt
@@ -1,11 +1,11 @@
 URL: https://amppattaya.com/en/
 Preset: desktop
-Medians: perf=91 lcp=1907 tbt=0 cls=0 dom=681
+Medians: perf=91 lcp=1904 tbt=11 cls=0 dom=681
 Gates: perf>=97 lcp<=2500 tbt<=200 cls<=0 dom<=900
 Result: FAIL (perf<97)
 Runs:
-- lh-desktop-run01.json perf=90 lcp=1907 tbt=3 cls=0 dom=717
-- lh-desktop-run02.json perf=97 lcp=1165 tbt=40 cls=0 dom=681
-- lh-desktop-run03.json perf=91 lcp=1929 tbt=0 cls=0 dom=676
-- lh-desktop-run04.json perf=88 lcp=1931 tbt=0 cls=0.0001594469995967866 dom=715
-- lh-desktop-run05.json perf=98 lcp=1042 tbt=0 cls=0 dom=676
+- lh-desktop-run01.json perf=84 lcp=2179 tbt=11 cls=0 dom=681
+- lh-desktop-run02.json perf=90 lcp=1958 tbt=11 cls=0 dom=676
+- lh-desktop-run03.json perf=92 lcp=1796 tbt=19 cls=0 dom=676
+- lh-desktop-run04.json perf=91 lcp=1904 tbt=7 cls=0 dom=717
+- lh-desktop-run05.json perf=97 lcp=1099 tbt=0 cls=0 dom=681


### PR DESCRIPTION
## Evidence Pack (Desktop Iter-18 post-gate)

### Gate Result: FAIL 
- perfMed: **91** (need 97)
- LCP median: 1904ms
- CF invariants: PASS 
- Deployment: PASS  (PR#213 deployed 04:46 UTC)
- hydrationSignals: 0

### Per-Run Summary
| Run | perf | LCP | TBT |
|-----|------|-----|-----|
| run01 | 84 | 2179ms | 11ms |
| run02 | 90 | 1958ms | 11ms |
| run03 | 92 | 1796ms | 19ms |
| run04 | 91 | 1904ms | 7ms |
| run05 | **97** | **1099ms** | 0ms |

### Key Finding
Bimodal LCP: 4/5 runs slow (~1900ms, perf 84-92), 1/5 fast (~1100ms, perf 97). Stage2 restoration did NOT improve the median. Root cause is server/CDN-side TTFB variance  NOT DeferredProviders staging.

### NextAction
Iter-19: Investigate TTFB root cause (ISR streaming, API fetch latency on home page, CF edge warming)

### Allowlist Files
- ops/logs/phase1/cf-headers.txt
- ops/logs/phase1/hydration.txt
- ops/logs/phase1/lh-desktop.txt
- ops/logs/phase1/lh-desktop.json
- ops/STATE.md