### PR TITLE
[V2][Sprint 1][#423] Add scope boundary check contract

### DIFF
--- a/docs/contracts/AMP_V2_SCOPE_BOUNDARY_CHECK_2026-03-15.md
+++ b/docs/contracts/AMP_V2_SCOPE_BOUNDARY_CHECK_2026-03-15.md
@@ -1,0 +1,194 @@
+# AMP V2 Scope Boundary Check
+
+Date: 2026-03-15
+
+Issue:
+`#423` V2 Scope Boundary Check
+
+Governance lock:
+`027ef62f` on `origin/main`
+
+Status guardrail:
+
+- `V1` remains `closed / production-ready`
+- `V2` remains `roadmap only`
+- this boundary check is a `Sprint 1 additive artifact` and does not reopen V1 scope
+
+## Purpose
+
+Confirm that the Sprint 1 foundation sequence stays additive, remains outside closed V1 scope, and does not implicitly unlock work beyond the approved implementation gate.
+
+## Reviewed Foundation Outputs
+
+Reviewed merged foundation issue outputs:
+
+- `docs/contracts/AMP_V2_DATA_MODEL_REVIEW_2026-03-15.md` from `#419`
+- `docs/contracts/AMP_V2_SEARCH_INDEX_STRATEGY_2026-03-15.md` from `#420`
+- `docs/contracts/AMP_V2_SEO_SEARCH_STRATEGY_2026-03-15.md` from `#421`
+- `docs/contracts/AMP_V2_ROUTE_OWNERSHIP_DECISION_2026-03-15.md` from `#422`
+
+Reviewed governing constraints:
+
+- `docs/contracts/AMP_V2_ARCHITECTURE_GUARDRAILS.md`
+- `docs/contracts/AMP_V2_SPRINT_1_IMPLEMENTATION_GATE_2026-03-15.md`
+- `docs/contracts/AMP_V2_SEARCH_SCOPE_BRIEF.md`
+- `docs/contracts/AMP_V2_BUYING_COST_ESTIMATOR_SCOPE.md`
+- `docs/contracts/AMP_V2_EPIC_TO_ISSUE_BREAKDOWN.md`
+
+## Boundary Check Result
+
+Result:
+
+`Pass`
+
+The completed foundation sequence remains inside the approved Sprint 1 implementation gate and does not reopen V1 scope.
+
+## What Was Actually Changed In The Foundation Sequence
+
+The completed sequence added only architecture and governance artifacts.
+
+It did not:
+
+- modify public V1 pages
+- modify homepage structure
+- modify advisory funnel behavior
+- modify CRM routes or workflow
+- modify lead forms
+- modify core layout ownership
+- ship a new public V2 feature route
+- add unfinished feature flags into production UX
+
+## Per-Issue Scope Check
+
+### `#419` Data Model Review
+
+Outcome:
+
+- documented current property/project schema reality
+- documented gaps for later issues
+- did not change schema or runtime contracts
+
+Boundary result:
+
+- additive only
+
+### `#420` Search Index Strategy
+
+Outcome:
+
+- locked property-first search/index direction
+- deferred migrations and endpoint work to later implementation issues
+
+Boundary result:
+
+- additive only
+
+### `#421` SEO Search Strategy
+
+Outcome:
+
+- locked crawlability, canonical, and `noindex` strategy
+- did not change runtime SEO behavior in this issue
+
+Boundary result:
+
+- additive only
+
+### `#422` Route Ownership Decision
+
+Outcome:
+
+- selected ` /[locale]/buy ` as first search owner route
+- did not change routing, navigation, or page behavior in this issue
+
+Boundary result:
+
+- additive only
+
+## Protected Surface Check
+
+### V1 pages
+
+- untouched
+
+### Homepage structure
+
+- untouched
+
+### Advisory funnel
+
+- untouched
+
+### CRM routes and lifecycle
+
+- untouched
+
+### Lead forms
+
+- untouched
+
+### Core layout
+
+- untouched
+
+## What This Sequence Now Explicitly Allows
+
+With `#419` through `#423` completed, the implementation gate now allows the approved next paths only:
+
+- Search backend path: `#405`, `#408`, `#409`
+- Search UI path: `#406`, `#407`, `#410`, `#411`, `#412`
+- Estimator governance path: `#417`, `#418`
+
+This does not automatically approve all later V2 work.
+
+It only confirms that the dependency-first architecture preparation sequence is complete.
+
+## What Remains Blocked
+
+The following remain blocked or out of scope until their own approved dependencies are complete:
+
+- `#413` Estimator UI
+- `#414` Cost Formula Engine
+- `#415` Estimator Page
+- `#416` Share Result Link
+- saved search
+- AI recommendation or ML ranking
+- compare-sync expansion beyond approved contract
+- CRM redesign
+- V1 page redesign
+- home IA changes
+- lead-form changes
+- Sprint 2, Sprint 3, and Sprint 4 roadmap work
+
+## Reporting Boundary
+
+Acceptable status language after this check:
+
+- `Sprint 1 implementation is executing under dependency-first order with V1 protected.`
+- `Foundation dependency sequence is complete.`
+- `Sprint 1 feature implementation may now begin.`
+
+Unacceptable status language remains:
+
+- `V2 complete`
+- `platform finished`
+- `V1 reopened`
+- `full proptech build started`
+
+## Guardrail Check
+
+- V1 surfaces untouched: yes
+- CRM untouched: yes
+- lead forms untouched: yes
+- core layout untouched: yes
+- homepage/advisory funnel untouched: yes
+
+## Conclusion
+
+`#423` is satisfied.
+
+The merged Sprint 1 foundation sequence remains additive and outside the V1 closed baseline.
+
+No protected surface was reopened.
+
+The dependency chain for architecture preparation is complete, and the repository may now proceed to the next approved Sprint 1 implementation path without governance drift.


### PR DESCRIPTION
Scope:
Implement #423 by adding an additive Sprint 1 scope boundary check contract that confirms the merged foundation sequence stays outside V1 closed scope and only unlocks the approved next implementation paths.

Why now:
#423 is the final required dependency in the Sprint 1 architecture-preparation sequence, and the repository needs an explicit pass/fail boundary check before feature implementation proceeds.

Files touched:
docs/contracts/AMP_V2_SCOPE_BOUNDARY_CHECK_2026-03-15.md

Guardrail check:
V1 surfaces untouched: yes
CRM untouched: yes
Lead forms untouched: yes
Core layout untouched: yes
Homepage/advisory funnel untouched: yes

Validation:
- git diff --check: pass
- Docs-only change; no runtime code changed
- No unit, route, or smoke tests were required for this issue

Risk:
Low. The main risk is later work treating the completed foundation sequence as broader V2 approval; the document explicitly limits the unlock to the next approved Sprint 1 issue paths only.

Rollback:
Revert this PR or revert the issue commit to remove the boundary check document. No schema, API, or runtime rollback is required.