### PR TITLE
[codex] compose dashboard section layout and skeleton states

### DIFF
--- a/admin-app/__tests__/admin_dashboard_layout_primitives.test.ts
+++ b/admin-app/__tests__/admin_dashboard_layout_primitives.test.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "..");
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf-8");
+}
+
+describe("admin dashboard layout primitives", () => {
+  it("defines reusable section, state, and skeleton building blocks", () => {
+    const component = read("components/admin/dashboard/DashboardSectionPrimitives.tsx");
+
+    expect(component).toContain("export function DashboardSection(");
+    expect(component).toContain("export function DashboardSectionState(");
+    expect(component).toContain("export function DashboardMetricSkeletonRow(");
+    expect(component).toContain("export function DashboardWidgetSkeletonGrid(");
+    expect(component).toContain("export function DashboardInsightSkeletonList(");
+    expect(component).toContain("export function DashboardTableSkeleton(");
+    expect(component).toContain('className="dashboard-section-body"');
+    expect(component).toContain('className="dashboard-summary-grid dashboard-summary-grid--skeleton"');
+    expect(component).toContain('className="dashboard-table-skeleton"');
+  });
+});

--- a/admin-app/__tests__/admin_dashboard_surface_styles.test.ts
+++ b/admin-app/__tests__/admin_dashboard_surface_styles.test.ts
@@ -34,8 +34,13 @@ describe("admin dashboard surface styles", () => {
   it("styles dashboard-specific widgets, table states, and warning list", () => {
     const css = read("app/globals.css");
 
+    expect(css).toContain(".dashboard-shell-grid {");
+    expect(css).toContain(".dashboard-section-state--error {");
+    expect(css).toContain(".dashboard-summary-grid {");
+    expect(css).toContain(".dashboard-insight-item {");
     expect(css).toContain(".dashboard-widget::before");
     expect(css).toContain(".dashboard-table tbody tr:hover td");
+    expect(css).toContain(".dashboard-table-skeleton {");
     expect(css).toContain(".dashboard-warning-list li");
     expect(css).toContain(".dashboard-table-wrap {");
     expect(css).toContain(".dashboard-status-unknown {");

--- a/admin-app/__tests__/b14_admin_dashboard_page.test.ts
+++ b/admin-app/__tests__/b14_admin_dashboard_page.test.ts
@@ -15,6 +15,7 @@ describe("B14 admin dashboard page contract", () => {
 
     expect(page).toContain('from "@/app/_lib/admin-auth"');
     expect(page).toContain('from "@/app/admin/dashboard/state-utils"');
+    expect(page).toContain('from "@/components/admin/dashboard/DashboardSectionPrimitives"');
     expect(page).toContain("loginAdmin");
     expect(page).toContain("transitionDashboardState");
     expect(page).not.toContain('fetch("/v1/auth/login"');
@@ -43,16 +44,26 @@ describe("B14 admin dashboard page contract", () => {
     expect(page).toContain('htmlFor="dashboard-login-password"');
     expect(page).toContain('autoComplete="username"');
     expect(page).toContain('autoComplete="current-password"');
+    expect(page).toContain("dashboard-shell-grid");
+    expect(page).toContain('className="dashboard-section--widgets"');
+    expect(page).toContain('className="dashboard-section--table"');
+    expect(page).toContain('className="dashboard-section--insights"');
+    expect(page).toContain('className="dashboard-section--warnings"');
+    expect(page).toContain("DashboardMetricSkeletonRow");
+    expect(page).toContain("DashboardWidgetSkeletonGrid");
+    expect(page).toContain("DashboardInsightSkeletonList");
+    expect(page).toContain("DashboardTableSkeleton");
     expect(page).toContain("state-empty");
-    expect(page).toContain("state-loading");
     expect(page).toContain("state-error");
+    expect(page).toContain("dashboardState === \"loading\"");
+    expect(page).toContain("dashboardState === \"idle\"");
     expect(page).toContain("dashboardState === \"error\"");
     expect(page).toContain("dashboardState === \"empty\"");
-    expect(page).toContain("dashboardState === \"success\"");
     expect(page).toContain("retry: \"Retry\"");
     expect(page).toContain("retry: \"ลองใหม่\"");
     expect(page).toContain('title: "Admin Health / QA Dashboard"');
-    expect(page).toContain('title: "Admin Health / QA Dashboard"');
     expect(page).toContain('subtitle: "หน้าเดียวสำหรับดูความสมบูรณ์ของระบบและลิงก์แก้ปัญหาแบบ actionable"');
+    expect(page).toContain('insightsTitle: "Pipeline insights"');
+    expect(page).toContain('insightsTitle: "ข้อมูล pipeline"');
   });
 });

--- a/admin-app/app/admin/dashboard/page.tsx
+++ b/admin-app/app/admin/dashboard/page.tsx
@@ -8,6 +8,14 @@ import {
   transitionDashboardState,
   type DashboardState,
 } from "@/app/admin/dashboard/state-utils";
+import {
+  DashboardInsightSkeletonList,
+  DashboardMetricSkeletonRow,
+  DashboardSection,
+  DashboardSectionState,
+  DashboardTableSkeleton,
+  DashboardWidgetSkeletonGrid,
+} from "@/components/admin/dashboard/DashboardSectionPrimitives";
 
 type Locale = AdminLocale;
 type WidgetStatus = "ok" | "warn" | "error" | "unknown";
@@ -69,6 +77,10 @@ const copy = {
     title: "Admin Health / QA Dashboard",
     subtitle:
       "Single-page operational view of content/media/leads/SEO/tracking completeness with actionable links.",
+    overviewReadyTitle: "Ready to load overview",
+    overviewReadyBody: "Refresh the dashboard to load the latest QA snapshot.",
+    overviewEmptyTitle: "Overview unavailable",
+    overviewEmptyBody: "Dashboard summary responded without any visible content yet.",
     loginTitle: "Admin sign in",
     loginSubtitle: "Use the same credentials as /api/v1/auth/login.",
     sessionActive: "Signed in session",
@@ -93,21 +105,44 @@ const copy = {
     emptyStateHint: "Check data pipelines and retry.",
     emptyWidgets: "No widgets found. Check backend summary contract.",
     widgets: "Health widgets",
+    widgetsHint: "Priority QA checks across content, media, translations, and deploy health.",
+    widgetsEmptyTitle: "No widgets returned",
+    widgetsEmptyBody: "Backend summary returned no health widgets for this snapshot.",
+    insightsTitle: "Pipeline insights",
+    insightsHint: "Freshness timestamps from upstream summary sources.",
+    insightsEmptyTitle: "No freshness insights",
+    insightsEmptyBody: "Freshness signals will appear here when upstream jobs report timestamps.",
     generatedAt: "Generated at",
     incomplete: "Incomplete widgets",
+    sectionReadyTitle: "Ready to load",
+    sectionReadyBody: "Refresh the dashboard to populate this section.",
+    sectionErrorTitle: "Section unavailable",
     recentInquiries: "Recent leads/inquiries",
+    recentInquiriesHint: "Latest captured leads and inquiries from public entry points.",
+    recentInquiriesEmptyTitle: "No recent inquiries",
+    recentInquiriesEmptyBody: "New lead rows will appear here after the next captured submission.",
     emptyInquiries: "No recent inquiries found.",
     sourcePage: "Source page",
     status: "Status",
     intent: "Intent",
     contact: "Contact",
+    name: "Name",
     createdAt: "Created at",
     warnings: "Warnings",
+    warningsHint: "Operator watchlist emitted by the summary endpoint.",
+    warningsEmptyTitle: "No active warnings",
+    warningsEmptyBody: "Current snapshot has no warning messages.",
+    checkedAt: "Checked at",
+    age: "Age",
     unknownValue: "Unknown",
   },
   th: {
     title: "Admin Health / QA Dashboard",
     subtitle: "หน้าเดียวสำหรับดูความสมบูรณ์ของระบบและลิงก์แก้ปัญหาแบบ actionable",
+    overviewReadyTitle: "พร้อมโหลดภาพรวม",
+    overviewReadyBody: "กดรีเฟรชเพื่อโหลด snapshot ล่าสุดของแดชบอร์ด",
+    overviewEmptyTitle: "ยังไม่มีภาพรวม",
+    overviewEmptyBody: "summary ตอบกลับมา แต่ยังไม่มีข้อมูลที่แสดงผลได้",
     loginTitle: "เข้าสู่ระบบแอดมิน",
     loginSubtitle: "ใช้บัญชีเดียวกับ /api/v1/auth/login",
     sessionActive: "เซสชันที่เข้าสู่ระบบอยู่",
@@ -132,16 +167,35 @@ const copy = {
     emptyStateHint: "ตรวจ pipeline ข้อมูลแล้วลองใหม่อีกครั้ง",
     emptyWidgets: "ยังไม่พบวิดเจ็ต ตรวจสอบ backend summary contract",
     widgets: "วิดเจ็ตสุขภาพระบบ",
+    widgetsHint: "QA checks หลักของ content, media, translations และ deploy",
+    widgetsEmptyTitle: "ยังไม่มีวิดเจ็ต",
+    widgetsEmptyBody: "backend summary ยังไม่ส่ง health widget มาในรอบนี้",
+    insightsTitle: "ข้อมูล pipeline",
+    insightsHint: "เวลาอัปเดตล่าสุดจาก upstream summary sources",
+    insightsEmptyTitle: "ยังไม่มี freshness insight",
+    insightsEmptyBody: "เมื่อ upstream jobs ส่ง timestamp มา ระบบจะแสดงในส่วนนี้",
     generatedAt: "เวลาที่สร้างรายงาน",
     incomplete: "วิดเจ็ตที่ยังไม่สมบูรณ์",
+    sectionReadyTitle: "พร้อมโหลดข้อมูล",
+    sectionReadyBody: "กดรีเฟรชเพื่อเติมข้อมูลในส่วนนี้",
+    sectionErrorTitle: "ไม่สามารถแสดงส่วนนี้ได้",
     recentInquiries: "ลีด/อินไควรีล่าสุด",
+    recentInquiriesHint: "ลีดและอินไควรีล่าสุดจากหน้า public",
+    recentInquiriesEmptyTitle: "ยังไม่มีอินไควรีล่าสุด",
+    recentInquiriesEmptyBody: "เมื่อมี submission ใหม่ ระบบจะแสดงแถวข้อมูลที่นี่",
     emptyInquiries: "ยังไม่มีอินไควรีล่าสุด",
     sourcePage: "หน้า source",
     status: "สถานะ",
     intent: "Intent",
     contact: "ช่องทางติดต่อ",
+    name: "ชื่อ",
     createdAt: "เวลาสร้าง",
     warnings: "คำเตือน",
+    warningsHint: "watchlist จาก summary endpoint",
+    warningsEmptyTitle: "ไม่มีคำเตือนที่เปิดอยู่",
+    warningsEmptyBody: "snapshot ปัจจุบันไม่มีข้อความเตือน",
+    checkedAt: "ตรวจล่าสุด",
+    age: "อายุข้อมูล",
     unknownValue: "ไม่ทราบ",
   },
 };
@@ -176,6 +230,29 @@ function widgetValueToText(value: DashboardWidget["value"], fallback: string): s
 
 function statusClass(status: WidgetStatus): string {
   return `dashboard-status dashboard-status-${status}`;
+}
+
+function humanizeMetricKey(key: string): string {
+  return key
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatAge(value: number | null, locale: Locale, fallback: string): string {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return fallback;
+  if (value < 60) return locale === "th" ? `${Math.round(value)} วินาทีที่ผ่านมา` : `${Math.round(value)}s ago`;
+  if (value < 3600) {
+    const minutes = Math.max(1, Math.round(value / 60));
+    return locale === "th" ? `${minutes} นาทีที่ผ่านมา` : `${minutes}m ago`;
+  }
+  if (value < 86400) {
+    const hours = Math.max(1, Math.round(value / 3600));
+    return locale === "th" ? `${hours} ชั่วโมงที่ผ่านมา` : `${hours}h ago`;
+  }
+  const days = Math.max(1, Math.round(value / 86400));
+  return locale === "th" ? `${days} วันที่ผ่านมา` : `${days}d ago`;
 }
 
 async function fetchSummary(token: string): Promise<DashboardSummaryResponse> {
@@ -220,6 +297,312 @@ export default function AdminDashboardPage() {
     const byKey = new Map(rows.map((row) => [row.key, row]));
     return WIDGET_KEYS.map((key) => byKey.get(key)).filter(Boolean) as DashboardWidget[];
   }, [summary]);
+  const freshnessEntries = useMemo(() => {
+    const source = summary?.data_freshness || {};
+    return Object.entries(source).sort(([left], [right]) => left.localeCompare(right)) as Array<
+      [string, FreshnessItem]
+    >;
+  }, [summary]);
+  const overviewMetrics = useMemo(
+    () => [
+      {
+        key: "generated_at",
+        label: t.generatedAt,
+        value: prettyDate(summary?.generated_at || null, locale),
+      },
+      {
+        key: "incomplete_widget_count",
+        label: t.incomplete,
+        value:
+          typeof summary?.incomplete_widget_count === "number"
+            ? String(summary.incomplete_widget_count)
+            : t.unknownValue,
+      },
+      {
+        key: "recent_inquiries",
+        label: t.recentInquiries,
+        value: String(summary?.recent_inquiries?.length || 0),
+      },
+      {
+        key: "warnings",
+        label: t.warnings,
+        value: String(summary?.warnings?.length || 0),
+      },
+    ],
+    [locale, summary, t],
+  );
+
+  function renderRefreshButton(label?: string) {
+    return (
+      <button
+        className="btn btn-secondary"
+        type="button"
+        onClick={() => void loadDashboard()}
+        disabled={loading}
+      >
+        {loading ? t.loading : label || t.refresh}
+      </button>
+    );
+  }
+
+  function renderOverviewPanel() {
+    if (dashboardState === "loading") {
+      return <DashboardMetricSkeletonRow cards={4} />;
+    }
+
+    if (dashboardState === "error") {
+      return (
+        <DashboardSectionState
+          tone="error"
+          title={t.sectionErrorTitle}
+          body={pageError || `${t.loadError} ${t.loadErrorHint}`}
+          action={renderRefreshButton(t.retry)}
+        />
+      );
+    }
+
+    if (dashboardState === "idle") {
+      return (
+        <DashboardSectionState
+          tone="info"
+          title={t.overviewReadyTitle}
+          body={t.overviewReadyBody}
+          action={renderRefreshButton()}
+        />
+      );
+    }
+
+    if (dashboardState === "empty") {
+      return (
+        <DashboardSectionState
+          tone="empty"
+          title={t.overviewEmptyTitle}
+          body={t.overviewEmptyBody}
+          action={renderRefreshButton(t.retry)}
+        />
+      );
+    }
+
+    return (
+      <div className="dashboard-summary-grid" aria-live="polite">
+        {overviewMetrics.map((item) => (
+          <article key={item.key} className="dashboard-summary-card">
+            <span>{item.label}</span>
+            <strong>{item.value}</strong>
+          </article>
+        ))}
+      </div>
+    );
+  }
+
+  function renderWidgetsPanel() {
+    if (dashboardState === "loading") {
+      return <DashboardWidgetSkeletonGrid cards={6} />;
+    }
+
+    if (dashboardState === "error") {
+      return (
+        <DashboardSectionState
+          tone="error"
+          title={t.sectionErrorTitle}
+          body={pageError || `${t.loadError} ${t.loadErrorHint}`}
+          action={renderRefreshButton(t.retry)}
+        />
+      );
+    }
+
+    if (dashboardState === "idle") {
+      return <DashboardSectionState tone="info" title={t.sectionReadyTitle} body={t.sectionReadyBody} action={renderRefreshButton()} />;
+    }
+
+    if (widgets.length === 0) {
+      return (
+        <DashboardSectionState
+          tone="empty"
+          title={t.widgetsEmptyTitle}
+          body={t.widgetsEmptyBody}
+          action={renderRefreshButton(t.retry)}
+        />
+      );
+    }
+
+    return (
+      <div className="dashboard-grid">
+        {widgets.map((widget) => (
+          <article key={widget.key} className="card dashboard-widget">
+            <header className="dashboard-widget-head">
+              <h3>{widget.title}</h3>
+              <span className={statusClass(widget.status)}>{widget.status}</span>
+            </header>
+            <p className="dashboard-widget-value">
+              {widgetValueToText(widget.value, t.unknownValue)}
+            </p>
+            <p className="locale-safe">{widget.summary}</p>
+            <div className="dashboard-widget-actions">
+              {(widget.actions || []).map((action, index) => (
+                <a
+                  key={`${widget.key}-${action.url}-${index}`}
+                  className="btn btn-secondary"
+                  href={action.url}
+                >
+                  {action.label}
+                </a>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    );
+  }
+
+  function renderInsightsPanel() {
+    if (dashboardState === "loading") {
+      return <DashboardInsightSkeletonList items={4} />;
+    }
+
+    if (dashboardState === "error") {
+      return (
+        <DashboardSectionState
+          tone="error"
+          title={t.sectionErrorTitle}
+          body={pageError || `${t.loadError} ${t.loadErrorHint}`}
+          action={renderRefreshButton(t.retry)}
+        />
+      );
+    }
+
+    if (dashboardState === "idle") {
+      return <DashboardSectionState tone="info" title={t.sectionReadyTitle} body={t.sectionReadyBody} action={renderRefreshButton()} />;
+    }
+
+    if (freshnessEntries.length === 0) {
+      return (
+        <DashboardSectionState
+          tone="empty"
+          title={t.insightsEmptyTitle}
+          body={t.insightsEmptyBody}
+          action={renderRefreshButton(t.retry)}
+        />
+      );
+    }
+
+    return (
+      <ul className="dashboard-insight-list">
+        {freshnessEntries.map(([key, item]) => (
+          <li key={key} className="dashboard-insight-item">
+            <div className="dashboard-insight-copy">
+              <strong>{humanizeMetricKey(key)}</strong>
+              <p>
+                {t.checkedAt}: {prettyDate(item.checked_at, locale)}
+              </p>
+            </div>
+            <span className="dashboard-insight-age">{formatAge(item.age_seconds, locale, t.unknownValue)}</span>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  function renderWarningsPanel() {
+    if (dashboardState === "loading") {
+      return <DashboardInsightSkeletonList items={3} />;
+    }
+
+    if (dashboardState === "error") {
+      return (
+        <DashboardSectionState
+          tone="error"
+          title={t.sectionErrorTitle}
+          body={pageError || `${t.loadError} ${t.loadErrorHint}`}
+          action={renderRefreshButton(t.retry)}
+        />
+      );
+    }
+
+    if (dashboardState === "idle") {
+      return <DashboardSectionState tone="info" title={t.sectionReadyTitle} body={t.sectionReadyBody} action={renderRefreshButton()} />;
+    }
+
+    if ((summary?.warnings || []).length === 0) {
+      return (
+        <DashboardSectionState
+          tone="empty"
+          title={t.warningsEmptyTitle}
+          body={t.warningsEmptyBody}
+          action={renderRefreshButton(t.retry)}
+        />
+      );
+    }
+
+    return (
+      <ul className="dashboard-warning-list">
+        {(summary?.warnings || []).map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  function renderTablePanel() {
+    if (dashboardState === "loading") {
+      return <DashboardTableSkeleton rows={5} />;
+    }
+
+    if (dashboardState === "error") {
+      return (
+        <DashboardSectionState
+          tone="error"
+          title={t.sectionErrorTitle}
+          body={pageError || `${t.loadError} ${t.loadErrorHint}`}
+          action={renderRefreshButton(t.retry)}
+        />
+      );
+    }
+
+    if (dashboardState === "idle") {
+      return <DashboardSectionState tone="info" title={t.sectionReadyTitle} body={t.sectionReadyBody} action={renderRefreshButton()} />;
+    }
+
+    if ((summary?.recent_inquiries || []).length === 0) {
+      return (
+        <DashboardSectionState
+          tone="empty"
+          title={t.recentInquiriesEmptyTitle}
+          body={t.recentInquiriesEmptyBody}
+          action={renderRefreshButton(t.retry)}
+        />
+      );
+    }
+
+    return (
+      <div className="dashboard-table-wrap">
+        <table className="dashboard-table">
+          <thead>
+            <tr>
+              <th>{t.createdAt}</th>
+              <th>{t.name}</th>
+              <th>{t.contact}</th>
+              <th>{t.status}</th>
+              <th>{t.intent}</th>
+              <th>{t.sourcePage}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(summary?.recent_inquiries || []).map((row) => (
+              <tr key={row.id}>
+                <td>{prettyDate(row.created_at, locale)}</td>
+                <td>{row.name}</td>
+                <td>{row.email || row.phone || "-"}</td>
+                <td>{row.status || "-"}</td>
+                <td>{row.intent || "-"}</td>
+                <td>{row.source_page || "-"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
 
   async function loadDashboard(tokenOverride?: string) {
     const activeToken = (tokenOverride ?? authToken).trim();
@@ -291,9 +674,10 @@ export default function AdminDashboardPage() {
 
   return (
     <main id="main-content" className="container content-stack">
-      <section className="card">
+      <section className="card dashboard-hero">
         <h1>{t.title}</h1>
         <p className="locale-safe">{t.subtitle}</p>
+        {isAuthenticated ? renderOverviewPanel() : <DashboardSectionState tone="info" title={t.loginTitle} body={t.authRequired} />}
       </section>
 
       <section className="card dashboard-controls" aria-label={t.loginTitle}>
@@ -343,9 +727,7 @@ export default function AdminDashboardPage() {
               {authEmail ? `${t.sessionAs}: ${authEmail}` : t.sessionUnknown}
             </p>
             <div className="card-actions">
-              <button className="btn btn-secondary" type="button" onClick={() => void loadDashboard()}>
-                {loading ? t.loading : t.refresh}
-              </button>
+              {renderRefreshButton()}
               <button className="btn btn-secondary" type="button" onClick={logout}>
                 {t.signOut}
               </button>
@@ -355,118 +737,44 @@ export default function AdminDashboardPage() {
         {!isAuthenticated ? <div className="state-empty">{t.authRequired}</div> : null}
       </section>
 
-      {isAuthenticated && dashboardState === "idle" ? <div className="state-empty">{t.idleState}</div> : null}
-      {isAuthenticated && dashboardState === "error" ? (
-        <div className="state-error" role="alert">
-          <p>{pageError || t.loadError}</p>
-          <div className="card-actions">
-            <button className="btn btn-secondary" type="button" onClick={() => void loadDashboard()}>
-              {t.retry}
-            </button>
+      {isAuthenticated ? (
+        <div className="dashboard-shell-grid">
+          <div className="dashboard-shell-main">
+            <DashboardSection
+              title={t.widgets}
+              subtitle={t.widgetsHint}
+              className="dashboard-section--widgets"
+            >
+              {renderWidgetsPanel()}
+            </DashboardSection>
+
+            <DashboardSection
+              title={t.recentInquiries}
+              subtitle={t.recentInquiriesHint}
+              className="dashboard-section--table"
+            >
+              {renderTablePanel()}
+            </DashboardSection>
+          </div>
+
+          <div className="dashboard-shell-side">
+            <DashboardSection
+              title={t.insightsTitle}
+              subtitle={t.insightsHint}
+              className="dashboard-section--insights"
+            >
+              {renderInsightsPanel()}
+            </DashboardSection>
+
+            <DashboardSection
+              title={t.warnings}
+              subtitle={t.warningsHint}
+              className="dashboard-section--warnings"
+            >
+              {renderWarningsPanel()}
+            </DashboardSection>
           </div>
         </div>
-      ) : null}
-      {isAuthenticated && dashboardState === "loading" ? <div className="state-loading">{t.loading}</div> : null}
-      {isAuthenticated && dashboardState === "empty" ? (
-        <section className="card">
-          <div className="state-empty">{t.emptyState}</div>
-          <p className="locale-safe">{t.emptyStateHint}</p>
-          <div className="card-actions">
-            <button className="btn btn-secondary" type="button" onClick={() => void loadDashboard()}>
-              {t.retry}
-            </button>
-          </div>
-        </section>
-      ) : null}
-
-      {isAuthenticated && dashboardState === "success" && summary ? (
-        <>
-          <section className="card dashboard-overview" aria-live="polite">
-            <p>
-              <strong>{t.generatedAt}:</strong> {prettyDate(summary.generated_at, locale)}
-            </p>
-            <p>
-              <strong>{t.incomplete}:</strong> {summary.incomplete_widget_count}
-            </p>
-          </section>
-
-          <section className="dashboard-grid" aria-label={t.widgets}>
-            {widgets.length === 0 ? (
-              <div className="card">
-                <div className="state-empty">{t.emptyWidgets}</div>
-              </div>
-            ) : (
-              widgets.map((widget) => (
-                <article key={widget.key} className="card dashboard-widget">
-                  <header className="dashboard-widget-head">
-                    <h2>{widget.title}</h2>
-                    <span className={statusClass(widget.status)}>{widget.status}</span>
-                  </header>
-                  <p className="dashboard-widget-value">
-                    {widgetValueToText(widget.value, t.unknownValue)}
-                  </p>
-                  <p className="locale-safe">{widget.summary}</p>
-                  <div className="dashboard-widget-actions">
-                    {(widget.actions || []).map((action, index) => (
-                      <a
-                        key={`${widget.key}-${action.url}-${index}`}
-                        className="btn btn-secondary"
-                        href={action.url}
-                      >
-                        {action.label}
-                      </a>
-                    ))}
-                  </div>
-                </article>
-              ))
-            )}
-          </section>
-
-          <section className="card" aria-label={t.recentInquiries}>
-            <h2>{t.recentInquiries}</h2>
-            {(summary.recent_inquiries || []).length === 0 ? (
-              <div className="state-empty">{t.emptyInquiries}</div>
-            ) : (
-              <div className="dashboard-table-wrap">
-                <table className="dashboard-table">
-                  <thead>
-                    <tr>
-                      <th>{t.createdAt}</th>
-                      <th>Name</th>
-                      <th>{t.contact}</th>
-                      <th>{t.status}</th>
-                      <th>{t.intent}</th>
-                      <th>{t.sourcePage}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {summary.recent_inquiries.map((row) => (
-                      <tr key={row.id}>
-                        <td>{prettyDate(row.created_at, locale)}</td>
-                        <td>{row.name}</td>
-                        <td>{row.email || row.phone || "-"}</td>
-                        <td>{row.status || "-"}</td>
-                        <td>{row.intent || "-"}</td>
-                        <td>{row.source_page || "-"}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </section>
-
-          {(summary.warnings || []).length > 0 ? (
-            <section className="card" aria-label={t.warnings}>
-              <h2>{t.warnings}</h2>
-              <ul className="dashboard-warning-list">
-                {summary.warnings.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            </section>
-          ) : null}
-        </>
       ) : null}
     </main>
   );

--- a/admin-app/app/globals.css
+++ b/admin-app/app/globals.css
@@ -4223,6 +4223,160 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   gap: 14px;
 }
 
+.dashboard-hero {
+  position: relative;
+  display: grid;
+  gap: 18px;
+  overflow: hidden;
+  min-height: 220px;
+}
+
+.dashboard-hero::after {
+  content: "";
+  position: absolute;
+  right: -80px;
+  bottom: -90px;
+  width: 220px;
+  height: 220px;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(37, 99, 235, 0.12) 0%, rgba(15, 118, 110, 0.04) 52%, transparent 72%);
+  pointer-events: none;
+}
+
+.dashboard-shell-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.92fr);
+  align-items: start;
+}
+
+.dashboard-shell-main,
+.dashboard-shell-side {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+.dashboard-section {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+.dashboard-section--widgets {
+  min-height: 440px;
+}
+
+.dashboard-section--table {
+  min-height: 360px;
+}
+
+.dashboard-section--insights,
+.dashboard-section--warnings {
+  min-height: 220px;
+}
+
+.dashboard-section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dashboard-section-copy {
+  display: grid;
+  gap: 6px;
+}
+
+.dashboard-section-copy h2 {
+  margin: 0;
+}
+
+.dashboard-section-copy p {
+  margin: 0;
+  color: var(--admin-ink-muted, var(--color-gray-700));
+}
+
+.dashboard-section-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.dashboard-section-body {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+
+.dashboard-section-state {
+  display: grid;
+  gap: 10px;
+  align-content: center;
+  min-height: 180px;
+  padding: 18px;
+  border: 1px dashed var(--admin-border-strong, rgba(14, 116, 144, 0.18));
+  border-radius: 18px;
+  background: rgba(248, 246, 239, 0.72);
+}
+
+.dashboard-section-state h3,
+.dashboard-section-state p {
+  margin: 0;
+}
+
+.dashboard-section-state p {
+  color: var(--admin-ink-muted, var(--color-gray-700));
+}
+
+.dashboard-section-state--info {
+  border-color: rgba(14, 116, 144, 0.16);
+  background: rgba(238, 244, 245, 0.64);
+}
+
+.dashboard-section-state--empty {
+  border-color: rgba(148, 163, 184, 0.24);
+  background: rgba(248, 250, 252, 0.72);
+}
+
+.dashboard-section-state--error {
+  border-color: rgba(220, 38, 38, 0.2);
+  background: rgba(254, 242, 242, 0.92);
+}
+
+.dashboard-overview,
+.dashboard-summary-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-items: stretch;
+}
+
+.dashboard-summary-card {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--admin-border-soft, var(--color-gray-200));
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+}
+
+.dashboard-summary-card span {
+  color: var(--admin-ink-muted, var(--color-gray-700));
+  font-size: var(--font-sm);
+}
+
+.dashboard-summary-card strong {
+  font-size: clamp(1.35rem, 1.2rem + 0.65vw, 1.9rem);
+  line-height: 1.1;
+  color: var(--admin-ink-strong, var(--color-gray-900));
+}
+
+.dashboard-summary-card--skeleton {
+  align-content: start;
+}
+
 .crm-auth-shell {
   display: grid;
   gap: 12px;
@@ -4239,17 +4393,14 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   gap: 10px;
 }
 
-.dashboard-overview {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  align-items: center;
-}
-
 .dashboard-grid {
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.dashboard-grid--skeleton {
+  align-items: stretch;
 }
 
 .dashboard-widget {
@@ -4278,7 +4429,8 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   gap: 12px;
 }
 
-.dashboard-widget-head h2 {
+.dashboard-widget-head h2,
+.dashboard-widget-head h3 {
   margin: 0;
   font-size: clamp(1rem, 0.92rem + 0.35vw, 1.14rem);
   color: var(--admin-ink-strong, var(--color-gray-800));
@@ -4298,6 +4450,58 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   flex-wrap: wrap;
   gap: 8px;
   margin-top: auto;
+}
+
+.dashboard-insight-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.dashboard-insight-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: start;
+  padding: 14px;
+  border: 1px solid var(--admin-border-soft, var(--color-gray-200));
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.76);
+}
+
+.dashboard-insight-item--skeleton {
+  align-items: center;
+}
+
+.dashboard-insight-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.dashboard-insight-copy strong,
+.dashboard-insight-copy p {
+  margin: 0;
+}
+
+.dashboard-insight-copy p {
+  color: var(--admin-ink-muted, var(--color-gray-700));
+}
+
+.dashboard-insight-age {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 6px 10px;
+  border: 1px solid var(--admin-border-soft, var(--color-gray-200));
+  border-radius: 999px;
+  background: rgba(238, 244, 245, 0.84);
+  color: var(--admin-accent-contrast, var(--color-gray-900));
+  font-size: var(--font-xs);
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .dashboard-status {
@@ -4351,6 +4555,26 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   border-radius: 16px;
   background: var(--admin-surface-card-strong, var(--color-white));
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.dashboard-table-skeleton {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--admin-border-soft, var(--color-gray-200));
+  border-radius: 16px;
+  background: var(--admin-surface-card-strong, var(--color-white));
+}
+
+.dashboard-table-skeleton-row {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.dashboard-table-skeleton-row--head {
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--color-gray-100);
 }
 
 .dashboard-table,
@@ -4746,8 +4970,17 @@ summary.mobile-nav__trigger::-webkit-details-marker {
     min-width: 620px;
   }
 
+  .dashboard-shell-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-section-head {
+    flex-direction: column;
+  }
+
   .dashboard-grid,
-  .dashboard-overview {
+  .dashboard-overview,
+  .dashboard-summary-grid {
     grid-template-columns: 1fr;
   }
 }
@@ -5540,6 +5773,18 @@ summary.mobile-nav__trigger::-webkit-details-marker {
 }
 
 @media (max-width: 720px) {
+  .dashboard-insight-item {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-insight-age {
+    justify-self: start;
+  }
+
+  .dashboard-table-skeleton-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .admin-shell-topbar-tools {
     grid-template-columns: 1fr;
   }

--- a/admin-app/components/admin/dashboard/DashboardSectionPrimitives.tsx
+++ b/admin-app/components/admin/dashboard/DashboardSectionPrimitives.tsx
@@ -1,0 +1,132 @@
+import type { ReactNode } from "react";
+
+function joinClasses(...values: Array<string | undefined | false>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+export function DashboardSection({
+  title,
+  subtitle,
+  actions,
+  className,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className={joinClasses("card", "dashboard-section", className)} aria-label={title}>
+      <header className="dashboard-section-head">
+        <div className="dashboard-section-copy">
+          <h2>{title}</h2>
+          {subtitle ? <p className="locale-safe">{subtitle}</p> : null}
+        </div>
+        {actions ? <div className="dashboard-section-actions">{actions}</div> : null}
+      </header>
+      <div className="dashboard-section-body">{children}</div>
+    </section>
+  );
+}
+
+export function DashboardSectionState({
+  tone = "info",
+  title,
+  body,
+  action,
+}: {
+  tone?: "empty" | "error" | "info";
+  title: string;
+  body: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div
+      className={joinClasses("dashboard-section-state", `dashboard-section-state--${tone}`)}
+      role={tone === "error" ? "alert" : "status"}
+      aria-live="polite"
+    >
+      <h3>{title}</h3>
+      <p className="locale-safe">{body}</p>
+      {action ? <div className="dashboard-section-actions">{action}</div> : null}
+    </div>
+  );
+}
+
+export function DashboardMetricSkeletonRow({ cards = 4 }: { cards?: number }) {
+  return (
+    <div className="dashboard-summary-grid dashboard-summary-grid--skeleton" aria-hidden="true">
+      {Array.from({ length: cards }).map((_, index) => (
+        <article key={index} className="dashboard-summary-card dashboard-summary-card--skeleton">
+          <div className="skeleton skeleton--text" />
+          <div className="skeleton skeleton--title" />
+          <div className="skeleton skeleton--text" />
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export function DashboardWidgetSkeletonGrid({ cards = 6 }: { cards?: number }) {
+  return (
+    <div className="dashboard-grid dashboard-grid--skeleton" aria-hidden="true">
+      {Array.from({ length: cards }).map((_, index) => (
+        <article key={index} className="card dashboard-widget dashboard-widget--skeleton">
+          <div className="dashboard-widget-head">
+            <div className="skeleton skeleton--title" />
+            <div className="skeleton skeleton--text" />
+          </div>
+          <div className="skeleton skeleton--title" />
+          <div className="skeleton skeleton--text" />
+          <div className="dashboard-widget-actions">
+            <div className="skeleton skeleton--text" />
+            <div className="skeleton skeleton--text" />
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export function DashboardInsightSkeletonList({ items = 4 }: { items?: number }) {
+  return (
+    <div className="dashboard-insight-list" aria-hidden="true">
+      {Array.from({ length: items }).map((_, index) => (
+        <article key={index} className="dashboard-insight-item dashboard-insight-item--skeleton">
+          <div className="dashboard-insight-copy">
+            <div className="skeleton skeleton--title" />
+            <div className="skeleton skeleton--text" />
+          </div>
+          <div className="skeleton skeleton--text" />
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export function DashboardTableSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="dashboard-table-skeleton" aria-hidden="true">
+      <div className="dashboard-table-skeleton-row dashboard-table-skeleton-row--head">
+        <div className="skeleton skeleton--text" />
+        <div className="skeleton skeleton--text" />
+        <div className="skeleton skeleton--text" />
+        <div className="skeleton skeleton--text" />
+        <div className="skeleton skeleton--text" />
+        <div className="skeleton skeleton--text" />
+      </div>
+      {Array.from({ length: rows }).map((_, index) => (
+        <div key={index} className="dashboard-table-skeleton-row">
+          <div className="skeleton skeleton--text" />
+          <div className="skeleton skeleton--text" />
+          <div className="skeleton skeleton--text" />
+          <div className="skeleton skeleton--text" />
+          <div className="skeleton skeleton--text" />
+          <div className="skeleton skeleton--text" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/docs/contracts/PR_DASH_P2_02_DASHBOARD_LAYOUT_BLOCKS.md
+++ b/docs/contracts/PR_DASH_P2_02_DASHBOARD_LAYOUT_BLOCKS.md
@@ -1,0 +1,48 @@
+# DASH-P2-PR2: Dashboard Section Composition and Loading States
+
+## Scope
+
+- `admin-app/app/admin/dashboard/page.tsx`
+- `admin-app/components/admin/dashboard/DashboardSectionPrimitives.tsx`
+- `admin-app/app/globals.css`
+
+## What Changed
+
+- Reframed the admin dashboard into stable layout blocks:
+  - hero overview
+  - KPI/widget section
+  - pipeline insights section
+  - recent inquiries table section
+  - warnings section
+- Added reusable dashboard primitives for:
+  - section shells
+  - section-level info/empty/error states
+  - metric, widget, insight, and table skeletons
+- Preserved the existing auth/session flow and backend summary contract while changing the composition surface.
+
+## Intended Runtime Behavior
+
+- Authenticated users always see the same section hierarchy, even while data is loading or unavailable.
+- Each major section owns its own placeholder state instead of collapsing the whole page into one generic message.
+- Loading surfaces reserve space for their eventual content to reduce layout jumpiness.
+
+## Regression Guards
+
+- `admin-app/__tests__/b14_admin_dashboard_page.test.ts`
+- `admin-app/__tests__/admin_dashboard_surface_styles.test.ts`
+- `admin-app/__tests__/admin_dashboard_layout_primitives.test.ts`
+
+## Acceptance Mapping
+
+- Layout stable with and without data:
+  - fixed dashboard shell columns
+  - section min-heights
+  - dedicated skeleton surfaces
+- Skeleton states match section hierarchy:
+  - overview metrics
+  - widget grid
+  - insight list
+  - table rows
+- Section-level empty/error states are visible and usable:
+  - retry actions available from each section
+  - idle/info states guide first refresh after sign-in


### PR DESCRIPTION
Closes #288

## Summary
This PR rebuilds the admin dashboard surface around stable section-level composition instead of one long page that swaps between generic whole-page states. The previous implementation could only show a single loading/error/empty block for the dashboard payload, which made the page jump significantly and left no reusable section scaffolding for the next widget-focused PRs.

The user-visible effect is a clearer dashboard hierarchy:
- hero overview summary
- KPI/widget section
- pipeline insights section
- recent inquiries table section
- warnings section

Each section now owns its loading, empty, and error presentation while preserving the existing auth/session flow and backend summary contract.

## Root Cause
Phase 1 established the shell and visual tokens, but the dashboard page itself was still a single functional surface. There was no reusable section primitive, no layout shell for main vs side content, and no skeleton system that matched the eventual hierarchy. That made it hard to iterate on widgets without causing repeated structural churn.

## Fix
- added reusable dashboard primitives for section wrappers, section states, and metric/widget/insight/table skeletons
- reorganized `app/admin/dashboard/page.tsx` into stable hero, KPI, insights, table, and warnings blocks
- surfaced freshness data in a dedicated insights section
- introduced section min-heights and responsive shell CSS to reduce layout jumpiness across loading/empty/success/error states
- documented the contract in `docs/contracts/PR_DASH_P2_02_DASHBOARD_LAYOUT_BLOCKS.md`
- added regression tests for the new primitives and updated dashboard contract/style assertions

## Validation
- `npm --prefix admin-app run test -- __tests__/b14_admin_dashboard_page.test.ts __tests__/admin_dashboard_surface_styles.test.ts __tests__/admin_dashboard_layout_primitives.test.ts __tests__/admin_shell_i18n.test.ts __tests__/admin_shell_navigation_behavior.test.ts __tests__/a_phase_admin_shell_routes.test.ts __tests__/b14_admin_workspaces_pages.test.ts __tests__/dashboard_state_utils.test.ts`
- `npm --prefix admin-app run build`

## Notes
Build still reports the existing unrelated `next/no-img-element` warnings in `components/media/RemoteImage.tsx` and `components/media/SafeCoverImage.tsx`.
