### PR TITLE
perf(iter-19): extract GuidedOverlay to client  remove searchParams from home ISR

### DIFF
--- a/admin-app/app/(site)/[locale]/_components/GuidedOverlay.tsx
+++ b/admin-app/app/(site)/[locale]/_components/GuidedOverlay.tsx
@@ -1,0 +1,299 @@
+'use client';
+/**
+ * GuidedOverlay — client component.
+ *
+ * Reads guided-finder URL params via useSearchParams so the HOME page server
+ * component does NOT consume searchParams.  Without searchParams consumption,
+ * Next.js ISR cache is shared across ALL URL variants (including ?lh=<ts>
+ * used by Lighthouse CI), eliminating the per-run SSR cold-start that caused
+ * the bimodal LCP distribution (Iter-19 root cause).
+ *
+ * Render this inside a <Suspense fallback={null}> at page level.
+ */
+import { useSearchParams } from 'next/navigation';
+
+import { buildWhatsAppUrl } from '@/app/_lib/public-cta';
+import { withLocale } from '@/app/_lib/i18n/routing';
+import type { Locale } from '@/app/_lib/i18n/types';
+
+// ── Dict slices passed as plain JSON props from the server component ─────────
+
+export type GuidedDictSlice = {
+  title: string;
+  stepGoal: string;
+  stepBudget: string;
+  stepContact: string;
+  stepProgress: string;
+  buy: string;
+  rent: string;
+  invest: string;
+  skipToContact: string;
+  budgetLabel: string;
+  budgetSelect: string;
+  budgetUnder3m: string;
+  budget3to5m: string;
+  budget5to8m: string;
+  budget8mPlus: string;
+  budgetNotSure: string;
+  next: string;
+  changeGoal: string;
+  back: string;
+  close: string;
+  summary: string;
+  noSelections: string;
+};
+
+export type GuidedOverlayProps = {
+  locale: Locale;
+  guided: GuidedDictSlice;
+  homeKV: {
+    goalPrefix: string;
+    budgetPrefix: string;
+    timelinePrefix: string;
+    whatsAppGreeting: string;
+    whatsAppFallback: string;
+  };
+  ctaKV: {
+    bookPrivateTour: string;
+    whatsapp: string;
+  };
+  closeAriaLabel: string;
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+type GuidedStep = 'goal' | 'budget' | 'contact';
+type GuidedGoal = 'buy' | 'rent' | 'invest';
+
+function pickParam(value: string | null): string | null {
+  return value;
+}
+
+function normalizeGuidedStep(step: string | null): GuidedStep {
+  if (step === 'goal' || step === 'budget' || step === 'contact') return step;
+  return 'goal';
+}
+
+function normalizeGoal(goal: string | null): GuidedGoal | null {
+  if (goal === 'buy' || goal === 'rent' || goal === 'invest') return goal;
+  return null;
+}
+
+function hrefWithQuery(path: string, query: Record<string, string>): string {
+  const url = new URL(path, 'https://amppattaya.com');
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  return url.pathname + url.search;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function GuidedOverlay({ locale, guided, homeKV, ctaKV, closeAriaLabel }: GuidedOverlayProps) {
+  const sp = useSearchParams();
+
+  const guidedOpen = sp.get('guided') === '1';
+
+  if (!guidedOpen) return null;
+
+  const step = normalizeGuidedStep(pickParam(sp.get('step')));
+  const goal = normalizeGoal(pickParam(sp.get('goal')));
+  const budget = pickParam(sp.get('budget'));
+  const timeline = pickParam(sp.get('timeline'));
+
+  const effectiveStep: GuidedStep = goal ? step : 'goal';
+
+  const summaryLines = [
+    goal ? `${homeKV.goalPrefix}: ${goal}` : null,
+    budget ? `${homeKV.budgetPrefix}: ${budget}` : null,
+    timeline ? `${homeKV.timelinePrefix}: ${timeline}` : null,
+  ].filter(Boolean) as string[];
+
+  const summaryText = summaryLines.join(' | ');
+  const whatsAppText = summaryText
+    ? `${homeKV.whatsAppGreeting} — ${summaryText}`
+    : homeKV.whatsAppFallback;
+  const whatsAppHref = buildWhatsAppUrl(whatsAppText);
+
+  const closeHref = withLocale(locale, '/');
+
+  return (
+    <div className="guided-overlay" role="presentation">
+      <dialog
+        className="guided-dialog"
+        open
+        aria-modal="true"
+        aria-labelledby="guided-dialog-title"
+      >
+        <div className="guided-dialog__header">
+          <div>
+            <div className="guided-dialog__title" id="guided-dialog-title">
+              {guided.title}
+            </div>
+            <div className="guided-dialog__step">
+              {effectiveStep === 'goal'
+                ? guided.stepGoal
+                : effectiveStep === 'budget'
+                  ? guided.stepBudget
+                  : guided.stepContact}
+              {'  '}•{'  '}{guided.stepProgress}
+            </div>
+          </div>
+          <a
+            className="guided-dialog__close"
+            href={closeHref}
+            aria-label={closeAriaLabel}
+          >
+            ✕
+          </a>
+        </div>
+
+        <div className="guided-dialog__body">
+          {/* Step 1: Goal */}
+          {effectiveStep === 'goal' ? (
+            <form
+              method="GET"
+              action={withLocale(locale, '/')}
+              className="guided-grid"
+            >
+              <input type="hidden" name="guided" value="1" />
+              <input type="hidden" name="step" value="budget" />
+              <div className="guided-row">
+                <button className="btn btn-cta" type="submit" name="goal" value="buy">
+                  {guided.buy}
+                </button>
+                <button className="btn btn-secondary" type="submit" name="goal" value="rent">
+                  {guided.rent}
+                </button>
+                <button className="btn btn-secondary" type="submit" name="goal" value="invest">
+                  {guided.invest}
+                </button>
+              </div>
+              <div className="cta-row cta-row--center">
+                <a
+                  className="btn btn-tertiary"
+                  href={withLocale(
+                    locale,
+                    hrefWithQuery('/', { guided: '1', step: 'contact' })
+                  )}
+                >
+                  {guided.skipToContact}
+                </a>
+              </div>
+            </form>
+          ) : null}
+
+          {/* Step 2: Budget */}
+          {effectiveStep === 'budget' ? (
+            <form
+              method="GET"
+              action={withLocale(locale, '/')}
+              className="guided-grid"
+            >
+              <input type="hidden" name="guided" value="1" />
+              <input type="hidden" name="step" value="contact" />
+              <input type="hidden" name="goal" value={goal ?? 'buy'} />
+
+              <label>
+                <div className="font-semibold">{guided.budgetLabel}</div>
+                <select
+                  className="form-input"
+                  name="budget"
+                  defaultValue={budget ?? ''}
+                >
+                  <option value="" disabled>
+                    {guided.budgetSelect}
+                  </option>
+                  <option value="<3m">{guided.budgetUnder3m}</option>
+                  <option value="3-5m">{guided.budget3to5m}</option>
+                  <option value="5-8m">{guided.budget5to8m}</option>
+                  <option value="8m+">{guided.budget8mPlus}</option>
+                  <option value="not_sure">{guided.budgetNotSure}</option>
+                </select>
+              </label>
+
+              <div className="cta-row">
+                <button className="btn btn-cta" type="submit">
+                  {guided.next}
+                </button>
+                <a
+                  className="btn btn-secondary"
+                  href={withLocale(
+                    locale,
+                    hrefWithQuery('/', { guided: '1', step: 'goal' })
+                  )}
+                >
+                  {guided.changeGoal}
+                </a>
+              </div>
+            </form>
+          ) : null}
+
+          {/* Step 3: Contact / Summary */}
+          {effectiveStep === 'contact' ? (
+            <div className="guided-grid">
+              <div className="font-semibold">{guided.summary}</div>
+              <div className="guided-summary">
+                {summaryLines.length ? (
+                  <ul className="bullet-list">
+                    {summaryLines.map((l) => (
+                      <li key={l}>{l}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div>{guided.noSelections}</div>
+                )}
+              </div>
+
+              <div className="guided-row">
+                <a
+                  className="btn btn-cta"
+                  href={withLocale(
+                    locale,
+                    hrefWithQuery('/contact', {
+                      topic: 'private_consultation',
+                      msg: whatsAppText,
+                    })
+                  )}
+                  data-amp-event-type="cta_click"
+                  data-amp-event-payload={JSON.stringify({
+                    cta: 'book_consultation',
+                    from: 'home_guided',
+                  })}
+                >
+                  {ctaKV.bookPrivateTour}
+                </a>
+                <a
+                  className="btn btn-secondary"
+                  href={whatsAppHref}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {ctaKV.whatsapp}
+                </a>
+              </div>
+
+              <div className="cta-row">
+                <a
+                  className="btn btn-tertiary"
+                  href={withLocale(
+                    locale,
+                    hrefWithQuery('/', {
+                      guided: '1',
+                      step: 'budget',
+                      goal: goal ?? 'buy',
+                      budget: budget ?? '',
+                    })
+                  )}
+                >
+                  {guided.back}
+                </a>
+                <a className="btn btn-secondary" href={closeHref}>
+                  {guided.close}
+                </a>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </dialog>
+    </div>
+  );
+}

--- a/admin-app/app/(site)/[locale]/page.tsx
+++ b/admin-app/app/(site)/[locale]/page.tsx
@@ -8,8 +8,8 @@ import { FeaturedProjects } from '@/components/home/FeaturedProjects';
 import { LeadForm } from '@/components/forms/LeadForm';
 import { Container } from '@/components/layout/Container';
 import propertyPlaceholder from '@/public/images/property-placeholder.svg';
-import { buildWhatsAppUrl } from '@/app/_lib/public-cta';
 import { getDictionary, normalizeLocale } from '@/app/_lib/i18n/get-dictionary';
+import { GuidedOverlay } from './_components/GuidedOverlay';
 import { withLocale } from '@/app/_lib/i18n/routing';
 import { makePageMetadata } from '@/app/_lib/i18n/metadata';
 import { getContentRecommendation } from '@/lib/personalization';
@@ -33,78 +33,20 @@ export async function generateMetadata({
 
 export default async function HomePage({
   params,
-  searchParams,
 }: {
   params: Promise<{ locale: string }>;
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { locale: rawLocale } = await params;
   const locale = normalizeLocale(rawLocale);
   const dict = getDictionary(locale);
 
-  type GuidedStep = 'goal' | 'budget' | 'contact';
-  type GuidedGoal = 'buy' | 'rent' | 'invest';
-
-  function pickParam(value: unknown): string | null {
-    if (typeof value === 'string') return value;
-    if (Array.isArray(value) && typeof value[0] === 'string') return value[0];
-    return null;
-  }
-
-  function normalizeGuidedStep(step: string | null): GuidedStep {
-    if (step === 'goal' || step === 'budget' || step === 'contact') return step;
-    return 'goal';
-  }
-
-  function normalizeGoal(goal: string | null): GuidedGoal | null {
-    if (goal === 'buy' || goal === 'rent' || goal === 'invest') return goal;
-    return null;
-  }
-
-  function hrefWithQuery(path: string, query: Record<string, string>): string {
-    const url = new URL(path, 'https://amppattaya.com');
-    for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
-    return url.pathname + url.search;
-  }
-
-  const smartLabels = {
-    buy: dict.guided.buy,
-    rent: dict.guided.rent,
-    invest: dict.guided.invest,
-  };
-
-  const sp = searchParams ? await searchParams : undefined;
-  const guidedOpen = pickParam(sp?.guided) === '1';
-  const step = normalizeGuidedStep(pickParam(sp?.step));
-  const goal = normalizeGoal(pickParam(sp?.goal));
-  const budget = pickParam(sp?.budget);
-  const timeline = pickParam(sp?.timeline);
-
-  const effectiveStep: GuidedStep = guidedOpen
-    ? goal
-      ? step
-      : 'goal'
-    : 'goal';
-
-  const summaryLines = [
-    goal ? `${dict.home.goalPrefix}: ${goal}` : null,
-    budget ? `${dict.home.budgetPrefix}: ${budget}` : null,
-    timeline ? `${dict.home.timelinePrefix}: ${timeline}` : null,
-  ].filter(Boolean) as string[];
-  const summaryText = summaryLines.join(' | ');
-  const whatsAppText = summaryText
-    ? `${dict.home.whatsAppGreeting} — ${summaryText}`
-    : dict.home.whatsAppFallback;
-  const whatsAppHref = buildWhatsAppUrl(whatsAppText);
-
-  const closeHref = withLocale(locale, '/');
 
   const recommendation = getContentRecommendation();
 
   async function FeaturedProjectsSection() {
     let allProjects: Awaited<ReturnType<typeof fetchProjects>> = [];
     try {
-      allProjects = await fetchProjects({ limit: 100 });
+      allProjects = await fetchProjects({ limit: 8 });
     } catch {
       allProjects = [];
     }
@@ -272,155 +214,32 @@ export default async function HomePage({
       <HomeHero
         dict={dict}
         locale={locale}
-        guidedHref={withLocale(locale, hrefWithQuery('/', { guided: '1', step: 'goal' }))}
+        guidedHref={withLocale(locale, '/?guided=1&step=goal')}
       />
 
-      {/* Guided Goal Modal */}
-      {guidedOpen ? (
-        <div className="guided-overlay" role="presentation">
-          <dialog className="guided-dialog" open aria-modal="true" aria-labelledby="guided-dialog-title">
-            <div className="guided-dialog__header">
-              <div>
-                <div className="guided-dialog__title" id="guided-dialog-title">{dict.guided.title}</div>
-                <div className="guided-dialog__step">
-                  {effectiveStep === 'goal'
-                    ? dict.guided.stepGoal
-                    : effectiveStep === 'budget'
-                      ? dict.guided.stepBudget
-                      : dict.guided.stepContact}
-                  {'  '}•{'  '}{dict.guided.stepProgress}
-                </div>
-              </div>
-              <a className="guided-dialog__close" href={closeHref} aria-label={dict.common.close}>
-                ✕
-              </a>
-            </div>
+      {/* Guided Finder Overlay — client component.
+          Reads URL params client-side so this server component stays
+          searchParams-free → Next.js ISR cache is shared across ALL URL
+          variants (including ?lh=<ts> Lighthouse runs). Iter-19 fix. */}
+      <Suspense fallback={null}>
+        <GuidedOverlay
+          locale={locale}
+          guided={dict.guided}
+          homeKV={{
+            goalPrefix: dict.home.goalPrefix,
+            budgetPrefix: dict.home.budgetPrefix,
+            timelinePrefix: dict.home.timelinePrefix,
+            whatsAppGreeting: dict.home.whatsAppGreeting,
+            whatsAppFallback: dict.home.whatsAppFallback,
+          }}
+          ctaKV={{
+            bookPrivateTour: dict.cta.bookPrivateTour,
+            whatsapp: dict.cta.whatsapp,
+          }}
+          closeAriaLabel={dict.common.close}
+        />
+      </Suspense>
 
-            <div className="guided-dialog__body">
-              {effectiveStep === 'goal' ? (
-                <form method="GET" action={withLocale(locale, '/')} className="guided-grid">
-                  <input type="hidden" name="guided" value="1" />
-                  <input type="hidden" name="step" value="budget" />
-                  <div className="guided-row">
-                    <button className="btn btn-cta" type="submit" name="goal" value="buy">
-                      {smartLabels.buy}
-                    </button>
-                    <button className="btn btn-secondary" type="submit" name="goal" value="rent">
-                      {smartLabels.rent}
-                    </button>
-                    <button className="btn btn-secondary" type="submit" name="goal" value="invest">
-                      {smartLabels.invest}
-                    </button>
-                  </div>
-                  <div className="cta-row cta-row--center">
-                    <a
-                      className="btn btn-tertiary"
-                      href={withLocale(
-                        locale,
-                        hrefWithQuery('/', { guided: '1', step: 'contact' })
-                      )}
-                    >
-                      {dict.guided.skipToContact}
-                    </a>
-                  </div>
-                </form>
-              ) : null}
-
-              {effectiveStep === 'budget' ? (
-                <form method="GET" action={withLocale(locale, '/')} className="guided-grid">
-                  <input type="hidden" name="guided" value="1" />
-                  <input type="hidden" name="step" value="contact" />
-                  <input type="hidden" name="goal" value={goal ?? 'buy'} />
-
-                  <label>
-                    <div className="font-semibold">{dict.guided.budgetLabel}</div>
-                    <select className="form-input" name="budget" defaultValue={budget ?? ''}>
-                      <option value="" disabled>
-                        {dict.guided.budgetSelect}
-                      </option>
-                      <option value="<3m">{dict.guided.budgetUnder3m}</option>
-                      <option value="3-5m">{dict.guided.budget3to5m}</option>
-                      <option value="5-8m">{dict.guided.budget5to8m}</option>
-                      <option value="8m+">{dict.guided.budget8mPlus}</option>
-                      <option value="not_sure">{dict.guided.budgetNotSure}</option>
-                    </select>
-                  </label>
-
-                  <div className="cta-row">
-                    <button className="btn btn-cta" type="submit">
-                      {dict.guided.next}
-                    </button>
-                    <a
-                      className="btn btn-secondary"
-                      href={withLocale(locale, hrefWithQuery('/', { guided: '1', step: 'goal' }))}
-                    >
-                      {dict.guided.changeGoal}
-                    </a>
-                  </div>
-                </form>
-              ) : null}
-
-              {effectiveStep === 'contact' ? (
-                <div className="guided-grid">
-                  <div className="font-semibold">{dict.guided.summary}</div>
-                  <div className="guided-summary">
-                    {summaryLines.length ? (
-                      <ul className="bullet-list">
-                        {summaryLines.map((l) => (
-                          <li key={l}>{l}</li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <div>{dict.guided.noSelections}</div>
-                    )}
-                  </div>
-
-                  <div className="guided-row">
-                    <TrackedLink
-                      className="btn btn-cta"
-                      href={withLocale(
-                        locale,
-                        hrefWithQuery('/contact', {
-                          topic: 'private_consultation',
-                          msg: whatsAppText,
-                        })
-                      )}
-                      eventType="cta_click"
-                      eventPayload={{ cta: 'book_consultation', from: 'home_guided' }}
-                    >
-                      {dict.cta.bookPrivateTour}
-                    </TrackedLink>
-
-                    <a className="btn btn-secondary" href={whatsAppHref} target="_blank" rel="noreferrer">
-                      {dict.cta.whatsapp}
-                    </a>
-                  </div>
-
-                  <div className="cta-row">
-                    <a
-                      className="btn btn-tertiary"
-                      href={withLocale(
-                        locale,
-                        hrefWithQuery('/', {
-                          guided: '1',
-                          step: 'budget',
-                          goal: goal ?? 'buy',
-                          budget: budget ?? '',
-                        })
-                      )}
-                    >
-                      {dict.guided.back}
-                    </a>
-                    <a className="btn btn-secondary" href={closeHref}>
-                      {dict.guided.close}
-                    </a>
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          </dialog>
-        </div>
-      ) : null}
 
       {/* Explore Opportunities (Combined Flow) */}
       <section className="cv-auto py-16 md:py-20 xl:py-24 2xl:py-28">

--- a/ops/STATE.md
+++ b/ops/STATE.md
@@ -1,7 +1,7 @@
 # ops/STATE.md (STATE-LOCK)
 
 - CurrentPhase: A+B=PASS, Phase1=FAIL, Phase2=BLOCKED, Phase3=BLOCKED, Phase4=BLOCKED, Phase5=BLOCKED
-- CurrentIteration: phase1-iter-18 (restore Stage2 idle/interaction gate — deployed, FAIL)
+- CurrentIteration: phase1-iter-19 (remove searchParams from home SSR, GuidedOverlay → client, limit:100→8 — deployed, pending gate)
 - MainlineStatus: RUNNING
 - LatestEvidence: ops/logs/phase1/
   - cf-headers.txt (2026-02-25 11:04:34)
@@ -21,5 +21,5 @@
   - Lighthouse truth model: use simulated LCP (`audits[largest-contentful-paint].numericValue`) as truth; observed is supporting note only
   - Lighthouse gates: mobile>=92, desktop>=97, CLS=0, DOM<900, hydrationSignals=0
   - Avoid evidence bloat: evidence PR should prefer lh-*.{txt,json}, hydration.txt, cf-headers.txt, ops/STATE.md (attempt files only if necessary)
-- NextAction: Iter-19 Evidence Pack (desktop-first): LCP bimodal (4/5 slow ~1900ms, 1/5 fast ~1100ms) — root cause is CDN/server-side TTFB variance, not DeferredProviders staging. Need investigation into TTFB reduction: check ISR streaming impact on TTFB, API fetch latency on home page, CF edge warming strategy.
-- LastResultSummary: Iter-18 patch merged (PR #213) — Stage2 restored (exact 9132ed3 baseline). Deployment PASS (GH Actions succeeded 04:46 UTC). CF invariants PASS. Desktop gate STILL FAIL: perfMed=91 (<97). Runs: 84/90/92/91/97 LCP: 2179/1958/1796/1904/1099ms. Bimodal: 4/5 slow (LCP>1700ms), 1/5 fast (LCP<1200ms). DeferredProviders timing NOT the root cause — LCP variance is server/CDN-side.
+- NextAction: Run desktop LH gate after deployment; if perfMed≥97 merge evidence PR.
+- LastResultSummary: Iter-19 patch deployed — root cause identified: home page consumed `await searchParams` server-side, causing every unique ?lh=<ts> LH run to trigger a fresh ISR computation (cache miss per run). Fix: extracted GuidedOverlay to client component (reads URL params via useSearchParams), removed searchParams from server component → ISR cache now shared for all URL variants. Also reduced fetchProjects limit:100→8 (only 6 displayed). TTFB probe: CF=DYNAMIC runs 2-10 = 220-250ms, run 1 = 1212ms (TCP cold). LH gate pending.

--- a/ops/bisect/ttfb_probe.ps1
+++ b/ops/bisect/ttfb_probe.ps1
@@ -1,0 +1,86 @@
+param([int]$Runs = 10, [string]$Url = "https://amppattaya.com/en/")
+
+$ErrorActionPreference = "SilentlyContinue"
+$results = @()
+
+Write-Host "=== TTFB / Cache Header Probe ($Runs runs) ===" -ForegroundColor Cyan
+Write-Host "URL: $Url" 
+Write-Host ""
+
+for ($i = 1; $i -le $Runs; $i++) {
+    $bust = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+    $testUrl = "${Url}?ttfb=${bust}"
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        $req = [System.Net.HttpWebRequest]::Create($testUrl)
+        $req.Method = "GET"
+        $req.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/131"
+        $req.Accept = "text/html"
+        $req.Headers.Add("Accept-Encoding", "identity")
+        $req.AllowAutoRedirect = $true
+        $req.Timeout = 15000
+
+        $resp = $req.GetResponse()
+        $sw.Stop()
+        $ttfb = $sw.ElapsedMilliseconds
+
+        $cfCache      = $resp.Headers["cf-cache-status"] ?? "—"
+        $age          = $resp.Headers["age"]              ?? "—"
+        $serverTiming = $resp.Headers["server-timing"]    ?? "—"
+        $setCookie    = if ($resp.Headers["set-cookie"]) { "YES" } else { "—" }
+        $xNextCache   = $resp.Headers["x-nextjs-cache"]   ?? $resp.Headers["x-vercel-cache"] ?? "—"
+        $cacheControl = $resp.Headers["cache-control"]    ?? "—"
+        $contentLen   = $resp.ContentLength
+        $statusCode   = [int]$resp.StatusCode
+
+        $resp.Close()
+
+        $row = [pscustomobject]@{
+            Run           = $i
+            TTFB_ms       = $ttfb
+            Status        = $statusCode
+            CF_Cache      = $cfCache
+            Age           = $age
+            SetCookie     = $setCookie
+            ContentLen    = $contentLen
+            ServerTiming  = ($serverTiming -replace ";dur=\d+\.\d+","").Substring(0, [math]::Min(60,$serverTiming.Length))
+        }
+        $results += $row
+        Write-Host ("[run{0:D2}] TTFB={1,4}ms  CF={2,-8} age={3,-5} cookie={4}" -f $i, $ttfb, $cfCache, $age, $setCookie)
+    } catch {
+        $sw.Stop()
+        Write-Host ("[run{0:D2}] ERROR: {1}" -f $i, $_.Exception.Message)
+        $results += [pscustomobject]@{
+            Run=($i); TTFB_ms=(-1); Status="ERR"; CF_Cache="—"; Age="—"; SetCookie="—"; ContentLen=(-1); ServerTiming=$_.Exception.Message.Substring(0,[math]::Min(40,$_.Exception.Message.Length))
+        }
+    }
+
+    if ($i -lt $Runs) { Start-Sleep -Milliseconds 800 }
+}
+
+Write-Host ""
+Write-Host "=== SUMMARY TABLE ===" -ForegroundColor Cyan
+$results | Format-Table Run, TTFB_ms, CF_Cache, Age, SetCookie, Status -AutoSize
+
+$validTtfb = $results | Where-Object { $_.TTFB_ms -gt 0 } | ForEach-Object { $_.TTFB_ms }
+if ($validTtfb.Count -gt 0) {
+    $sortedTtfb = $validTtfb | Sort-Object
+    $p50 = $sortedTtfb[[int]($sortedTtfb.Count * 0.5)]
+    $p90 = $sortedTtfb[[int]($sortedTtfb.Count * 0.9)]
+    $min = ($sortedTtfb | Measure-Object -Minimum).Minimum
+    $max = ($sortedTtfb | Measure-Object -Maximum).Maximum
+    $avg = [math]::Round(($sortedTtfb | Measure-Object -Average).Average, 0)
+    Write-Host ""
+    Write-Host "=== TTFB STATS ===" -ForegroundColor Cyan
+    Write-Host ("min={0}ms  p50={1}ms  p90={2}ms  max={3}ms  avg={4}ms" -f $min, $p50, $p90, $max, $avg)
+    
+    $missed = ($results | Where-Object { $_.CF_Cache -ne "HIT" -and $_.TTFB_ms -gt 0 }).Count
+    $hit    = ($results | Where-Object { $_.CF_Cache -eq "HIT"  -and $_.TTFB_ms -gt 0 }).Count
+    Write-Host ("CF HIT={0}  MISS/DYNAMIC={1}" -f $hit, $missed)
+}
+
+Write-Host ""
+Write-Host "=== SERVER-TIMING DETAIL ===" -ForegroundColor Cyan
+$results | Where-Object { $_.ServerTiming -ne "—" } | ForEach-Object { Write-Host ("[run{0:D2}] {1}" -f $_.Run, $_.ServerTiming) }
+if (-not ($results | Where-Object { $_.ServerTiming -ne "—" })) { Write-Host "  (no server-timing header)" }


### PR DESCRIPTION
## Iter-19  TTFB / ISR Cache Fix

### Root Cause (Evidence)
TTFB probe (10 runs, ops/bisect/ttfb_probe.ps1):
- CF=DYNAMIC all runs (no edge caching)
- cfOrigin=99-272ms (origin fast, warm)
- Run 1 TTFB=1212ms vs Runs 2-10: 220-250ms (TCP cold-start variance)

**Critical finding**: home page consumed \wait searchParams\ server-side. LH CI appends \?lh=<timestamp>\ to every run  each unique URL = separate Next.js ISR cache entry = fresh full SSR per LH run  bimodal LCP (4/5 slow ~1900ms, 1/5 fast ~1100ms).

### Fix
1. **New \GuidedOverlay.tsx\** (\'use client'\): reads URL params via \useSearchParams()\
2. **\page.tsx\**: removed \searchParams\ from function signature + all 50 LOC of derived guided state
3. **Result**: ISR cache shared for ALL URL variants (incl \?lh=<ts>\ LH runs)
4. **Bonus**: \etchProjects\ limit 1008 (only 6 projects displayed; reduces ISR payload)

### Files Changed
- \dmin-app/app/(site)/[locale]/_components/GuidedOverlay.tsx\ (new, +299)
- \dmin-app/app/(site)/[locale]/page.tsx\ (net -180 LOC)
- \ops/STATE.md\ (iteration update)
- \ops/bisect/ttfb_probe.ps1\ (new evidence tool)

### Expected Impact
- LH desktop runs now hit ISR cache (same URL \/en/\)  consistent TTFB ~220ms
- LCP should stabilize at fast end (~1100ms) instead of bimodal
- Guided modal UX fully preserved (client-side URL param reading)