### PR TITLE
[codex] upgrade recent inquiries table

### DIFF
--- a/admin-app/__tests__/admin_dashboard_recent_inquiries_table.test.ts
+++ b/admin-app/__tests__/admin_dashboard_recent_inquiries_table.test.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "..");
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf-8");
+}
+
+describe("admin dashboard recent inquiries table", () => {
+  it("defines filter, sort, reset, and mobile card fallback behavior", () => {
+    const component = read("components/admin/dashboard/DashboardRecentInquiriesTable.tsx");
+
+    expect(component).toContain("const [query, setQuery] = useState(\"\")");
+    expect(component).toContain("const [statusFilter, setStatusFilter] = useState(\"all\")");
+    expect(component).toContain("const [sortKey, setSortKey] = useState<SortKey>(\"created_at\")");
+    expect(component).toContain("const [sortDirection, setSortDirection] = useState<SortDirection>(\"desc\")");
+    expect(component).toContain("dashboard-table-toolbar");
+    expect(component).toContain("dashboard-table-direction");
+    expect(component).toContain("dashboard-table-reset");
+    expect(component).toContain("dashboard-table-wrap--desktop");
+    expect(component).toContain("dashboard-table-card-list");
+    expect(component).toContain("dashboard-section-state dashboard-section-state--empty");
+  });
+});

--- a/admin-app/__tests__/admin_dashboard_surface_styles.test.ts
+++ b/admin-app/__tests__/admin_dashboard_surface_styles.test.ts
@@ -45,6 +45,10 @@ describe("admin dashboard surface styles", () => {
     expect(css).toContain(".dashboard-period-toggle {");
     expect(css).toContain(".dashboard-chart {");
     expect(css).toContain(".dashboard-chart-line {");
+    expect(css).toContain(".dashboard-table-shell {");
+    expect(css).toContain(".dashboard-table-toolbar {");
+    expect(css).toContain(".dashboard-table-chip {");
+    expect(css).toContain(".dashboard-table-card-list {");
     expect(css).toContain(".dashboard-table tbody tr:hover td");
     expect(css).toContain(".dashboard-table-skeleton {");
     expect(css).toContain(".dashboard-warning-list li");

--- a/admin-app/__tests__/b14_admin_dashboard_page.test.ts
+++ b/admin-app/__tests__/b14_admin_dashboard_page.test.ts
@@ -17,6 +17,7 @@ describe("B14 admin dashboard page contract", () => {
     expect(page).toContain('from "@/app/admin/dashboard/state-utils"');
     expect(page).toContain('from "@/components/admin/dashboard/DashboardSectionPrimitives"');
     expect(page).toContain('from "@/components/admin/dashboard/DashboardKpiWidgets"');
+    expect(page).toContain('from "@/components/admin/dashboard/DashboardRecentInquiriesTable"');
     expect(page).toContain('from "@/components/admin/dashboard/DashboardTrendChart"');
     expect(page).toContain('from "@/components/admin/dashboard/trend-utils"');
     expect(page).toContain("loginAdmin");
@@ -54,6 +55,7 @@ describe("B14 admin dashboard page contract", () => {
     expect(page).toContain('className="dashboard-section--warnings"');
     expect(page).toContain("DashboardMetricSkeletonRow");
     expect(page).toContain("DashboardKpiWidgets");
+    expect(page).toContain("DashboardRecentInquiriesTable");
     expect(page).toContain("DashboardTrendChart");
     expect(page).toContain("DashboardTrendChartSkeleton");
     expect(page).toContain("DashboardWidgetSkeletonGrid");

--- a/admin-app/app/admin/dashboard/page.tsx
+++ b/admin-app/app/admin/dashboard/page.tsx
@@ -17,6 +17,7 @@ import {
   DashboardWidgetSkeletonGrid,
 } from "@/components/admin/dashboard/DashboardSectionPrimitives";
 import { DashboardKpiWidgets } from "@/components/admin/dashboard/DashboardKpiWidgets";
+import { DashboardRecentInquiriesTable } from "@/components/admin/dashboard/DashboardRecentInquiriesTable";
 import {
   DashboardTrendChart,
   DashboardTrendChartSkeleton,
@@ -632,32 +633,7 @@ export default function AdminDashboardPage() {
     }
 
     return (
-      <div className="dashboard-table-wrap">
-        <table className="dashboard-table">
-          <thead>
-            <tr>
-              <th>{t.createdAt}</th>
-              <th>{t.name}</th>
-              <th>{t.contact}</th>
-              <th>{t.status}</th>
-              <th>{t.intent}</th>
-              <th>{t.sourcePage}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {(summary?.recent_inquiries || []).map((row) => (
-              <tr key={row.id}>
-                <td>{prettyDate(row.created_at, locale)}</td>
-                <td>{row.name}</td>
-                <td>{row.email || row.phone || "-"}</td>
-                <td>{row.status || "-"}</td>
-                <td>{row.intent || "-"}</td>
-                <td>{row.source_page || "-"}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <DashboardRecentInquiriesTable rows={summary?.recent_inquiries || []} locale={locale} />
     );
   }
 

--- a/admin-app/app/globals.css
+++ b/admin-app/app/globals.css
@@ -4741,6 +4741,98 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
 }
 
+.dashboard-table-shell {
+  display: grid;
+  gap: 14px;
+}
+
+.dashboard-table-toolbar {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(4, minmax(0, 1fr)) auto;
+  align-items: end;
+}
+
+.dashboard-table-toolbar-field {
+  min-width: 0;
+}
+
+.dashboard-table-direction,
+.dashboard-table-reset {
+  min-height: 42px;
+}
+
+.dashboard-table-summary {
+  margin: 0;
+  color: var(--admin-ink-muted, var(--color-gray-700));
+  font-size: var(--font-sm);
+}
+
+.dashboard-table-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 6px 10px;
+  border: 1px solid rgba(12, 74, 110, 0.14);
+  border-radius: 999px;
+  background: rgba(238, 244, 245, 0.95);
+  color: var(--admin-accent-strong, #0c4a6e);
+  font-size: var(--font-xs);
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.dashboard-table-card-list {
+  display: none;
+}
+
+.dashboard-table-card {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--admin-border-soft, var(--color-gray-200));
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(252, 249, 243, 0.96) 100%);
+  box-shadow: var(--admin-shadow-soft, 0 18px 42px rgba(148, 163, 184, 0.12));
+}
+
+.dashboard-table-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.dashboard-table-card-head p,
+.dashboard-table-card-meta span,
+.dashboard-table-card-meta strong {
+  margin: 0;
+}
+
+.dashboard-table-card-name {
+  margin: 0 0 4px;
+  color: var(--admin-ink-strong, var(--color-gray-900));
+  font-size: 1rem;
+}
+
+.dashboard-table-card-meta {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dashboard-table-card-meta div {
+  display: grid;
+  gap: 4px;
+}
+
+.dashboard-table-card-meta span {
+  color: var(--admin-ink-muted, var(--color-gray-700));
+  font-size: var(--font-xs);
+}
+
 .dashboard-table-skeleton {
   display: grid;
   gap: 10px;
@@ -5152,6 +5244,23 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   .dashboard-table,
   .seo-table {
     min-width: 620px;
+  }
+
+  .dashboard-table-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-table-wrap--desktop {
+    display: none;
+  }
+
+  .dashboard-table-card-list {
+    display: grid;
+    gap: 12px;
+  }
+
+  .dashboard-table-card-meta {
+    grid-template-columns: 1fr;
   }
 
   .dashboard-shell-grid {

--- a/admin-app/components/admin/dashboard/DashboardRecentInquiriesTable.tsx
+++ b/admin-app/components/admin/dashboard/DashboardRecentInquiriesTable.tsx
@@ -1,0 +1,268 @@
+import { useId, useMemo, useState } from "react";
+
+import type { AdminLocale } from "@/app/_lib/admin-i18n";
+
+type RecentInquiry = {
+  id: string;
+  created_at: string | null;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  status: string;
+  intent: string | null;
+  source_page: string | null;
+};
+
+type SortKey = "created_at" | "status" | "name";
+type SortDirection = "asc" | "desc";
+
+const copy = {
+  en: {
+    filter: "Filter inquiries",
+    status: "Status",
+    statusAll: "All statuses",
+    sortBy: "Sort by",
+    sortCreated: "Created at",
+    sortStatus: "Status",
+    sortName: "Name",
+    sortDirection: "Direction",
+    asc: "ASC",
+    desc: "DESC",
+    reset: "Reset",
+    results: "rows",
+    noMatchesTitle: "No matching inquiries",
+    noMatchesBody: "Adjust the search, status filter, or sort settings.",
+    sourcePage: "Source page",
+    contact: "Contact",
+    intent: "Intent",
+    createdAt: "Created at",
+    name: "Name",
+  },
+  th: {
+    filter: "กรอง inquiry",
+    status: "สถานะ",
+    statusAll: "ทุกสถานะ",
+    sortBy: "เรียงตาม",
+    sortCreated: "เวลาสร้าง",
+    sortStatus: "สถานะ",
+    sortName: "ชื่อ",
+    sortDirection: "ทิศทาง",
+    asc: "ASC",
+    desc: "DESC",
+    reset: "รีเซ็ต",
+    results: "แถว",
+    noMatchesTitle: "ไม่พบ inquiry ที่ตรงเงื่อนไข",
+    noMatchesBody: "ลองปรับคำค้นหา ตัวกรองสถานะ หรือรูปแบบการเรียง",
+    sourcePage: "หน้า source",
+    contact: "ช่องทางติดต่อ",
+    intent: "Intent",
+    createdAt: "เวลาสร้าง",
+    name: "ชื่อ",
+  },
+} as const;
+
+function prettyDate(value: string | null, locale: AdminLocale): string {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(locale === "th" ? "th-TH" : "en-US", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+export function DashboardRecentInquiriesTable({
+  rows,
+  locale,
+}: {
+  rows: RecentInquiry[];
+  locale: AdminLocale;
+}) {
+  const ui = copy[locale];
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [sortKey, setSortKey] = useState<SortKey>("created_at");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const filterId = useId();
+  const statusId = useId();
+  const sortId = useId();
+
+  const statusOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(rows.map((row) => String(row.status || "").trim()).filter(Boolean)),
+      ).sort((left, right) => left.localeCompare(right)),
+    [rows],
+  );
+
+  const filteredRows = useMemo(() => {
+    const normalizedQuery = normalizeText(query);
+    return rows.filter((row) => {
+      const matchesStatus =
+        statusFilter === "all" || normalizeText(row.status) === normalizeText(statusFilter);
+      if (!matchesStatus) return false;
+      if (!normalizedQuery) return true;
+      const haystack = [
+        row.name,
+        row.email,
+        row.phone,
+        row.status,
+        row.intent,
+        row.source_page,
+      ]
+        .map((value) => normalizeText(value))
+        .join(" ");
+      return haystack.includes(normalizedQuery);
+    });
+  }, [query, rows, statusFilter]);
+
+  const sortedRows = useMemo(() => {
+    const ordered = [...filteredRows];
+    ordered.sort((left, right) => {
+      const direction = sortDirection === "asc" ? 1 : -1;
+      if (sortKey === "created_at") {
+        const leftTime = left.created_at ? new Date(left.created_at).getTime() : 0;
+        const rightTime = right.created_at ? new Date(right.created_at).getTime() : 0;
+        return (leftTime - rightTime) * direction;
+      }
+      const leftValue = normalizeText(sortKey === "status" ? left.status : left.name);
+      const rightValue = normalizeText(sortKey === "status" ? right.status : right.name);
+      return leftValue.localeCompare(rightValue) * direction;
+    });
+    return ordered;
+  }, [filteredRows, sortDirection, sortKey]);
+
+  function resetControls() {
+    setQuery("");
+    setStatusFilter("all");
+    setSortKey("created_at");
+    setSortDirection("desc");
+  }
+
+  return (
+    <div className="dashboard-table-shell">
+      <div className="dashboard-table-toolbar">
+        <label className="field dashboard-table-toolbar-field" htmlFor={filterId}>
+          <span>{ui.filter}</span>
+          <input
+            id={filterId}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={ui.filter}
+          />
+        </label>
+
+        <label className="field dashboard-table-toolbar-field" htmlFor={statusId}>
+          <span>{ui.status}</span>
+          <select id={statusId} value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+            <option value="all">{ui.statusAll}</option>
+            {statusOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="field dashboard-table-toolbar-field" htmlFor={sortId}>
+          <span>{ui.sortBy}</span>
+          <select id={sortId} value={sortKey} onChange={(event) => setSortKey(event.target.value as SortKey)}>
+            <option value="created_at">{ui.sortCreated}</option>
+            <option value="status">{ui.sortStatus}</option>
+            <option value="name">{ui.sortName}</option>
+          </select>
+        </label>
+
+        <button
+          type="button"
+          className="btn btn-secondary dashboard-table-direction"
+          onClick={() => setSortDirection((current) => (current === "asc" ? "desc" : "asc"))}
+        >
+          {ui.sortDirection}: {sortDirection === "asc" ? ui.asc : ui.desc}
+        </button>
+
+        <button type="button" className="btn btn-secondary dashboard-table-reset" onClick={resetControls}>
+          {ui.reset}
+        </button>
+      </div>
+
+      <p className="dashboard-table-summary" aria-live="polite">
+        {sortedRows.length} / {rows.length} {ui.results}
+      </p>
+
+      {sortedRows.length === 0 ? (
+        <div className="dashboard-section-state dashboard-section-state--empty" role="status" aria-live="polite">
+          <h3>{ui.noMatchesTitle}</h3>
+          <p>{ui.noMatchesBody}</p>
+        </div>
+      ) : (
+        <>
+          <div className="dashboard-table-wrap dashboard-table-wrap--desktop">
+            <table className="dashboard-table">
+              <thead>
+                <tr>
+                  <th>{ui.createdAt}</th>
+                  <th>{ui.name}</th>
+                  <th>{ui.contact}</th>
+                  <th>{ui.status}</th>
+                  <th>{ui.intent}</th>
+                  <th>{ui.sourcePage}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedRows.map((row) => (
+                  <tr key={row.id}>
+                    <td>{prettyDate(row.created_at, locale)}</td>
+                    <td>{row.name}</td>
+                    <td>{row.email || row.phone || "-"}</td>
+                    <td>
+                      <span className="dashboard-table-chip">{row.status || "-"}</span>
+                    </td>
+                    <td>{row.intent || "-"}</td>
+                    <td>{row.source_page || "-"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="dashboard-table-card-list">
+            {sortedRows.map((row) => (
+              <article key={row.id} className="dashboard-table-card">
+                <div className="dashboard-table-card-head">
+                  <div>
+                    <h3 className="dashboard-table-card-name">{row.name}</h3>
+                    <p>{prettyDate(row.created_at, locale)}</p>
+                  </div>
+                  <span className="dashboard-table-chip">{row.status || "-"}</span>
+                </div>
+
+                <div className="dashboard-table-card-meta">
+                  <div>
+                    <span>{ui.contact}</span>
+                    <strong>{row.email || row.phone || "-"}</strong>
+                  </div>
+                  <div>
+                    <span>{ui.intent}</span>
+                    <strong>{row.intent || "-"}</strong>
+                  </div>
+                  <div>
+                    <span>{ui.sourcePage}</span>
+                    <strong>{row.source_page || "-"}</strong>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/docs/contracts/PR_DASH_P3_03_RECENT_INQUIRIES_TABLE.md
+++ b/docs/contracts/PR_DASH_P3_03_RECENT_INQUIRIES_TABLE.md
@@ -1,0 +1,45 @@
+# DASH-P3-PR3: Recent Inquiries Table Interactions and Mobile Fallback
+
+## Scope
+
+- `admin-app/app/admin/dashboard/page.tsx`
+- `admin-app/components/admin/dashboard/DashboardRecentInquiriesTable.tsx`
+- `admin-app/app/globals.css`
+
+## What Changed
+
+- Replaced the raw success-state table renderer with a dedicated recent inquiries table component.
+- Added client-side search, status filtering, sort key selection, and sort direction toggle.
+- Kept the existing inquiry fields and backend contract intact:
+  - `created_at`
+  - `name`
+  - `email`
+  - `phone`
+  - `status`
+  - `intent`
+  - `source_page`
+- Added a stacked card fallback for narrow screens instead of relying on horizontal table scrolling alone.
+
+## Interaction Notes
+
+- Search matches across the existing visible inquiry fields.
+- Status options are derived from the rows already returned by `/api/admin/dashboard/health-summary`.
+- Sorting supports:
+  - created time
+  - status
+  - name
+- Reset returns the view to default:
+  - no query
+  - all statuses
+  - sort by newest first
+
+## Acceptance Mapping
+
+- Users can scan, filter, and sort key rows quickly:
+  - toolbar controls are rendered above the inquiry list
+  - result count updates from filtered rows
+- Mobile remains usable:
+  - desktop table is hidden on narrow screens
+  - stacked inquiry cards expose the same fields for mobile reading
+- Existing inquiry semantics remain intact:
+  - no backend or field-name changes were introduced


### PR DESCRIPTION
## Summary
This PR closes #291 by replacing the raw recent inquiries table renderer on the admin dashboard with a dedicated interaction layer that keeps the existing backend data contract intact while making the section faster to scan on desktop and still readable on mobile.

The previous success state rendered rows directly into a plain table. That preserved the data, but it made the redesigned dashboard inconsistent with the richer Phase 2 and Phase 3 surfaces: operators could not quickly narrow results, status scanning depended on raw text, and mobile users were left with horizontal overflow as the only fallback.

The root cause was that the dashboard page owned the table markup inline, so the section had no reusable client-side state for search, filtering, or sort order and no alternate rendering strategy for narrow breakpoints.

This change moves the success-state inquiries renderer into a dedicated `DashboardRecentInquiriesTable` component. The component adds a query control, a status filter derived from the current result set, sort key selection, a sort direction toggle, and a reset action. The desktop view keeps the table layout for dense scanning, while a stacked card fallback exposes the same inquiry fields on smaller screens.

## User Impact
Operators can now:
- search across the existing inquiry fields without leaving the page
- filter the feed by status
- reorder rows by created time, status, or name
- review the same inquiry data on mobile without relying on a wide table alone

## Validation
- `npm --prefix admin-app run test -- __tests__/b14_admin_dashboard_page.test.ts __tests__/admin_dashboard_surface_styles.test.ts __tests__/admin_dashboard_recent_inquiries_table.test.ts __tests__/admin_dashboard_trend_chart.test.ts __tests__/admin_dashboard_kpi_widgets.test.ts __tests__/b14_admin_workspaces_pages.test.ts`
- `npm --prefix admin-app run build`
