### PR TITLE
[codex] implement dashboard kpi widgets

### DIFF
--- a/admin-app/__tests__/admin_dashboard_kpi_widgets.test.ts
+++ b/admin-app/__tests__/admin_dashboard_kpi_widgets.test.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "..");
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf-8");
+}
+
+describe("admin dashboard kpi widgets", () => {
+  it("formats raw metric detail blocks and locale-safe action links", () => {
+    const component = read("components/admin/dashboard/DashboardKpiWidgets.tsx");
+
+    expect(component).toContain('from "@/app/_lib/admin-i18n"');
+    expect(component).toContain("withAdminLocale(action.url, locale)");
+    expect(component).toContain("project_cover_coverage");
+    expect(component).toContain("review_video_source_verification_pending");
+    expect(component).toContain("last_import_mirror_status");
+    expect(component).toContain("last_deploy_health_status");
+    expect(component).toContain("dashboard-kpi-pill-row");
+    expect(component).toContain("dashboard-kpi-detail-list");
+    expect(component).toContain("dashboard-kpi-card--");
+  });
+});

--- a/admin-app/__tests__/admin_dashboard_surface_styles.test.ts
+++ b/admin-app/__tests__/admin_dashboard_surface_styles.test.ts
@@ -39,6 +39,9 @@ describe("admin dashboard surface styles", () => {
     expect(css).toContain(".dashboard-summary-grid {");
     expect(css).toContain(".dashboard-insight-item {");
     expect(css).toContain(".dashboard-widget::before");
+    expect(css).toContain(".dashboard-kpi-card {");
+    expect(css).toContain(".dashboard-kpi-pill {");
+    expect(css).toContain(".dashboard-kpi-detail-list {");
     expect(css).toContain(".dashboard-table tbody tr:hover td");
     expect(css).toContain(".dashboard-table-skeleton {");
     expect(css).toContain(".dashboard-warning-list li");

--- a/admin-app/__tests__/b14_admin_dashboard_page.test.ts
+++ b/admin-app/__tests__/b14_admin_dashboard_page.test.ts
@@ -16,6 +16,7 @@ describe("B14 admin dashboard page contract", () => {
     expect(page).toContain('from "@/app/_lib/admin-auth"');
     expect(page).toContain('from "@/app/admin/dashboard/state-utils"');
     expect(page).toContain('from "@/components/admin/dashboard/DashboardSectionPrimitives"');
+    expect(page).toContain('from "@/components/admin/dashboard/DashboardKpiWidgets"');
     expect(page).toContain("loginAdmin");
     expect(page).toContain("transitionDashboardState");
     expect(page).not.toContain('fetch("/v1/auth/login"');
@@ -50,9 +51,11 @@ describe("B14 admin dashboard page contract", () => {
     expect(page).toContain('className="dashboard-section--insights"');
     expect(page).toContain('className="dashboard-section--warnings"');
     expect(page).toContain("DashboardMetricSkeletonRow");
+    expect(page).toContain("DashboardKpiWidgets");
     expect(page).toContain("DashboardWidgetSkeletonGrid");
     expect(page).toContain("DashboardInsightSkeletonList");
     expect(page).toContain("DashboardTableSkeleton");
+    expect(page).toContain("rawMetrics={summary?.raw_metrics}");
     expect(page).toContain("state-empty");
     expect(page).toContain("state-error");
     expect(page).toContain("dashboardState === \"loading\"");

--- a/admin-app/app/admin/dashboard/page.tsx
+++ b/admin-app/app/admin/dashboard/page.tsx
@@ -16,6 +16,7 @@ import {
   DashboardTableSkeleton,
   DashboardWidgetSkeletonGrid,
 } from "@/components/admin/dashboard/DashboardSectionPrimitives";
+import { DashboardKpiWidgets } from "@/components/admin/dashboard/DashboardKpiWidgets";
 
 type Locale = AdminLocale;
 type WidgetStatus = "ok" | "warn" | "error" | "unknown";
@@ -217,21 +218,6 @@ function prettyDate(value: string | null, locale: Locale): string {
   }).format(date);
 }
 
-function widgetValueToText(value: DashboardWidget["value"], fallback: string): string {
-  if (value === null || value === undefined) return fallback;
-  if (typeof value === "string") return value.trim() || fallback;
-  if (typeof value === "number") return Number.isFinite(value) ? String(value) : fallback;
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return fallback;
-  }
-}
-
-function statusClass(status: WidgetStatus): string {
-  return `dashboard-status dashboard-status-${status}`;
-}
-
 function humanizeMetricKey(key: string): string {
   return key
     .split("_")
@@ -427,31 +413,12 @@ export default function AdminDashboardPage() {
     }
 
     return (
-      <div className="dashboard-grid">
-        {widgets.map((widget) => (
-          <article key={widget.key} className="card dashboard-widget">
-            <header className="dashboard-widget-head">
-              <h3>{widget.title}</h3>
-              <span className={statusClass(widget.status)}>{widget.status}</span>
-            </header>
-            <p className="dashboard-widget-value">
-              {widgetValueToText(widget.value, t.unknownValue)}
-            </p>
-            <p className="locale-safe">{widget.summary}</p>
-            <div className="dashboard-widget-actions">
-              {(widget.actions || []).map((action, index) => (
-                <a
-                  key={`${widget.key}-${action.url}-${index}`}
-                  className="btn btn-secondary"
-                  href={action.url}
-                >
-                  {action.label}
-                </a>
-              ))}
-            </div>
-          </article>
-        ))}
-      </div>
+      <DashboardKpiWidgets
+        widgets={widgets}
+        rawMetrics={summary?.raw_metrics}
+        locale={locale}
+        fallback={t.unknownValue}
+      />
     );
   }
 

--- a/admin-app/app/globals.css
+++ b/admin-app/app/globals.css
@@ -4399,6 +4399,10 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+.dashboard-kpi-grid {
+  align-items: stretch;
+}
+
 .dashboard-grid--skeleton {
   align-items: stretch;
 }
@@ -4450,6 +4454,70 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   flex-wrap: wrap;
   gap: 8px;
   margin-top: auto;
+}
+
+.dashboard-kpi-card {
+  gap: 14px;
+}
+
+.dashboard-kpi-card--ok {
+  border-color: rgba(34, 197, 94, 0.18);
+}
+
+.dashboard-kpi-card--warn {
+  border-color: rgba(245, 158, 11, 0.24);
+}
+
+.dashboard-kpi-card--error {
+  border-color: rgba(239, 68, 68, 0.24);
+}
+
+.dashboard-kpi-card--unknown {
+  border-color: rgba(148, 163, 184, 0.24);
+}
+
+.dashboard-kpi-value-block {
+  display: grid;
+  gap: 6px;
+}
+
+.dashboard-kpi-secondary {
+  margin: 0;
+  color: var(--admin-ink-muted, var(--color-gray-700));
+  font-size: var(--font-sm);
+}
+
+.dashboard-kpi-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.dashboard-kpi-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 6px 10px;
+  border: 1px solid var(--admin-border-soft, var(--color-gray-200));
+  border-radius: 999px;
+  background: rgba(238, 244, 245, 0.84);
+  color: var(--admin-accent-contrast, var(--color-gray-900));
+  font-size: var(--font-xs);
+  font-weight: 600;
+}
+
+.dashboard-kpi-detail-list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--admin-ink-muted, var(--color-gray-700));
+  font-size: var(--font-sm);
+}
+
+.dashboard-kpi-detail-list li {
+  margin: 0;
 }
 
 .dashboard-insight-list {

--- a/admin-app/components/admin/dashboard/DashboardKpiWidgets.tsx
+++ b/admin-app/components/admin/dashboard/DashboardKpiWidgets.tsx
@@ -1,0 +1,448 @@
+import Link from "next/link";
+
+import { type AdminLocale, withAdminLocale } from "@/app/_lib/admin-i18n";
+
+type WidgetStatus = "ok" | "warn" | "error" | "unknown";
+
+type DashboardAction = {
+  label: string;
+  url: string;
+};
+
+type DashboardWidget = {
+  key: string;
+  title: string;
+  value: string | number | Record<string, unknown> | null;
+  status: WidgetStatus;
+  summary: string;
+  actions: DashboardAction[];
+};
+
+type DashboardRawMetrics = {
+  project_cover_coverage?: {
+    checked_at?: string | null;
+    projects_total?: number | null;
+    projects_real_cover_count?: number | null;
+    projects_real_cover_pct?: number | null;
+    projects_external_cover_count?: number | null;
+    projects_missing_cover_count?: number | null;
+  };
+  media_integrity?: {
+    scanned_at?: string | null;
+    broken_media_count?: number | null;
+    external_image_leakage_count?: number | null;
+    error_count?: number | null;
+    warn_count?: number | null;
+  };
+  pending_translations?: {
+    total_pending_translations?: number | null;
+    policy?: {
+      approved?: boolean | null;
+      checked_at?: string | null;
+    };
+    areas_missing_en_th?: number | null;
+    developers_missing_en_th?: number | null;
+    projects_missing_en_th?: number | null;
+    articles_missing_en_th?: number | null;
+    home_composer_missing_locale_pairs?: number | null;
+  };
+  unpublished_drafts?: {
+    total_unpublished_drafts?: number | null;
+    projects_draft?: number | null;
+    areas_draft?: number | null;
+    articles_draft?: number | null;
+    testimonials_draft?: number | null;
+    home_composer_draft?: number | null;
+    marketplace_items_draft?: number | null;
+  };
+  recent_inquiries?: {
+    count?: number | null;
+    latest_at?: string | null;
+  };
+  review_video_source_verification_pending?: {
+    total_pending?: number | null;
+    reviews_pending?: number | null;
+    videos_pending?: number | null;
+  };
+  last_import_status?: {
+    status?: string | null;
+    checked_at?: string | null;
+    rows_total?: number | null;
+    rows_errors?: number | null;
+    filename?: string | null;
+  };
+  last_mirror_status?: {
+    status?: string | null;
+    checked_at?: string | null;
+    failures_count?: number | null;
+  };
+  last_deploy_health_status?: {
+    health_status?: string | null;
+    health_checked_at?: string | null;
+    deploy_status?: string | null;
+    deploy_checked_at?: string | null;
+    source?: string | null;
+    build_sha?: string | null;
+  };
+};
+
+type WidgetPresentation = {
+  primaryValue: string;
+  secondaryValue?: string;
+  pills?: string[];
+  details?: string[];
+};
+
+const copy = {
+  en: {
+    covered: "Covered",
+    broken: "Broken",
+    missing: "Missing",
+    external: "External",
+    scanned: "Scanned",
+    reviews: "Reviews",
+    videos: "Videos",
+    policy: "Policy",
+    entities: "Entities",
+    drafts: "Drafts",
+    warnings: "Warnings",
+    latest: "Latest",
+    import: "Import",
+    mirror: "Mirror",
+    health: "Health",
+    deploy: "Deploy",
+    rows: "Rows",
+    errors: "Errors",
+    failures: "Failures",
+    build: "Build",
+    source: "Source",
+    approved: "Approved",
+    draft: "Draft",
+    healthy: "Healthy",
+    attention: "Attention",
+    unknown: "Unknown",
+  },
+  th: {
+    covered: "มี cover",
+    broken: "Broken",
+    missing: "ขาด cover",
+    external: "external",
+    scanned: "สแกนล่าสุด",
+    reviews: "Reviews",
+    videos: "วิดีโอ",
+    policy: "policy",
+    entities: "entities",
+    drafts: "drafts",
+    warnings: "warnings",
+    latest: "ล่าสุด",
+    import: "Import",
+    mirror: "Mirror",
+    health: "Health",
+    deploy: "Deploy",
+    rows: "แถว",
+    errors: "errors",
+    failures: "failures",
+    build: "Build",
+    source: "Source",
+    approved: "อนุมัติแล้ว",
+    draft: "draft",
+    healthy: "ปกติ",
+    attention: "ต้องตรวจ",
+    unknown: "ไม่ทราบ",
+  },
+} as const;
+
+function prettyDate(value: string | null | undefined, locale: AdminLocale): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(locale === "th" ? "th-TH" : "en-US", {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function formatCount(value: number | null | undefined, locale: AdminLocale, fallback: string): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return new Intl.NumberFormat(locale === "th" ? "th-TH" : "en-US").format(value);
+}
+
+function formatPercent(value: number | null | undefined, locale: AdminLocale, fallback: string): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  const rounded = value % 1 === 0 ? value.toFixed(0) : value.toFixed(2);
+  return `${new Intl.NumberFormat(locale === "th" ? "th-TH" : "en-US").format(Number(rounded))}%`;
+}
+
+function formatTextValue(value: DashboardWidget["value"], fallback: string): string {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === "number") return Number.isFinite(value) ? String(value) : fallback;
+  if (typeof value === "string") return value.trim() || fallback;
+  return fallback;
+}
+
+function statusClass(status: WidgetStatus): string {
+  return `dashboard-status dashboard-status-${status}`;
+}
+
+function formatStatusWord(
+  value: string | null | undefined,
+  locale: AdminLocale,
+  fallback: string,
+): string {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return fallback;
+  if (normalized === "ok") return locale === "th" ? "OK" : "OK";
+  if (normalized === "failed") return locale === "th" ? "FAILED" : "FAILED";
+  if (normalized === "partial") return locale === "th" ? "PARTIAL" : "PARTIAL";
+  if (normalized === "unknown") return fallback;
+  return normalized.toUpperCase();
+}
+
+function compactBuildSha(value: string | null | undefined): string | null {
+  const text = String(value || "").trim();
+  if (!text) return null;
+  return text.slice(0, 7);
+}
+
+function createPresentation(
+  widget: DashboardWidget,
+  rawMetrics: DashboardRawMetrics,
+  locale: AdminLocale,
+  fallback: string,
+): WidgetPresentation {
+  const ui = copy[locale];
+
+  if (widget.key === "project_cover_coverage") {
+    const metric = rawMetrics.project_cover_coverage;
+    return {
+      primaryValue: formatPercent(
+        typeof widget.value === "number" ? widget.value : metric?.projects_real_cover_pct,
+        locale,
+        fallback,
+      ),
+      secondaryValue:
+        metric && typeof metric.projects_total === "number"
+          ? `${ui.covered} ${formatCount(metric.projects_real_cover_count, locale, fallback)} / ${formatCount(metric.projects_total, locale, fallback)}`
+          : undefined,
+      details: [
+        `${ui.missing}: ${formatCount(metric?.projects_missing_cover_count, locale, fallback)}`,
+        `${ui.external}: ${formatCount(metric?.projects_external_cover_count, locale, fallback)}`,
+      ],
+    };
+  }
+
+  if (widget.key === "broken_media_count") {
+    const metric = rawMetrics.media_integrity;
+    return {
+      primaryValue: formatCount(
+        typeof widget.value === "number" ? widget.value : metric?.broken_media_count,
+        locale,
+        fallback,
+      ),
+      details: [
+        `${ui.errors}: ${formatCount(metric?.error_count, locale, fallback)}`,
+        `${ui.warnings}: ${formatCount(metric?.warn_count, locale, fallback)}`,
+        `${ui.scanned}: ${prettyDate(metric?.scanned_at, locale) || fallback}`,
+      ],
+    };
+  }
+
+  if (widget.key === "external_image_leakage_count") {
+    const metric = rawMetrics.media_integrity;
+    return {
+      primaryValue: formatCount(
+        typeof widget.value === "number" ? widget.value : metric?.external_image_leakage_count,
+        locale,
+        fallback,
+      ),
+      details: [
+        `${ui.broken}: ${formatCount(metric?.broken_media_count, locale, fallback)}`,
+        `${ui.scanned}: ${prettyDate(metric?.scanned_at, locale) || fallback}`,
+      ],
+    };
+  }
+
+  if (widget.key === "pending_translations_count") {
+    const metric = rawMetrics.pending_translations;
+    return {
+      primaryValue: formatCount(
+        typeof widget.value === "number" ? widget.value : metric?.total_pending_translations,
+        locale,
+        fallback,
+      ),
+      secondaryValue:
+        metric?.policy?.approved === true
+          ? ui.approved
+          : ui.draft,
+      details: [
+        `${ui.entities}: ${formatCount(metric?.projects_missing_en_th, locale, fallback)} projects / ${formatCount(metric?.articles_missing_en_th, locale, fallback)} articles`,
+        `Home composer: ${formatCount(metric?.home_composer_missing_locale_pairs, locale, fallback)}`,
+      ],
+    };
+  }
+
+  if (widget.key === "unpublished_drafts_count") {
+    const metric = rawMetrics.unpublished_drafts;
+    return {
+      primaryValue: formatCount(
+        typeof widget.value === "number" ? widget.value : metric?.total_unpublished_drafts,
+        locale,
+        fallback,
+      ),
+      details: [
+        `Projects: ${formatCount(metric?.projects_draft, locale, fallback)}`,
+        `Articles: ${formatCount(metric?.articles_draft, locale, fallback)}`,
+        `Home composer: ${formatCount(metric?.home_composer_draft, locale, fallback)}`,
+      ],
+    };
+  }
+
+  if (widget.key === "recent_leads_inquiries") {
+    const metric = rawMetrics.recent_inquiries;
+    return {
+      primaryValue: formatCount(
+        typeof widget.value === "number" ? widget.value : metric?.count,
+        locale,
+        fallback,
+      ),
+      details: [`${ui.latest}: ${prettyDate(metric?.latest_at, locale) || fallback}`],
+    };
+  }
+
+  if (widget.key === "review_video_source_verification_pending") {
+    const metric = rawMetrics.review_video_source_verification_pending;
+    return {
+      primaryValue: formatCount(
+        typeof widget.value === "number" ? widget.value : metric?.total_pending,
+        locale,
+        fallback,
+      ),
+      pills: [
+        `${ui.reviews}: ${formatCount(metric?.reviews_pending, locale, fallback)}`,
+        `${ui.videos}: ${formatCount(metric?.videos_pending, locale, fallback)}`,
+      ],
+    };
+  }
+
+  if (widget.key === "last_import_mirror_status") {
+    const importMetric = rawMetrics.last_import_status;
+    const mirrorMetric = rawMetrics.last_mirror_status;
+    const overall =
+      widget.status === "ok"
+        ? ui.healthy
+        : widget.status === "unknown"
+          ? ui.unknown
+          : ui.attention;
+    return {
+      primaryValue: overall,
+      pills: [
+        `${ui.import}: ${formatStatusWord(importMetric?.status, locale, fallback)}`,
+        `${ui.mirror}: ${formatStatusWord(mirrorMetric?.status, locale, fallback)}`,
+      ],
+      details: [
+        `${ui.rows}: ${formatCount(importMetric?.rows_total, locale, fallback)}`,
+        `${ui.errors}: ${formatCount(importMetric?.rows_errors, locale, fallback)}`,
+        `${ui.failures}: ${formatCount(mirrorMetric?.failures_count, locale, fallback)}`,
+      ],
+    };
+  }
+
+  if (widget.key === "last_deploy_health_status") {
+    const metric = rawMetrics.last_deploy_health_status;
+    const overall =
+      widget.status === "ok"
+        ? ui.healthy
+        : widget.status === "unknown"
+          ? ui.unknown
+          : ui.attention;
+    return {
+      primaryValue: overall,
+      pills: [
+        `${ui.health}: ${formatStatusWord(metric?.health_status, locale, fallback)}`,
+        `${ui.deploy}: ${formatStatusWord(metric?.deploy_status, locale, fallback)}`,
+      ],
+      details: [
+        `${ui.build}: ${compactBuildSha(metric?.build_sha) || fallback}`,
+        `${ui.source}: ${String(metric?.source || fallback)}`,
+      ],
+    };
+  }
+
+  return {
+    primaryValue: formatTextValue(widget.value, fallback),
+  };
+}
+
+export function DashboardKpiWidgets({
+  widgets,
+  rawMetrics,
+  locale,
+  fallback,
+}: {
+  widgets: DashboardWidget[];
+  rawMetrics?: Record<string, unknown> | null;
+  locale: AdminLocale;
+  fallback: string;
+}) {
+  const metricMap = (rawMetrics || {}) as DashboardRawMetrics;
+
+  return (
+    <div className="dashboard-grid dashboard-kpi-grid">
+      {widgets.map((widget) => {
+        const presentation = createPresentation(widget, metricMap, locale, fallback);
+        return (
+          <article
+            key={widget.key}
+            className={`card dashboard-widget dashboard-kpi-card dashboard-kpi-card--${widget.status}`}
+          >
+            <header className="dashboard-widget-head">
+              <h3>{widget.title}</h3>
+              <span className={statusClass(widget.status)}>{widget.status}</span>
+            </header>
+
+            <div className="dashboard-kpi-value-block">
+              <p className="dashboard-widget-value">{presentation.primaryValue}</p>
+              {presentation.secondaryValue ? (
+                <p className="dashboard-kpi-secondary">{presentation.secondaryValue}</p>
+              ) : null}
+            </div>
+
+            {(presentation.pills || []).length > 0 ? (
+              <div className="dashboard-kpi-pill-row">
+                {(presentation.pills || []).map((item) => (
+                  <span key={`${widget.key}-${item}`} className="dashboard-kpi-pill">
+                    {item}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+
+            {(presentation.details || []).length > 0 ? (
+              <ul className="dashboard-kpi-detail-list">
+                {(presentation.details || []).map((item) => (
+                  <li key={`${widget.key}-${item}`}>{item}</li>
+                ))}
+              </ul>
+            ) : null}
+
+            <p className="locale-safe">{widget.summary}</p>
+
+            <div className="dashboard-widget-actions">
+              {(widget.actions || []).map((action, index) => (
+                <Link
+                  key={`${widget.key}-${action.url}-${index}`}
+                  className="btn btn-secondary"
+                  href={withAdminLocale(action.url, locale)}
+                >
+                  {action.label}
+                </Link>
+              ))}
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/docs/contracts/PR_DASH_P3_01_KPI_WIDGETS.md
+++ b/docs/contracts/PR_DASH_P3_01_KPI_WIDGETS.md
@@ -1,0 +1,40 @@
+# DASH-P3-PR1: KPI Widgets on Existing Health-Summary Data
+
+## Scope
+
+- `admin-app/app/admin/dashboard/page.tsx`
+- `admin-app/components/admin/dashboard/DashboardKpiWidgets.tsx`
+- `admin-app/app/globals.css`
+
+## What Changed
+
+- Replaced the raw widget success renderer with a dedicated KPI widget component.
+- Kept the existing dashboard state handling from Phase 2:
+  - loading
+  - idle/info
+  - empty
+  - error
+- Added per-key formatting based on existing `raw_metrics` data, without changing the API contract.
+- Kept widget action links functional and locale-safe through `withAdminLocale(...)`.
+
+## Formatting Coverage
+
+- `project_cover_coverage`: percentage plus covered/missing/external detail lines
+- `broken_media_count` and `external_image_leakage_count`: localized counts plus scan context
+- `pending_translations_count`: total count plus policy/entity context
+- `unpublished_drafts_count`: total count plus draft breakdown
+- `recent_leads_inquiries`: count plus latest activity timestamp
+- `review_video_source_verification_pending`: split review/video pending pills
+- `last_import_mirror_status`: import/mirror pills plus rows/errors/failures detail
+- `last_deploy_health_status`: health/deploy pills plus build/source detail
+
+## Acceptance Mapping
+
+- KPI area reflects live backend values correctly:
+  - success renderer consumes `widgets` and `raw_metrics` from `/api/admin/dashboard/health-summary`
+- Widget actions remain functional:
+  - action URLs are still driven by backend payload
+  - links are locale-safe in the admin app
+- No API contract changes required:
+  - no new backend fields introduced
+  - existing widget keys and `raw_metrics` shape are reused


### PR DESCRIPTION
Closes #289

## Summary
This PR upgrades the redesigned dashboard KPI area from raw widget cards to data-aware KPI widgets built entirely on top of the existing `/api/admin/dashboard/health-summary` payload. The previous success state only rendered the widget `value` directly, which worked for plain counts but degraded badly for mixed payloads like import/mirror status pairs, deploy telemetry state, and review/video verification metrics.

The user-visible effect is a KPI grid that is easier to scan and materially more useful without any backend contract change:
- locale-safe action links
- per-key value formatting
- secondary context lines for raw metrics
- status-aware pills for paired operational states

## Root Cause
Phase 2 established the page structure, but the widget surface still treated every backend value the same. That meant object values had to collapse into generic text and action links did not preserve the current admin locale. The backend was already returning enough raw metric context to present better KPIs; the frontend just was not using it.

## Fix
- added `DashboardKpiWidgets` to render KPI success cards from `widgets + raw_metrics`
- formatted key metrics differently based on widget key while preserving the existing backend contract
- surfaced secondary details for coverage, translations, drafts, recent inquiries, review/video pending, import/mirror, and deploy/health widgets
- switched KPI action links to `withAdminLocale(...)` so they stay functional inside localized admin routes
- documented the KPI contract in `docs/contracts/PR_DASH_P3_01_KPI_WIDGETS.md`
- added regression tests for the KPI component and updated dashboard/style contract tests

## Validation
- `npm --prefix admin-app run test -- __tests__/b14_admin_dashboard_page.test.ts __tests__/admin_dashboard_surface_styles.test.ts __tests__/admin_dashboard_layout_primitives.test.ts __tests__/admin_dashboard_kpi_widgets.test.ts __tests__/b14_admin_workspaces_pages.test.ts`
- `npm --prefix admin-app run build`

## Notes
Build still reports the existing unrelated `next/no-img-element` warnings in `components/media/RemoteImage.tsx` and `components/media/SafeCoverImage.tsx`.
