### PR TITLE
[V2][Sprint 2][Epic 1] Shortlist API

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -30,6 +30,7 @@ from apps.api.routes.v1 import (
     home_runtime,
     projects,
     properties,
+    shortlists,
 )
 from packages.core.database import SessionLocal, init_db
 from packages.core.schemas.property_api import SearchResponse
@@ -93,6 +94,7 @@ app.include_router(projects.router)
 app.include_router(content.router)
 app.include_router(home_composer.router)
 app.include_router(properties.router)
+app.include_router(shortlists.router)
 app.include_router(events.router)
 app.include_router(home_runtime.router)
 

--- a/apps/api/routes/v1/shortlists.py
+++ b/apps/api/routes/v1/shortlists.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import asc, desc, select
+from sqlalchemy.orm import Session
+
+from apps.api.routes.v1 import properties as property_routes
+from packages.core.database import get_db
+from packages.core.models import Area, Project, Property, Shortlist, ShortlistItem
+from packages.core.schemas.property_api import (
+    ShortlistDetail,
+    ShortlistPropertyItem,
+    ShortlistResponse,
+)
+
+router = APIRouter(prefix="/v1", tags=["shortlists"])
+
+
+def _load_current_shortlist(db: Session, owner_type: str, owner_key: str) -> Shortlist | None:
+    return db.scalar(
+        select(Shortlist)
+        .where(
+            Shortlist.owner_type == owner_type,
+            Shortlist.owner_key == owner_key,
+            Shortlist.status == "active",
+        )
+        .order_by(desc(Shortlist.updated_at), desc(Shortlist.created_at), desc(Shortlist.id))
+        .limit(1)
+    )
+
+
+def _load_shortlist_items(db: Session, shortlist_id: UUID) -> list[ShortlistItem]:
+    return db.scalars(
+        select(ShortlistItem)
+        .where(ShortlistItem.shortlist_id == shortlist_id)
+        .order_by(
+            asc(ShortlistItem.position),
+            asc(ShortlistItem.added_at),
+            asc(ShortlistItem.id),
+        )
+    ).all()
+
+
+@router.get("/shortlists/current", response_model=ShortlistResponse)
+def get_current_shortlist(
+    owner_type: str = Query(pattern=r"^(session|user)$"),
+    owner_key: str = Query(min_length=1, max_length=128),
+    locale: str = Query(default="en", pattern=r"^(en|th)$"),
+    db: Session = Depends(get_db),
+) -> ShortlistResponse:
+    normalized_owner_key = owner_key.strip()
+    shortlist = _load_current_shortlist(db, owner_type=owner_type, owner_key=normalized_owner_key)
+    if shortlist is None:
+        return ShortlistResponse(shortlist=None)
+
+    shortlist_items = _load_shortlist_items(db, shortlist.id)
+    property_ids = [item.property_id for item in shortlist_items]
+    properties = (
+        db.scalars(select(Property).where(Property.id.in_(property_ids))).all()
+        if property_ids
+        else []
+    )
+    properties_by_id = {property_row.id: property_row for property_row in properties}
+
+    project_ids = {
+        property_row.project_id
+        for property_row in properties
+        if property_row.project_id is not None
+    }
+    area_ids = {
+        property_row.area_id for property_row in properties if property_row.area_id is not None
+    }
+    project_names = (
+        dict(db.execute(select(Project.id, Project.name).where(Project.id.in_(project_ids))).all())
+        if project_ids
+        else {}
+    )
+    area_names = (
+        dict(db.execute(select(Area.id, Area.name).where(Area.id.in_(area_ids))).all())
+        if area_ids
+        else {}
+    )
+
+    items: list[ShortlistPropertyItem] = []
+    for shortlist_item in shortlist_items:
+        property_row = properties_by_id.get(shortlist_item.property_id)
+        if property_row is None:
+            continue
+
+        title_i18n = property_routes._normalize_i18n_map(getattr(property_row, "title_i18n", None))
+        title = (
+            property_routes._resolve_text_for_locale(
+                title_i18n,
+                getattr(property_row, "title", None),
+                locale,
+            )
+            or property_row.title
+        )
+        stored_local = property_routes._coerce_image_list(
+            getattr(property_row, "local_images", None)
+        )
+        stored_images = property_routes._coerce_image_list(getattr(property_row, "images", None))
+        disk_images = property_routes._list_local_images(property_row.id)
+        merged_images = property_routes._merge_images(stored_local, stored_images, disk_images)
+        image = property_routes._resolve_canonical_cover(
+            cover_image_url=getattr(property_row, "cover_image_url", None),
+            cover_image=getattr(property_row, "cover_image", None),
+            merged=merged_images,
+        )
+
+        items.append(
+            ShortlistPropertyItem(
+                property_id=property_row.id,
+                slug=property_row.slug,
+                title=title,
+                project=project_names.get(property_row.project_id),
+                location=area_names.get(property_row.area_id) or property_row.city,
+                price=property_row.price,
+                size=property_row.size_sqm or property_row.size,
+                bedrooms=property_row.bedrooms,
+                bathrooms=property_row.bathrooms,
+                image=image,
+                status=property_row.status,
+                foreign_quota=property_routes._has_foreign_quota_indicator(
+                    getattr(property_row, "features", None),
+                    getattr(property_row, "ownership_notes", None),
+                ),
+                position=shortlist_item.position,
+                added_at=shortlist_item.added_at,
+                source_surface=shortlist_item.source_surface,
+            )
+        )
+
+    return ShortlistResponse(
+        shortlist=ShortlistDetail(
+            id=shortlist.id,
+            owner_type=shortlist.owner_type,
+            owner_key=shortlist.owner_key,
+            status=shortlist.status,
+            title=shortlist.title,
+            intent=shortlist.intent,
+            share_mode=shortlist.share_mode,
+            source_context=shortlist.source_context,
+            created_at=shortlist.created_at,
+            updated_at=shortlist.updated_at,
+            last_viewed_at=shortlist.last_viewed_at,
+            item_count=len(items),
+            items=items,
+        )
+    )

--- a/packages/core/schemas/property_api.py
+++ b/packages/core/schemas/property_api.py
@@ -106,6 +106,44 @@ class SearchResponse(BaseModel):
     results: list[SearchResultItem]
 
 
+class ShortlistPropertyItem(BaseModel):
+    property_id: UUID
+    slug: str | None = None
+    title: str
+    project: str | None = None
+    location: str | None = None
+    price: Decimal
+    size: Decimal | None = None
+    bedrooms: int | None = None
+    bathrooms: int | None = None
+    image: str | None = None
+    status: str
+    foreign_quota: bool = False
+    position: int
+    added_at: datetime
+    source_surface: str | None = None
+
+
+class ShortlistDetail(BaseModel):
+    id: UUID
+    owner_type: str
+    owner_key: str
+    status: str
+    title: str | None = None
+    intent: str | None = None
+    share_mode: str | None = None
+    source_context: dict | None = None
+    created_at: datetime
+    updated_at: datetime
+    last_viewed_at: datetime | None = None
+    item_count: int
+    items: list[ShortlistPropertyItem]
+
+
+class ShortlistResponse(BaseModel):
+    shortlist: ShortlistDetail | None = None
+
+
 class PropertyAdminListResponse(BaseModel):
     data: list[PropertyDetail]
     meta: PaginationMeta

--- a/tests/test_b17_shortlist_api.py
+++ b/tests/test_b17_shortlist_api.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+
+from packages.core.database import SessionLocal, init_db
+from packages.core.models import Area, Project, Property, Shortlist, ShortlistItem
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_tables() -> Generator[None, None, None]:
+    init_db()
+    with SessionLocal() as db:
+        db.query(ShortlistItem).delete()
+        db.query(Shortlist).delete()
+        db.query(Property).delete()
+        db.query(Project).delete()
+        db.query(Area).delete()
+        db.commit()
+    yield
+    with SessionLocal() as db:
+        db.query(ShortlistItem).delete()
+        db.query(Shortlist).delete()
+        db.query(Property).delete()
+        db.query(Project).delete()
+        db.query(Area).delete()
+        db.commit()
+
+
+def _seed_shortlist_fixture() -> dict[str, str]:
+    owner_key = f"sess-b17-{uuid4()}"
+    archived_owner_key = f"sess-b17-archived-{uuid4()}"
+
+    with SessionLocal() as db:
+        area = Area(
+            slug=f"b17-area-{uuid4()}",
+            name="Wongamat",
+            city="Pattaya",
+            status="published",
+            summary={"en": "B17 area summary"},
+            cover_image_url="/media/library/b17-area.webp",
+        )
+        db.add(area)
+        db.flush()
+
+        project = Project(
+            slug=f"b17-project-{uuid4()}",
+            name="Wongamat Tower",
+            status="published",
+            area_id=area.id,
+            property_type="condo",
+            cover_image_url="/media/library/b17-project.webp",
+            summary={"en": "B17 project summary"},
+        )
+        db.add(project)
+        db.flush()
+
+        property_one = Property(
+            source_id=f"b17-property-one-{uuid4()}",
+            slug=f"b17-property-one-{uuid4()}",
+            title="B17 Property One",
+            title_i18n={"en": "B17 Property One EN", "th": "บี17 ยูนิตหนึ่ง"},
+            type="resale",
+            property_type="condo",
+            status="active",
+            price=5100000,
+            bedrooms=1,
+            bathrooms=1,
+            size_sqm=41,
+            city="Pattaya",
+            address="B17 Address One",
+            area_id=area.id,
+            project_id=project.id,
+            cover_image_url="/media/library/b17-property-one.webp",
+            local_images=["/media/library/b17-property-one.webp"],
+            features={"tags": ["foreign quota"]},
+        )
+        property_two = Property(
+            source_id=f"b17-property-two-{uuid4()}",
+            slug=f"b17-property-two-{uuid4()}",
+            title="B17 Property Two",
+            title_i18n={"en": "B17 Property Two EN", "th": "บี17 ยูนิตสอง"},
+            type="new",
+            property_type="condo",
+            status="inactive",
+            price=8200000,
+            bedrooms=2,
+            bathrooms=2,
+            size_sqm=68,
+            city="Pattaya",
+            address="B17 Address Two",
+            area_id=area.id,
+            project_id=project.id,
+            cover_image_url="/media/library/b17-property-two.webp",
+            local_images=["/media/library/b17-property-two.webp"],
+        )
+        db.add_all([property_one, property_two])
+        db.flush()
+
+        property_one_slug = property_one.slug or ""
+        property_two_slug = property_two.slug or ""
+
+        archived_shortlist = Shortlist(
+            owner_type="session",
+            owner_key=archived_owner_key,
+            status="archived",
+            intent="invest",
+        )
+        shortlist = Shortlist(
+            owner_type="session",
+            owner_key=owner_key,
+            intent="buy",
+            title="My shortlist",
+            source_context={"surface": "compare"},
+        )
+        db.add_all([archived_shortlist, shortlist])
+        db.flush()
+
+        db.add_all(
+            [
+                ShortlistItem(
+                    shortlist_id=shortlist.id,
+                    property_id=property_two.id,
+                    position=1,
+                    source_surface="compare",
+                ),
+                ShortlistItem(
+                    shortlist_id=shortlist.id,
+                    property_id=property_one.id,
+                    position=0,
+                    source_surface="listing_card",
+                ),
+            ]
+        )
+        db.commit()
+
+    return {
+        "owner_key": owner_key,
+        "archived_owner_key": archived_owner_key,
+        "property_one_slug": property_one_slug,
+        "property_two_slug": property_two_slug,
+    }
+
+
+def test_b17_shortlist_api_returns_owner_bound_shortlist_with_sorted_items(client) -> None:
+    seeded = _seed_shortlist_fixture()
+
+    response = client.get(
+        f"/v1/shortlists/current?owner_type=session&owner_key={seeded['owner_key']}&locale=th"
+    )
+    assert response.status_code == 200, response.text
+
+    body = response.json()
+    shortlist = body["shortlist"]
+    assert shortlist is not None
+    assert shortlist["owner_type"] == "session"
+    assert shortlist["owner_key"] == seeded["owner_key"]
+    assert shortlist["status"] == "active"
+    assert shortlist["intent"] == "buy"
+    assert shortlist["title"] == "My shortlist"
+    assert shortlist["source_context"] == {"surface": "compare"}
+    assert shortlist["item_count"] == 2
+
+    first_item, second_item = shortlist["items"]
+    assert first_item["slug"] == seeded["property_one_slug"]
+    assert first_item["title"] == "บี17 ยูนิตหนึ่ง"
+    assert first_item["position"] == 0
+    assert first_item["project"] == "Wongamat Tower"
+    assert first_item["location"] == "Wongamat"
+    assert first_item["foreign_quota"] is True
+    assert first_item["source_surface"] == "listing_card"
+    assert str(first_item["image"]).startswith("/media/")
+
+    assert second_item["slug"] == seeded["property_two_slug"]
+    assert second_item["position"] == 1
+    assert second_item["status"] == "inactive"
+    assert second_item["source_surface"] == "compare"
+
+
+def test_b17_shortlist_api_returns_null_for_missing_or_non_active_shortlist(client) -> None:
+    seeded = _seed_shortlist_fixture()
+
+    missing = client.get("/v1/shortlists/current?owner_type=session&owner_key=missing-owner")
+    assert missing.status_code == 200, missing.text
+    assert missing.json() == {"shortlist": None}
+
+    archived = client.get(
+        f"/v1/shortlists/current?owner_type=session&owner_key={seeded['archived_owner_key']}"
+    )
+    assert archived.status_code == 200, archived.text
+    assert archived.json() == {"shortlist": None}


### PR DESCRIPTION
## Summary
- add a public read-only shortlist API for the active session/user-owned shortlist
- expose shortlist response schemas and item mapping on top of the merged persistence layer
- add targeted backend tests for shortlist retrieval and empty-owner handling

## Scope
- Issue: #445
- V1 impact = none
- additive-only shortlist foundation work

## Guardrails
- no CRM changes
- no lead-form changes
- no core-layout changes
- no homepage changes
- no advisory funnel changes

## Validation
- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m pytest -q tests/test_b16_shortlist_persistence.py tests/test_b17_shortlist_api.py
- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m ruff check apps/api/routes/v1/shortlists.py packages/core/schemas/property_api.py apps/api/main.py tests/test_b17_shortlist_api.py
- git diff --check