### PR TITLE
evidence(iter-19): desktop gate FAIL snapshot (perfMed=90)

### DIFF
--- a/ops/STATE.md
+++ b/ops/STATE.md
@@ -1,13 +1,13 @@
 # ops/STATE.md (STATE-LOCK)
 
 - CurrentPhase: A+B=PASS, Phase1=FAIL, Phase2=BLOCKED, Phase3=BLOCKED, Phase4=BLOCKED, Phase5=BLOCKED
-- CurrentIteration: phase1-iter-19 (remove searchParams from home SSR, GuidedOverlay → client, limit:100→8 — deployed, pending gate)
+- CurrentIteration: phase1-iter-19 (remove searchParams from home SSR, GuidedOverlay → client, limit:100→8 — deployed, FAIL)
 - MainlineStatus: RUNNING
 - LatestEvidence: ops/logs/phase1/
-  - cf-headers.txt (2026-02-25 11:04:34)
+  - cf-headers.txt (2026-02-25 14:53:15)
   - lh-mobile.txt + lh-mobile.json (2026-02-25 07:49:49)
-  - lh-desktop.txt + lh-desktop.json (2026-02-25 11:05:53)
-  - hydration.txt (2026-02-25 11:05:53)
+  - lh-desktop.txt + lh-desktop.json (2026-02-25 15:06:41)
+  - hydration.txt (2026-02-25 15:06:41)
 - OpenPRsAllowed: 2 (1x Phase1 mainline iteration PR + 1x parallel-prep PR)
 - OpenPRsNow: (none)
 - PRsToClose: (none)
@@ -21,5 +21,5 @@
   - Lighthouse truth model: use simulated LCP (`audits[largest-contentful-paint].numericValue`) as truth; observed is supporting note only
   - Lighthouse gates: mobile>=92, desktop>=97, CLS=0, DOM<900, hydrationSignals=0
   - Avoid evidence bloat: evidence PR should prefer lh-*.{txt,json}, hydration.txt, cf-headers.txt, ops/STATE.md (attempt files only if necessary)
-- NextAction: Run desktop LH gate after deployment; if perfMed≥97 merge evidence PR.
-- LastResultSummary: Iter-19 patch deployed — root cause identified: home page consumed `await searchParams` server-side, causing every unique ?lh=<ts> LH run to trigger a fresh ISR computation (cache miss per run). Fix: extracted GuidedOverlay to client component (reads URL params via useSearchParams), removed searchParams from server component → ISR cache now shared for all URL variants. Also reduced fetchProjects limit:100→8 (only 6 displayed). TTFB probe: CF=DYNAMIC runs 2-10 = 220-250ms, run 1 = 1212ms (TCP cold). LH gate pending.
+- NextAction: Iter-20 Evidence-first patch: tackle Hero/LCP render delay on desktop (current perfMed ~90-91) while keeping TTFB stable and hydrationSignals=0.
+- LastResultSummary: Iter-19 deployed and verified. Cloudflare invariants PASS (`HTML=DYNAMIC`, static `_next/*` = HIT, no Set-Cookie). Desktop gate still FAIL: `perfMed=90`, `lcpMed=1865ms`, `tbtMed=0`, `clsMed=0`, `domMed=717` (runs: 76/93/90/90/91). One transient `NO_NAVSTART` observed and auto-retried; final evidence contains full 5 valid runs.

--- a/ops/logs/phase1/cf-headers.txt
+++ b/ops/logs/phase1/cf-headers.txt
@@ -151,3 +151,21 @@
 [2026-02-25T12:34:31] STATIC round2 url=https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js cf=HIT age=47882 server=cloudflare set-cookie=
 [2026-02-25T12:34:31] PASS static age increased on round2
 [2026-02-25T12:34:31] VERIFY end
+[2026-02-25T13:57:44] VERIFY start
+[2026-02-25T13:57:44] HTML /en/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T13:57:45] HTML /en/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T13:57:46] HTML /th/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T13:57:47] HTML /th/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T13:57:51] STATIC round1 url=https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js cf=HIT age=52879 server=cloudflare set-cookie=
+[2026-02-25T13:57:51] STATIC round2 url=https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js cf=HIT age=67732 server=cloudflare set-cookie=
+[2026-02-25T13:57:51] PASS static age increased on round2
+[2026-02-25T13:57:51] VERIFY end
+[2026-02-25T14:53:06] VERIFY start
+[2026-02-25T14:53:07] HTML /en/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T14:53:10] HTML /en/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T14:53:11] HTML /th/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T14:53:12] HTML /th/ cf=DYNAMIC age= server=cloudflare cache-control=public, s-maxage=300, stale-while-revalidate=3600
+[2026-02-25T14:53:15] STATIC round1 url=https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js cf=HIT age=71054 server=cloudflare set-cookie=
+[2026-02-25T14:53:15] STATIC round2 url=https://amppattaya.com/_next/static/chunks/4bd1b696-bf5e0dbacfa5baef.js cf=HIT age=56206 server=cloudflare set-cookie=
+[2026-02-25T14:53:15] INFO static age did not increase on round2 (soft signal; may be different edge)
+[2026-02-25T14:53:15] VERIFY end

--- a/ops/logs/phase1/hydration.txt
+++ b/ops/logs/phase1/hydration.txt
@@ -646,3 +646,30 @@ hydrationSignals(total): 0
   - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
   - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/?lh=1771997412216:0:0
 ### END PRESET: desktop
+### PRESET: desktop
+timestamp: 2026-02-25T08:06:41.098Z
+url: https://amppattaya.com/en/
+preset: desktop
+runs: 5
+hydrationSignals(total): 0
+- lh-desktop-run01.json consoleErrors=3 hydrationSignals=0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/:0:0
+- lh-desktop-run02.json consoleErrors=3 hydrationSignals=0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/:0:0
+- lh-desktop-run03.json consoleErrors=3 hydrationSignals=0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/:0:0
+- lh-desktop-run04.json consoleErrors=3 hydrationSignals=0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/:0:0
+- lh-desktop-run05.json consoleErrors=3 hydrationSignals=0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Failed to load resource: the server responded with a status of 422 () @ https://amppattaya.com/api/v1/events:0:0
+  - Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'". Note that 'script-src-ele @ https://amppattaya.com/en/:0:0
+### END PRESET: desktop

--- a/ops/logs/phase1/lh-desktop.json
+++ b/ops/logs/phase1/lh-desktop.json
@@ -11,11 +11,11 @@
     "domMax": 900
   },
   "medians": {
-    "perfScoreMed": 91,
-    "lcpMed": 1903.6709999999998,
-    "tbtMed": 11,
+    "perfScoreMed": 90,
+    "lcpMed": 1865.3599999999997,
+    "tbtMed": 0,
     "clsMed": 0,
-    "domMed": 681,
+    "domMed": 717,
     "hydrationSignals": 0
   },
   "ok": false,
@@ -26,11 +26,11 @@
     {
       "file": "lh-desktop-run01.json",
       "status": 0,
-      "perfScore": 84,
-      "lcp": 2179.304,
-      "tbt": 11,
-      "cls": 0,
-      "dom": 681,
+      "perfScore": 76,
+      "lcp": 2741.2668,
+      "tbt": 0,
+      "cls": 0.0002900627480351927,
+      "dom": 715,
       "consoleErrorsCount": 3,
       "hydrationSignals": 0,
       "consoleErrors": [
@@ -48,7 +48,7 @@
         },
         {
           "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
-          "url": "https://amppattaya.com/en/?lh=1771997336611",
+          "url": "https://amppattaya.com/en/",
           "line": 0,
           "col": 0
         }
@@ -57,11 +57,11 @@
     {
       "file": "lh-desktop-run02.json",
       "status": 0,
-      "perfScore": 90,
-      "lcp": 1957.5220000000006,
-      "tbt": 11,
+      "perfScore": 93,
+      "lcp": 1691.0868420683273,
+      "tbt": 0,
       "cls": 0,
-      "dom": 676,
+      "dom": 717,
       "consoleErrorsCount": 3,
       "hydrationSignals": 0,
       "consoleErrors": [
@@ -79,7 +79,7 @@
         },
         {
           "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
-          "url": "https://amppattaya.com/en/?lh=1771997357855",
+          "url": "https://amppattaya.com/en/",
           "line": 0,
           "col": 0
         }
@@ -88,9 +88,71 @@
     {
       "file": "lh-desktop-run03.json",
       "status": 0,
-      "perfScore": 92,
-      "lcp": 1796.4604999999997,
-      "tbt": 19,
+      "perfScore": 90,
+      "lcp": 1890.176,
+      "tbt": 1,
+      "cls": 0,
+      "dom": 717,
+      "consoleErrorsCount": 3,
+      "hydrationSignals": 0,
+      "consoleErrors": [
+        {
+          "description": "Failed to load resource: the server responded with a status of 422 ()",
+          "url": "https://amppattaya.com/api/v1/events",
+          "line": 0,
+          "col": 0
+        },
+        {
+          "description": "Failed to load resource: the server responded with a status of 422 ()",
+          "url": "https://amppattaya.com/api/v1/events",
+          "line": 0,
+          "col": 0
+        },
+        {
+          "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
+          "url": "https://amppattaya.com/en/",
+          "line": 0,
+          "col": 0
+        }
+      ]
+    },
+    {
+      "file": "lh-desktop-run04.json",
+      "status": 0,
+      "perfScore": 90,
+      "lcp": 1835.3850000000002,
+      "tbt": 0,
+      "cls": 0,
+      "dom": 717,
+      "consoleErrorsCount": 3,
+      "hydrationSignals": 0,
+      "consoleErrors": [
+        {
+          "description": "Failed to load resource: the server responded with a status of 422 ()",
+          "url": "https://amppattaya.com/api/v1/events",
+          "line": 0,
+          "col": 0
+        },
+        {
+          "description": "Failed to load resource: the server responded with a status of 422 ()",
+          "url": "https://amppattaya.com/api/v1/events",
+          "line": 0,
+          "col": 0
+        },
+        {
+          "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
+          "url": "https://amppattaya.com/en/",
+          "line": 0,
+          "col": 0
+        }
+      ]
+    },
+    {
+      "file": "lh-desktop-run05.json",
+      "status": 0,
+      "perfScore": 91,
+      "lcp": 1865.3599999999997,
+      "tbt": 9,
       "cls": 0,
       "dom": 676,
       "consoleErrorsCount": 3,
@@ -110,62 +172,20 @@
         },
         {
           "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
-          "url": "https://amppattaya.com/en/?lh=1771997376207",
-          "line": 0,
-          "col": 0
-        }
-      ]
-    },
-    {
-      "file": "lh-desktop-run04.json",
-      "status": 0,
-      "perfScore": 91,
-      "lcp": 1903.6709999999998,
-      "tbt": 7,
-      "cls": 0,
-      "dom": 717,
-      "consoleErrorsCount": 1,
-      "hydrationSignals": 0,
-      "consoleErrors": [
-        {
-          "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
-          "url": "https://amppattaya.com/en/?lh=1771997394371",
-          "line": 0,
-          "col": 0
-        }
-      ]
-    },
-    {
-      "file": "lh-desktop-run05.json",
-      "status": 0,
-      "perfScore": 97,
-      "lcp": 1099.289,
-      "tbt": 0,
-      "cls": 0,
-      "dom": 681,
-      "consoleErrorsCount": 3,
-      "hydrationSignals": 0,
-      "consoleErrors": [
-        {
-          "description": "Failed to load resource: the server responded with a status of 422 ()",
-          "url": "https://amppattaya.com/api/v1/events",
-          "line": 0,
-          "col": 0
-        },
-        {
-          "description": "Failed to load resource: the server responded with a status of 422 ()",
-          "url": "https://amppattaya.com/api/v1/events",
-          "line": 0,
-          "col": 0
-        },
-        {
-          "description": "Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015' violates the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.",
-          "url": "https://amppattaya.com/en/?lh=1771997412216",
+          "url": "https://amppattaya.com/en/",
           "line": 0,
           "col": 0
         }
       ]
     }
   ],
-  "attemptErrors": []
+  "attemptErrors": [
+    {
+      "attempt": 1,
+      "status": 1,
+      "runtimeError": "Something went wrong with recording the trace over your page load. Please run Lighthouse again. (NO_NAVSTART)",
+      "file": "lh-desktop-attempt01.json",
+      "transient": true
+    }
+  ]
 }

--- a/ops/logs/phase1/lh-desktop.txt
+++ b/ops/logs/phase1/lh-desktop.txt
@@ -1,11 +1,11 @@
 URL: https://amppattaya.com/en/
 Preset: desktop
-Medians: perf=91 lcp=1904 tbt=11 cls=0 dom=681
+Medians: perf=90 lcp=1865 tbt=0 cls=0 dom=717
 Gates: perf>=97 lcp<=2500 tbt<=200 cls<=0 dom<=900
 Result: FAIL (perf<97)
 Runs:
-- lh-desktop-run01.json perf=84 lcp=2179 tbt=11 cls=0 dom=681
-- lh-desktop-run02.json perf=90 lcp=1958 tbt=11 cls=0 dom=676
-- lh-desktop-run03.json perf=92 lcp=1796 tbt=19 cls=0 dom=676
-- lh-desktop-run04.json perf=91 lcp=1904 tbt=7 cls=0 dom=717
-- lh-desktop-run05.json perf=97 lcp=1099 tbt=0 cls=0 dom=681
+- lh-desktop-run01.json perf=76 lcp=2741 tbt=0 cls=0.0002900627480351927 dom=715
+- lh-desktop-run02.json perf=93 lcp=1691 tbt=0 cls=0 dom=717
+- lh-desktop-run03.json perf=90 lcp=1890 tbt=1 cls=0 dom=717
+- lh-desktop-run04.json perf=90 lcp=1835 tbt=0 cls=0 dom=717
+- lh-desktop-run05.json perf=91 lcp=1865 tbt=9 cls=0 dom=676


### PR DESCRIPTION
## Iter-19 Evidence Pack (FAIL)

### Scope
Evidence-only update after Iter-19 deployment.

### Included files (allowlist)
- ops/logs/phase1/cf-headers.txt
- ops/logs/phase1/hydration.txt
- ops/logs/phase1/lh-desktop.txt
- ops/logs/phase1/lh-desktop.json
- ops/STATE.md

### Result Summary
- Cloudflare invariants: PASS
  - HTML: cf-cache-status=DYNAMIC
  - Static _next assets: HIT
  - No Set-Cookie on cached static assets
- Desktop gate: FAIL
  - perfMed=90
  - lcpMed=1865ms
  - tbtMed=0ms
  - clsMed=0
  - domMed=717
- 5 valid desktop runs captured; one transient NO_NAVSTART occurred and was retried.

### Next Action
Iter-20 should focus on Hero/LCP render-delay stabilization (desktop), while keeping TTFB stable and hydrationSignals=0.