### PR TITLE
[V2][Sprint 2][Epic 1] Shortlist Save Remove Behavior

### DIFF
--- a/apps/api/routes/v1/shortlists.py
+++ b/apps/api/routes/v1/shortlists.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
-from sqlalchemy import asc, desc, select
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import asc, desc, func, select
 from sqlalchemy.orm import Session
 
 from apps.api.routes.v1 import properties as property_routes
@@ -11,6 +12,8 @@ from packages.core.database import get_db
 from packages.core.models import Area, Project, Property, Shortlist, ShortlistItem
 from packages.core.schemas.property_api import (
     ShortlistDetail,
+    ShortlistItemSaveRequest,
+    ShortlistMutationResponse,
     ShortlistPropertyItem,
     ShortlistResponse,
 )
@@ -43,18 +46,12 @@ def _load_shortlist_items(db: Session, shortlist_id: UUID) -> list[ShortlistItem
     ).all()
 
 
-@router.get("/shortlists/current", response_model=ShortlistResponse)
-def get_current_shortlist(
-    owner_type: str = Query(pattern=r"^(session|user)$"),
-    owner_key: str = Query(min_length=1, max_length=128),
-    locale: str = Query(default="en", pattern=r"^(en|th)$"),
-    db: Session = Depends(get_db),
-) -> ShortlistResponse:
-    normalized_owner_key = owner_key.strip()
-    shortlist = _load_current_shortlist(db, owner_type=owner_type, owner_key=normalized_owner_key)
-    if shortlist is None:
-        return ShortlistResponse(shortlist=None)
-
+def _serialize_shortlist_detail(
+    db: Session,
+    shortlist: Shortlist,
+    *,
+    locale: str,
+) -> ShortlistDetail:
     shortlist_items = _load_shortlist_items(db, shortlist.id)
     property_ids = [item.property_id for item in shortlist_items]
     properties = (
@@ -133,20 +130,182 @@ def get_current_shortlist(
             )
         )
 
-    return ShortlistResponse(
-        shortlist=ShortlistDetail(
-            id=shortlist.id,
-            owner_type=shortlist.owner_type,
-            owner_key=shortlist.owner_key,
-            status=shortlist.status,
-            title=shortlist.title,
-            intent=shortlist.intent,
-            share_mode=shortlist.share_mode,
-            source_context=shortlist.source_context,
-            created_at=shortlist.created_at,
-            updated_at=shortlist.updated_at,
-            last_viewed_at=shortlist.last_viewed_at,
-            item_count=len(items),
-            items=items,
+    return ShortlistDetail(
+        id=shortlist.id,
+        owner_type=shortlist.owner_type,
+        owner_key=shortlist.owner_key,
+        status=shortlist.status,
+        title=shortlist.title,
+        intent=shortlist.intent,
+        share_mode=shortlist.share_mode,
+        source_context=shortlist.source_context,
+        created_at=shortlist.created_at,
+        updated_at=shortlist.updated_at,
+        last_viewed_at=shortlist.last_viewed_at,
+        item_count=len(items),
+        items=items,
+    )
+
+
+def _touch_shortlist(shortlist: Shortlist) -> None:
+    shortlist.updated_at = datetime.now(timezone.utc)
+
+
+def _apply_shortlist_metadata(
+    shortlist: Shortlist,
+    *,
+    intent: str | None,
+    title: str | None,
+    source_context: dict | None,
+) -> None:
+    if intent is not None:
+        shortlist.intent = intent.strip() or None
+    if title is not None:
+        shortlist.title = title.strip() or None
+    if source_context is not None:
+        shortlist.source_context = source_context
+
+
+def _normalize_owner_key(owner_key: str) -> str:
+    normalized = owner_key.strip()
+    if normalized:
+        return normalized
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail="owner_key must not be blank",
+    )
+
+
+def _reindex_shortlist_items(items: list[ShortlistItem]) -> None:
+    for index, shortlist_item in enumerate(items):
+        shortlist_item.position = index
+
+
+@router.get("/shortlists/current", response_model=ShortlistResponse)
+def get_current_shortlist(
+    owner_type: str = Query(pattern=r"^(session|user)$"),
+    owner_key: str = Query(min_length=1, max_length=128),
+    locale: str = Query(default="en", pattern=r"^(en|th)$"),
+    db: Session = Depends(get_db),
+) -> ShortlistResponse:
+    normalized_owner_key = _normalize_owner_key(owner_key)
+    shortlist = _load_current_shortlist(db, owner_type=owner_type, owner_key=normalized_owner_key)
+    if shortlist is None:
+        return ShortlistResponse(shortlist=None)
+
+    return ShortlistResponse(shortlist=_serialize_shortlist_detail(db, shortlist, locale=locale))
+
+
+@router.post("/shortlists/current/items", response_model=ShortlistMutationResponse)
+def save_shortlist_item(
+    payload: ShortlistItemSaveRequest,
+    locale: str = Query(default="en", pattern=r"^(en|th)$"),
+    db: Session = Depends(get_db),
+) -> ShortlistMutationResponse:
+    normalized_owner_key = _normalize_owner_key(payload.owner_key)
+    property_row = db.get(Property, payload.property_id)
+    if property_row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Property not found")
+
+    shortlist = _load_current_shortlist(
+        db,
+        owner_type=payload.owner_type,
+        owner_key=normalized_owner_key,
+    )
+    if shortlist is None:
+        shortlist = Shortlist(
+            owner_type=payload.owner_type,
+            owner_key=normalized_owner_key,
+            status="active",
         )
+        db.add(shortlist)
+        db.flush()
+
+    _apply_shortlist_metadata(
+        shortlist,
+        intent=payload.intent,
+        title=payload.title,
+        source_context=payload.source_context,
+    )
+
+    existing_item = db.scalar(
+        select(ShortlistItem)
+        .where(
+            ShortlistItem.shortlist_id == shortlist.id,
+            ShortlistItem.property_id == payload.property_id,
+        )
+        .limit(1)
+    )
+    if existing_item is None:
+        current_max_position = db.scalar(
+            select(func.max(ShortlistItem.position)).where(
+                ShortlistItem.shortlist_id == shortlist.id
+            )
+        )
+        db.add(
+            ShortlistItem(
+                shortlist_id=shortlist.id,
+                property_id=payload.property_id,
+                position=(current_max_position or -1) + 1,
+                source_surface=payload.source_surface,
+            )
+        )
+        action = "saved"
+    else:
+        if payload.source_surface is not None:
+            existing_item.source_surface = payload.source_surface
+        action = "already_saved"
+
+    _touch_shortlist(shortlist)
+    db.commit()
+    db.refresh(shortlist)
+
+    return ShortlistMutationResponse(
+        action=action,
+        shortlist=_serialize_shortlist_detail(db, shortlist, locale=locale),
+    )
+
+
+@router.delete(
+    "/shortlists/current/items/{property_id}",
+    response_model=ShortlistMutationResponse,
+)
+def remove_shortlist_item(
+    property_id: UUID,
+    owner_type: str = Query(pattern=r"^(session|user)$"),
+    owner_key: str = Query(min_length=1, max_length=128),
+    locale: str = Query(default="en", pattern=r"^(en|th)$"),
+    db: Session = Depends(get_db),
+) -> ShortlistMutationResponse:
+    normalized_owner_key = _normalize_owner_key(owner_key)
+    shortlist = _load_current_shortlist(db, owner_type=owner_type, owner_key=normalized_owner_key)
+    if shortlist is None:
+        return ShortlistMutationResponse(action="not_found", shortlist=None)
+
+    shortlist_item = db.scalar(
+        select(ShortlistItem)
+        .where(
+            ShortlistItem.shortlist_id == shortlist.id,
+            ShortlistItem.property_id == property_id,
+        )
+        .limit(1)
+    )
+    if shortlist_item is None:
+        return ShortlistMutationResponse(
+            action="not_found",
+            shortlist=_serialize_shortlist_detail(db, shortlist, locale=locale),
+        )
+
+    db.delete(shortlist_item)
+    db.flush()
+
+    remaining_items = _load_shortlist_items(db, shortlist.id)
+    _reindex_shortlist_items(remaining_items)
+    _touch_shortlist(shortlist)
+    db.commit()
+    db.refresh(shortlist)
+
+    return ShortlistMutationResponse(
+        action="removed",
+        shortlist=_serialize_shortlist_detail(db, shortlist, locale=locale),
     )

--- a/packages/core/schemas/property_api.py
+++ b/packages/core/schemas/property_api.py
@@ -144,6 +144,21 @@ class ShortlistResponse(BaseModel):
     shortlist: ShortlistDetail | None = None
 
 
+class ShortlistItemSaveRequest(BaseModel):
+    owner_type: str
+    owner_key: str
+    property_id: UUID
+    source_surface: str | None = None
+    intent: str | None = None
+    title: str | None = None
+    source_context: dict | None = None
+
+
+class ShortlistMutationResponse(BaseModel):
+    action: str
+    shortlist: ShortlistDetail | None = None
+
+
 class PropertyAdminListResponse(BaseModel):
     data: list[PropertyDetail]
     meta: PaginationMeta

--- a/tests/test_b18_shortlist_save_remove.py
+++ b/tests/test_b18_shortlist_save_remove.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+
+from packages.core.database import SessionLocal, init_db
+from packages.core.models import Area, Project, Property, Shortlist, ShortlistItem
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_tables() -> Generator[None, None, None]:
+    init_db()
+    with SessionLocal() as db:
+        db.query(ShortlistItem).delete()
+        db.query(Shortlist).delete()
+        db.query(Property).delete()
+        db.query(Project).delete()
+        db.query(Area).delete()
+        db.commit()
+    yield
+    with SessionLocal() as db:
+        db.query(ShortlistItem).delete()
+        db.query(Shortlist).delete()
+        db.query(Property).delete()
+        db.query(Project).delete()
+        db.query(Area).delete()
+        db.commit()
+
+
+def _seed_property_inventory() -> dict[str, str]:
+    owner_key = f"sess-b18-{uuid4()}"
+
+    with SessionLocal() as db:
+        area = Area(
+            slug=f"b18-area-{uuid4()}",
+            name="Pratumnak",
+            city="Pattaya",
+            status="published",
+            summary={"en": "B18 area summary"},
+            cover_image_url="/media/library/b18-area.webp",
+        )
+        db.add(area)
+        db.flush()
+
+        project = Project(
+            slug=f"b18-project-{uuid4()}",
+            name="Pratumnak Point",
+            status="published",
+            area_id=area.id,
+            property_type="condo",
+            cover_image_url="/media/library/b18-project.webp",
+            summary={"en": "B18 project summary"},
+        )
+        db.add(project)
+        db.flush()
+
+        property_one = Property(
+            source_id=f"b18-property-one-{uuid4()}",
+            slug=f"b18-property-one-{uuid4()}",
+            title="B18 Property One",
+            title_i18n={"en": "B18 Property One EN", "th": "บี18 ยูนิตหนึ่ง"},
+            type="resale",
+            property_type="condo",
+            status="active",
+            price=6200000,
+            bedrooms=1,
+            bathrooms=1,
+            size_sqm=47,
+            city="Pattaya",
+            address="B18 Address One",
+            area_id=area.id,
+            project_id=project.id,
+            cover_image_url="/media/library/b18-property-one.webp",
+            local_images=["/media/library/b18-property-one.webp"],
+        )
+        property_two = Property(
+            source_id=f"b18-property-two-{uuid4()}",
+            slug=f"b18-property-two-{uuid4()}",
+            title="B18 Property Two",
+            title_i18n={"en": "B18 Property Two EN", "th": "บี18 ยูนิตสอง"},
+            type="new",
+            property_type="condo",
+            status="active",
+            price=7900000,
+            bedrooms=2,
+            bathrooms=2,
+            size_sqm=71,
+            city="Pattaya",
+            address="B18 Address Two",
+            area_id=area.id,
+            project_id=project.id,
+            cover_image_url="/media/library/b18-property-two.webp",
+            local_images=["/media/library/b18-property-two.webp"],
+        )
+        db.add_all([property_one, property_two])
+        db.commit()
+
+        property_one_id = str(property_one.id)
+        property_two_id = str(property_two.id)
+
+    return {
+        "owner_key": owner_key,
+        "property_one_id": property_one_id,
+        "property_two_id": property_two_id,
+    }
+
+
+def test_b18_shortlist_save_creates_shortlist_and_is_idempotent(client) -> None:
+    seeded = _seed_property_inventory()
+
+    created = client.post(
+        "/v1/shortlists/current/items?locale=th",
+        json={
+            "owner_type": "session",
+            "owner_key": seeded["owner_key"],
+            "property_id": seeded["property_one_id"],
+            "source_surface": "compare",
+            "intent": "buy",
+            "title": "Buyer picks",
+            "source_context": {"surface": "compare"},
+        },
+    )
+    assert created.status_code == 200, created.text
+    created_body = created.json()
+    assert created_body["action"] == "saved"
+    assert created_body["shortlist"]["item_count"] == 1
+    assert created_body["shortlist"]["items"][0]["position"] == 0
+    assert created_body["shortlist"]["items"][0]["source_surface"] == "compare"
+    assert created_body["shortlist"]["items"][0]["title"] == "บี18 ยูนิตหนึ่ง"
+
+    repeated = client.post(
+        "/v1/shortlists/current/items",
+        json={
+            "owner_type": "session",
+            "owner_key": seeded["owner_key"],
+            "property_id": seeded["property_one_id"],
+            "source_surface": "listing_card",
+        },
+    )
+    assert repeated.status_code == 200, repeated.text
+    repeated_body = repeated.json()
+    assert repeated_body["action"] == "already_saved"
+    assert repeated_body["shortlist"]["item_count"] == 1
+    assert repeated_body["shortlist"]["items"][0]["source_surface"] == "listing_card"
+
+
+def test_b18_shortlist_remove_deletes_item_and_reindexes_positions(client) -> None:
+    seeded = _seed_property_inventory()
+
+    client.post(
+        "/v1/shortlists/current/items",
+        json={
+            "owner_type": "session",
+            "owner_key": seeded["owner_key"],
+            "property_id": seeded["property_one_id"],
+            "source_surface": "listing_card",
+        },
+    )
+    client.post(
+        "/v1/shortlists/current/items",
+        json={
+            "owner_type": "session",
+            "owner_key": seeded["owner_key"],
+            "property_id": seeded["property_two_id"],
+            "source_surface": "compare",
+        },
+    )
+
+    removed = client.delete(
+        f"/v1/shortlists/current/items/{seeded['property_one_id']}?owner_type=session&owner_key={seeded['owner_key']}"
+    )
+    assert removed.status_code == 200, removed.text
+    removed_body = removed.json()
+    assert removed_body["action"] == "removed"
+    assert removed_body["shortlist"]["item_count"] == 1
+    assert removed_body["shortlist"]["items"][0]["property_id"] == seeded["property_two_id"]
+    assert removed_body["shortlist"]["items"][0]["position"] == 0
+
+    missing = client.delete(
+        f"/v1/shortlists/current/items/{seeded['property_one_id']}?owner_type=session&owner_key=missing-owner"
+    )
+    assert missing.status_code == 200, missing.text
+    assert missing.json() == {"action": "not_found", "shortlist": None}


### PR DESCRIPTION
## Summary
- add shortlist item save and remove endpoints on top of the shortlist API branch
- make saves idempotent, create an owner shortlist on first save, and reindex positions after remove
- add targeted backend tests for create, repeat-save, remove, and missing-owner behavior

## Scope
- Issue: #447
- stacked on top of #445
- V1 impact = none
- additive-only shortlist foundation work

## Guardrails
- no CRM changes
- no lead-form changes
- no core-layout changes
- no homepage changes
- no advisory funnel changes

## Validation
- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m pytest -q tests/test_b16_shortlist_persistence.py tests/test_b17_shortlist_api.py tests/test_b18_shortlist_save_remove.py
- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m ruff check apps/api/routes/v1/shortlists.py packages/core/schemas/property_api.py tests/test_b18_shortlist_save_remove.py
- git diff --check