### PR TITLE
[codex] add dashboard trend chart

### DIFF
--- a/admin-app/__tests__/admin_dashboard_surface_styles.test.ts
+++ b/admin-app/__tests__/admin_dashboard_surface_styles.test.ts
@@ -42,6 +42,9 @@ describe("admin dashboard surface styles", () => {
     expect(css).toContain(".dashboard-kpi-card {");
     expect(css).toContain(".dashboard-kpi-pill {");
     expect(css).toContain(".dashboard-kpi-detail-list {");
+    expect(css).toContain(".dashboard-period-toggle {");
+    expect(css).toContain(".dashboard-chart {");
+    expect(css).toContain(".dashboard-chart-line {");
     expect(css).toContain(".dashboard-table tbody tr:hover td");
     expect(css).toContain(".dashboard-table-skeleton {");
     expect(css).toContain(".dashboard-warning-list li");

--- a/admin-app/__tests__/admin_dashboard_trend_chart.test.ts
+++ b/admin-app/__tests__/admin_dashboard_trend_chart.test.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "..");
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf-8");
+}
+
+describe("admin dashboard trend chart component", () => {
+  it("defines chart surface and skeleton exports", () => {
+    const component = read("components/admin/dashboard/DashboardTrendChart.tsx");
+
+    expect(component).toContain("export function DashboardTrendChart(");
+    expect(component).toContain("export function DashboardTrendChartSkeleton()");
+    expect(component).toContain("dashboard-chart-svg");
+    expect(component).toContain("dashboard-chart-line");
+    expect(component).toContain("dashboard-chart-dot");
+    expect(component).toContain("dashboard-chart-axis");
+  });
+});

--- a/admin-app/__tests__/admin_dashboard_trend_utils.test.ts
+++ b/admin-app/__tests__/admin_dashboard_trend_utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildInquiryTrendPoints,
+  hasTrendData,
+  summarizeTrend,
+} from "@/components/admin/dashboard/trend-utils";
+
+describe("admin dashboard trend utils", () => {
+  it("builds 7d points ending at the generated day", () => {
+    const points = buildInquiryTrendPoints(
+      [
+        { created_at: "2026-03-08T09:00:00Z" },
+        { created_at: "2026-03-08T10:00:00Z" },
+        { created_at: "2026-03-06T12:00:00Z" },
+      ],
+      "2026-03-08T12:00:00Z",
+      "7d",
+      "en",
+    );
+
+    expect(points).toHaveLength(7);
+    expect(points[6]?.key).toBe("2026-03-08");
+    expect(points[6]?.value).toBe(2);
+    expect(points[4]?.key).toBe("2026-03-06");
+    expect(points[4]?.value).toBe(1);
+    expect(hasTrendData(points)).toBe(true);
+  });
+
+  it("builds 30d windows and summarizes totals", () => {
+    const points = buildInquiryTrendPoints(
+      [{ created_at: "2026-02-15T12:00:00Z" }],
+      "2026-03-08T12:00:00Z",
+      "30d",
+      "en",
+    );
+
+    expect(points).toHaveLength(30);
+    expect(hasTrendData(points)).toBe(true);
+    expect(summarizeTrend(points)).toEqual({
+      total: 1,
+      peak: 1,
+      activeDays: 1,
+    });
+  });
+
+  it("reports no data when every bucket is empty", () => {
+    const points = buildInquiryTrendPoints([], "2026-03-08T12:00:00Z", "7d", "en");
+
+    expect(hasTrendData(points)).toBe(false);
+    expect(summarizeTrend(points)).toEqual({
+      total: 0,
+      peak: 0,
+      activeDays: 0,
+    });
+  });
+});

--- a/admin-app/__tests__/b14_admin_dashboard_page.test.ts
+++ b/admin-app/__tests__/b14_admin_dashboard_page.test.ts
@@ -17,6 +17,8 @@ describe("B14 admin dashboard page contract", () => {
     expect(page).toContain('from "@/app/admin/dashboard/state-utils"');
     expect(page).toContain('from "@/components/admin/dashboard/DashboardSectionPrimitives"');
     expect(page).toContain('from "@/components/admin/dashboard/DashboardKpiWidgets"');
+    expect(page).toContain('from "@/components/admin/dashboard/DashboardTrendChart"');
+    expect(page).toContain('from "@/components/admin/dashboard/trend-utils"');
     expect(page).toContain("loginAdmin");
     expect(page).toContain("transitionDashboardState");
     expect(page).not.toContain('fetch("/v1/auth/login"');
@@ -52,10 +54,14 @@ describe("B14 admin dashboard page contract", () => {
     expect(page).toContain('className="dashboard-section--warnings"');
     expect(page).toContain("DashboardMetricSkeletonRow");
     expect(page).toContain("DashboardKpiWidgets");
+    expect(page).toContain("DashboardTrendChart");
+    expect(page).toContain("DashboardTrendChartSkeleton");
     expect(page).toContain("DashboardWidgetSkeletonGrid");
     expect(page).toContain("DashboardInsightSkeletonList");
     expect(page).toContain("DashboardTableSkeleton");
     expect(page).toContain("rawMetrics={summary?.raw_metrics}");
+    expect(page).toContain("buildInquiryTrendPoints");
+    expect(page).toContain("hasTrendData");
     expect(page).toContain("state-empty");
     expect(page).toContain("state-error");
     expect(page).toContain("dashboardState === \"loading\"");
@@ -66,6 +72,8 @@ describe("B14 admin dashboard page contract", () => {
     expect(page).toContain("retry: \"ลองใหม่\"");
     expect(page).toContain('title: "Admin Health / QA Dashboard"');
     expect(page).toContain('subtitle: "หน้าเดียวสำหรับดูความสมบูรณ์ของระบบและลิงก์แก้ปัญหาแบบ actionable"');
+    expect(page).toContain('trendTitle: "Lead activity trend"');
+    expect(page).toContain('trendTitle: "แนวโน้ม activity ของลีด"');
     expect(page).toContain('insightsTitle: "Pipeline insights"');
     expect(page).toContain('insightsTitle: "ข้อมูล pipeline"');
   });

--- a/admin-app/app/admin/dashboard/page.tsx
+++ b/admin-app/app/admin/dashboard/page.tsx
@@ -17,6 +17,15 @@ import {
   DashboardWidgetSkeletonGrid,
 } from "@/components/admin/dashboard/DashboardSectionPrimitives";
 import { DashboardKpiWidgets } from "@/components/admin/dashboard/DashboardKpiWidgets";
+import {
+  DashboardTrendChart,
+  DashboardTrendChartSkeleton,
+} from "@/components/admin/dashboard/DashboardTrendChart";
+import {
+  buildInquiryTrendPoints,
+  hasTrendData,
+  type TrendPeriod,
+} from "@/components/admin/dashboard/trend-utils";
 
 type Locale = AdminLocale;
 type WidgetStatus = "ok" | "warn" | "error" | "unknown";
@@ -109,6 +118,12 @@ const copy = {
     widgetsHint: "Priority QA checks across content, media, translations, and deploy health.",
     widgetsEmptyTitle: "No widgets returned",
     widgetsEmptyBody: "Backend summary returned no health widgets for this snapshot.",
+    trendTitle: "Lead activity trend",
+    trendHint: "Daily inquiry buckets from the existing dashboard rows.",
+    trendEmptyTitle: "No activity in this window",
+    trendEmptyBody: "Switch periods or wait for fresh inquiry rows to populate this trend.",
+    trendPeriod7d: "7D",
+    trendPeriod30d: "30D",
     insightsTitle: "Pipeline insights",
     insightsHint: "Freshness timestamps from upstream summary sources.",
     insightsEmptyTitle: "No freshness insights",
@@ -171,6 +186,12 @@ const copy = {
     widgetsHint: "QA checks หลักของ content, media, translations และ deploy",
     widgetsEmptyTitle: "ยังไม่มีวิดเจ็ต",
     widgetsEmptyBody: "backend summary ยังไม่ส่ง health widget มาในรอบนี้",
+    trendTitle: "แนวโน้ม activity ของลีด",
+    trendHint: "bucket รายวันจาก inquiry rows ที่มีอยู่แล้วในแดชบอร์ด",
+    trendEmptyTitle: "ช่วงเวลานี้ยังไม่มี activity",
+    trendEmptyBody: "ลองสลับช่วงเวลา หรือรอ inquiry ใหม่เข้ามาในหน้าต่างนี้",
+    trendPeriod7d: "7D",
+    trendPeriod30d: "30D",
     insightsTitle: "ข้อมูล pipeline",
     insightsHint: "เวลาอัปเดตล่าสุดจาก upstream summary sources",
     insightsEmptyTitle: "ยังไม่มี freshness insight",
@@ -265,6 +286,7 @@ export default function AdminDashboardPage() {
   const [pageError, setPageError] = useState<string | null>(null);
   const [summary, setSummary] = useState<DashboardSummaryResponse | null>(null);
   const [dashboardState, setDashboardState] = useState<DashboardState>("idle");
+  const [chartPeriod, setChartPeriod] = useState<TrendPeriod>("7d");
 
   useEffect(() => {
     setLocale(detectLocale());
@@ -289,6 +311,16 @@ export default function AdminDashboardPage() {
       [string, FreshnessItem]
     >;
   }, [summary]);
+  const trendPoints = useMemo(
+    () =>
+      buildInquiryTrendPoints(
+        summary?.recent_inquiries || [],
+        summary?.generated_at || null,
+        chartPeriod,
+        locale,
+      ),
+    [chartPeriod, locale, summary],
+  );
   const overviewMetrics = useMemo(
     () => [
       {
@@ -381,6 +413,31 @@ export default function AdminDashboardPage() {
     );
   }
 
+  function renderTrendToggle() {
+    return (
+      <div className="dashboard-period-toggle" aria-label={t.trendTitle}>
+        <button
+          type="button"
+          className={chartPeriod === "7d" ? "dashboard-period-button is-active" : "dashboard-period-button"}
+          aria-pressed={chartPeriod === "7d"}
+          onClick={() => setChartPeriod("7d")}
+          disabled={loading}
+        >
+          {t.trendPeriod7d}
+        </button>
+        <button
+          type="button"
+          className={chartPeriod === "30d" ? "dashboard-period-button is-active" : "dashboard-period-button"}
+          aria-pressed={chartPeriod === "30d"}
+          onClick={() => setChartPeriod("30d")}
+          disabled={loading}
+        >
+          {t.trendPeriod30d}
+        </button>
+      </div>
+    );
+  }
+
   function renderWidgetsPanel() {
     if (dashboardState === "loading") {
       return <DashboardWidgetSkeletonGrid cards={6} />;
@@ -468,6 +525,39 @@ export default function AdminDashboardPage() {
         ))}
       </ul>
     );
+  }
+
+  function renderTrendPanel() {
+    if (dashboardState === "loading") {
+      return <DashboardTrendChartSkeleton />;
+    }
+
+    if (dashboardState === "error") {
+      return (
+        <DashboardSectionState
+          tone="error"
+          title={t.sectionErrorTitle}
+          body={pageError || `${t.loadError} ${t.loadErrorHint}`}
+          action={renderRefreshButton(t.retry)}
+        />
+      );
+    }
+
+    if (dashboardState === "idle") {
+      return <DashboardSectionState tone="info" title={t.sectionReadyTitle} body={t.sectionReadyBody} action={renderRefreshButton()} />;
+    }
+
+    if (!hasTrendData(trendPoints)) {
+      return (
+        <DashboardSectionState
+          tone="empty"
+          title={t.trendEmptyTitle}
+          body={t.trendEmptyBody}
+        />
+      );
+    }
+
+    return <DashboardTrendChart points={trendPoints} locale={locale} period={chartPeriod} />;
   }
 
   function renderWarningsPanel() {
@@ -713,6 +803,15 @@ export default function AdminDashboardPage() {
               className="dashboard-section--widgets"
             >
               {renderWidgetsPanel()}
+            </DashboardSection>
+
+            <DashboardSection
+              title={t.trendTitle}
+              subtitle={t.trendHint}
+              className="dashboard-section--chart"
+              actions={renderTrendToggle()}
+            >
+              {renderTrendPanel()}
             </DashboardSection>
 
             <DashboardSection

--- a/admin-app/app/globals.css
+++ b/admin-app/app/globals.css
@@ -4271,6 +4271,10 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   min-height: 360px;
 }
 
+.dashboard-section--chart {
+  min-height: 340px;
+}
+
 .dashboard-section--insights,
 .dashboard-section--warnings {
   min-height: 220px;
@@ -4518,6 +4522,118 @@ summary.mobile-nav__trigger::-webkit-details-marker {
 
 .dashboard-kpi-detail-list li {
   margin: 0;
+}
+
+.dashboard-period-toggle {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.dashboard-period-button {
+  min-height: 36px;
+  padding: 8px 12px;
+  border: 1px solid var(--admin-border-soft, var(--color-gray-200));
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--admin-ink-muted, var(--color-gray-700));
+  font-size: var(--font-xs);
+  font-weight: 600;
+}
+
+.dashboard-period-button.is-active {
+  border-color: var(--admin-accent-strong, #0f766e);
+  background: rgba(15, 118, 110, 0.1);
+  color: var(--admin-accent-contrast, var(--color-gray-900));
+}
+
+.dashboard-chart {
+  display: grid;
+  gap: 14px;
+}
+
+.dashboard-chart-stats {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dashboard-chart-stat {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  border: 1px solid var(--admin-border-soft, var(--color-gray-200));
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.dashboard-chart-stat span {
+  color: var(--admin-ink-muted, var(--color-gray-700));
+  font-size: var(--font-sm);
+}
+
+.dashboard-chart-stat strong {
+  color: var(--admin-ink-strong, var(--color-gray-900));
+  font-size: clamp(1.1rem, 1rem + 0.45vw, 1.5rem);
+  line-height: 1.15;
+}
+
+.dashboard-chart-surface {
+  padding: 12px 12px 8px;
+  border: 1px solid var(--admin-border-soft, var(--color-gray-200));
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(238, 244, 245, 0.82) 100%);
+}
+
+.dashboard-chart-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.dashboard-chart-grid {
+  stroke: rgba(148, 163, 184, 0.2);
+  stroke-width: 1;
+}
+
+.dashboard-chart-area {
+  fill: rgba(37, 99, 235, 0.12);
+}
+
+.dashboard-chart-line {
+  fill: none;
+  stroke: #2563eb;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.dashboard-chart-dot {
+  fill: #0f766e;
+  stroke: rgba(255, 255, 255, 0.94);
+  stroke-width: 2;
+}
+
+.dashboard-chart-dot.is-latest {
+  fill: #2563eb;
+}
+
+.dashboard-chart-axis {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
+  color: var(--admin-ink-muted, var(--color-gray-700));
+  font-size: var(--font-xs);
+}
+
+.dashboard-chart-axis span,
+.dashboard-chart-axis .skeleton {
+  justify-self: start;
+}
+
+.dashboard-chart-placeholder {
+  min-height: 160px;
 }
 
 .dashboard-insight-list {
@@ -5841,6 +5957,10 @@ summary.mobile-nav__trigger::-webkit-details-marker {
 }
 
 @media (max-width: 720px) {
+  .dashboard-chart-stats {
+    grid-template-columns: 1fr;
+  }
+
   .dashboard-insight-item {
     grid-template-columns: 1fr;
   }

--- a/admin-app/components/admin/dashboard/DashboardTrendChart.tsx
+++ b/admin-app/components/admin/dashboard/DashboardTrendChart.tsx
@@ -1,0 +1,147 @@
+import type { AdminLocale } from "@/app/_lib/admin-i18n";
+
+import {
+  summarizeTrend,
+  type TrendPeriod,
+  type TrendPoint,
+} from "@/components/admin/dashboard/trend-utils";
+
+const copy = {
+  en: {
+    total: "Total",
+    peak: "Peak day",
+    activeDays: "Active days",
+    ariaLabel: "Lead activity trend chart",
+  },
+  th: {
+    total: "รวม",
+    peak: "วันที่สูงสุด",
+    activeDays: "วันที่มี activity",
+    ariaLabel: "กราฟแนวโน้ม activity ของลีด",
+  },
+} as const;
+
+function formatCount(value: number, locale: AdminLocale): string {
+  return new Intl.NumberFormat(locale === "th" ? "th-TH" : "en-US").format(value);
+}
+
+function buildChartGeometry(points: TrendPoint[]) {
+  const width = 320;
+  const height = 180;
+  const left = 14;
+  const right = 14;
+  const top = 18;
+  const bottom = 140;
+  const usableWidth = width - left - right;
+  const usableHeight = bottom - top;
+  const maxValue = Math.max(...points.map((point) => point.value), 1);
+  const step = points.length > 1 ? usableWidth / (points.length - 1) : usableWidth;
+
+  const coordinates = points.map((point, index) => {
+    const x = left + step * index;
+    const y = bottom - (point.value / maxValue) * usableHeight;
+    return { ...point, x, y };
+  });
+
+  const linePoints = coordinates.map((point) => `${point.x},${point.y}`).join(" ");
+  const areaPath = coordinates.length
+    ? `M ${coordinates[0].x} ${bottom} L ${coordinates
+        .map((point) => `${point.x} ${point.y}`)
+        .join(" L ")} L ${coordinates[coordinates.length - 1].x} ${bottom} Z`
+    : "";
+
+  return { coordinates, linePoints, areaPath, width, height, top, bottom };
+}
+
+export function DashboardTrendChart({
+  points,
+  locale,
+  period,
+}: {
+  points: TrendPoint[];
+  locale: AdminLocale;
+  period: TrendPeriod;
+}) {
+  const ui = copy[locale];
+  const summary = summarizeTrend(points);
+  const geometry = buildChartGeometry(points);
+  const axisPoints =
+    period === "30d"
+      ? [points[0], points[9], points[19], points[29]].filter(Boolean)
+      : points;
+
+  return (
+    <div className="dashboard-chart">
+      <div className="dashboard-chart-stats">
+        <article className="dashboard-chart-stat">
+          <span>{ui.total}</span>
+          <strong>{formatCount(summary.total, locale)}</strong>
+        </article>
+        <article className="dashboard-chart-stat">
+          <span>{ui.peak}</span>
+          <strong>{formatCount(summary.peak, locale)}</strong>
+        </article>
+        <article className="dashboard-chart-stat">
+          <span>{ui.activeDays}</span>
+          <strong>{formatCount(summary.activeDays, locale)}</strong>
+        </article>
+      </div>
+
+      <div className="dashboard-chart-surface">
+        <svg
+          className="dashboard-chart-svg"
+          viewBox={`0 0 ${geometry.width} ${geometry.height}`}
+          role="img"
+          aria-label={ui.ariaLabel}
+        >
+          {[0, 1, 2, 3].map((step) => {
+            const y = geometry.top + ((geometry.bottom - geometry.top) / 3) * step;
+            return <line key={step} x1="12" y1={y} x2="308" y2={y} className="dashboard-chart-grid" />;
+          })}
+          <path d={geometry.areaPath} className="dashboard-chart-area" />
+          <polyline points={geometry.linePoints} className="dashboard-chart-line" />
+          {geometry.coordinates.map((point) => (
+            <circle
+              key={point.key}
+              cx={point.x}
+              cy={point.y}
+              r={point.isLatest ? 4.5 : 3.5}
+              className={point.isLatest ? "dashboard-chart-dot is-latest" : "dashboard-chart-dot"}
+            />
+          ))}
+        </svg>
+      </div>
+
+      <div className="dashboard-chart-axis" aria-hidden="true">
+        {axisPoints.map((point) => (
+          <span key={point.key}>{point.shortLabel}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function DashboardTrendChartSkeleton() {
+  return (
+    <div className="dashboard-chart dashboard-chart--skeleton" aria-hidden="true">
+      <div className="dashboard-chart-stats">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <article key={index} className="dashboard-chart-stat">
+            <div className="skeleton skeleton--text" />
+            <div className="skeleton skeleton--title" />
+          </article>
+        ))}
+      </div>
+      <div className="dashboard-chart-surface">
+        <div className="dashboard-chart-placeholder">
+          <div className="skeleton skeleton--image" />
+        </div>
+      </div>
+      <div className="dashboard-chart-axis">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="skeleton skeleton--text" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/admin-app/components/admin/dashboard/trend-utils.ts
+++ b/admin-app/components/admin/dashboard/trend-utils.ts
@@ -1,0 +1,95 @@
+import type { AdminLocale } from "@/app/_lib/admin-i18n";
+
+export type TrendPeriod = "7d" | "30d";
+
+export type TrendInquiryRow = {
+  created_at: string | null;
+};
+
+export type TrendPoint = {
+  key: string;
+  label: string;
+  shortLabel: string;
+  value: number;
+  isLatest: boolean;
+};
+
+function startOfUtcDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function formatBucketKey(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function parseDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+}
+
+export function buildInquiryTrendPoints(
+  rows: TrendInquiryRow[],
+  generatedAt: string | null,
+  period: TrendPeriod,
+  locale: AdminLocale,
+): TrendPoint[] {
+  const days = period === "30d" ? 30 : 7;
+  const endSource = parseDate(generatedAt) || new Date();
+  const endDate = startOfUtcDay(endSource);
+  const formatter = new Intl.DateTimeFormat(locale === "th" ? "th-TH" : "en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+  const shortFormatter = new Intl.DateTimeFormat(locale === "th" ? "th-TH" : "en-US", {
+    weekday: period === "30d" ? undefined : "short",
+    day: period === "30d" ? "numeric" : undefined,
+    timeZone: "UTC",
+  });
+
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const parsed = parseDate(row.created_at);
+    if (!parsed) continue;
+    const key = formatBucketKey(startOfUtcDay(parsed));
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+
+  return Array.from({ length: days }).map((_, index) => {
+    const date = new Date(endDate);
+    date.setUTCDate(endDate.getUTCDate() - (days - index - 1));
+    const key = formatBucketKey(date);
+    const value = counts.get(key) || 0;
+    return {
+      key,
+      label: formatter.format(date),
+      shortLabel: shortFormatter.format(date),
+      value,
+      isLatest: index === days - 1,
+    };
+  });
+}
+
+export function hasTrendData(points: TrendPoint[]): boolean {
+  return points.some((point) => point.value > 0);
+}
+
+export function summarizeTrend(points: TrendPoint[]): {
+  total: number;
+  peak: number;
+  activeDays: number;
+} {
+  return points.reduce(
+    (summary, point) => ({
+      total: summary.total + point.value,
+      peak: Math.max(summary.peak, point.value),
+      activeDays: summary.activeDays + (point.value > 0 ? 1 : 0),
+    }),
+    { total: 0, peak: 0, activeDays: 0 },
+  );
+}

--- a/docs/contracts/PR_DASH_P3_02_TREND_CHART.md
+++ b/docs/contracts/PR_DASH_P3_02_TREND_CHART.md
@@ -1,0 +1,48 @@
+# DASH-P3-PR2: Trend Chart Module with Period Toggle
+
+## Scope
+
+- `admin-app/app/admin/dashboard/page.tsx`
+- `admin-app/components/admin/dashboard/DashboardTrendChart.tsx`
+- `admin-app/components/admin/dashboard/trend-utils.ts`
+- `admin-app/app/globals.css`
+
+## What Changed
+
+- Added a dedicated dashboard chart section between KPI widgets and the recent inquiries table.
+- Implemented a lightweight SVG trend chart instead of introducing a charting dependency.
+- Added a period toggle for `7D` and `30D`.
+- Used existing `recent_inquiries.created_at` rows from `/api/admin/dashboard/health-summary` as the chart data source.
+
+## State Handling
+
+- `loading`: chart skeleton surface
+- `idle`: info state prompting first refresh
+- `error`: explicit section error card with retry
+- `no-data`: explicit empty state when the selected period has no activity buckets
+- `success`: rendered chart with summary stats and axis labels
+
+## Data Contract
+
+- No backend contract changes
+- Trend points are derived client-side from:
+  - `summary.generated_at`
+  - `summary.recent_inquiries[*].created_at`
+
+## Visual Notes
+
+- Chart uses:
+  - summary stats row
+  - SVG area + line + dots
+  - compact axis labels
+  - pill-style period toggle
+- The section remains responsive by collapsing stats vertically on narrow viewports
+
+## Acceptance Mapping
+
+- Chart panel renders across breakpoints:
+  - responsive stats row and SVG surface styles added
+- Period toggles update the displayed series/state reliably:
+  - bucket generation is handled by pure `trend-utils`
+- Error/empty states are explicit and non-breaking:
+  - chart section uses the same section-state patterns introduced in Phase 2


### PR DESCRIPTION
Closes #290

## Summary
This PR adds the Phase 3 chart module to the redesigned admin dashboard. Instead of introducing a new backend metric or a heavyweight chart dependency, the chart derives a real 7-day or 30-day activity series from the existing `recent_inquiries[*].created_at` values already returned by `/api/admin/dashboard/health-summary`.

The user-visible effect is a lightweight lead-activity trend section with:
- a `7D` / `30D` toggle
- explicit loading, idle, error, and no-data states
- responsive SVG rendering with summary stats

## Root Cause
After the KPI work, the dashboard still lacked any time-oriented visualization. The API already exposed enough existing data to derive a useful trend, but the UI had no client-side bucketing layer and no chart surface tied into the Phase 2 state patterns.

## Fix
- added pure `trend-utils` helpers to build daily buckets for `7d` and `30d`
- added a lightweight SVG chart component plus skeleton state
- inserted a new dashboard chart section between KPI widgets and the inquiries table
- added a pill-style period toggle wired to the chart data state
- documented the chart contract and visual notes in `docs/contracts/PR_DASH_P3_02_TREND_CHART.md`
- added regression tests for chart component wiring and trend bucketing logic

## Validation
- `npm --prefix admin-app run test -- __tests__/b14_admin_dashboard_page.test.ts __tests__/admin_dashboard_surface_styles.test.ts __tests__/admin_dashboard_trend_chart.test.ts __tests__/admin_dashboard_trend_utils.test.ts __tests__/admin_dashboard_kpi_widgets.test.ts __tests__/b14_admin_workspaces_pages.test.ts`
- `npm --prefix admin-app run build`

## Notes
Build still reports the existing unrelated `next/no-img-element` warnings in `components/media/RemoteImage.tsx` and `components/media/SafeCoverImage.tsx`.
