### PR TITLE
[V2][Sprint 2][Epic 1] Shortlist Share Capability

### DIFF
--- a/apps/api/routes/v1/shortlists.py
+++ b/apps/api/routes/v1/shortlists.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 from datetime import datetime, timezone
 from uuid import UUID
 
@@ -11,11 +12,15 @@ from apps.api.routes.v1 import properties as property_routes
 from packages.core.database import get_db
 from packages.core.models import Area, Project, Property, Shortlist, ShortlistItem
 from packages.core.schemas.property_api import (
+    SharedShortlistDetail,
+    SharedShortlistResponse,
     ShortlistDetail,
     ShortlistItemSaveRequest,
     ShortlistMutationResponse,
     ShortlistPropertyItem,
     ShortlistResponse,
+    ShortlistShareRequest,
+    ShortlistShareResponse,
 )
 
 router = APIRouter(prefix="/v1", tags=["shortlists"])
@@ -181,6 +186,39 @@ def _reindex_shortlist_items(items: list[ShortlistItem]) -> None:
         shortlist_item.position = index
 
 
+def _serialize_shared_shortlist_detail(
+    db: Session,
+    shortlist: Shortlist,
+    *,
+    locale: str,
+) -> SharedShortlistDetail:
+    detail = _serialize_shortlist_detail(db, shortlist, locale=locale)
+    return SharedShortlistDetail(
+        id=detail.id,
+        title=detail.title,
+        intent=detail.intent,
+        share_mode=shortlist.share_mode,
+        created_at=detail.created_at,
+        updated_at=detail.updated_at,
+        item_count=detail.item_count,
+        items=detail.items,
+    )
+
+
+def _generate_share_token(db: Session) -> str:
+    for _ in range(10):
+        candidate = secrets.token_urlsafe(18)
+        existing = db.scalar(
+            select(Shortlist.id).where(Shortlist.share_token_ref == candidate).limit(1)
+        )
+        if existing is None:
+            return candidate
+    raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Unable to generate shortlist share token",
+    )
+
+
 @router.get("/shortlists/current", response_model=ShortlistResponse)
 def get_current_shortlist(
     owner_type: str = Query(pattern=r"^(session|user)$"),
@@ -308,4 +346,70 @@ def remove_shortlist_item(
     return ShortlistMutationResponse(
         action="removed",
         shortlist=_serialize_shortlist_detail(db, shortlist, locale=locale),
+    )
+
+
+@router.post("/shortlists/current/share", response_model=ShortlistShareResponse)
+def share_current_shortlist(
+    payload: ShortlistShareRequest,
+    locale: str = Query(default="en", pattern=r"^(en|th)$"),
+    db: Session = Depends(get_db),
+) -> ShortlistShareResponse:
+    normalized_owner_key = _normalize_owner_key(payload.owner_key)
+    shortlist = _load_current_shortlist(
+        db,
+        owner_type=payload.owner_type,
+        owner_key=normalized_owner_key,
+    )
+    if shortlist is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shortlist not found")
+
+    shortlist_items = _load_shortlist_items(db, shortlist.id)
+    if not shortlist_items:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Shortlist is empty")
+
+    if shortlist.share_token_ref is None:
+        shortlist.share_token_ref = _generate_share_token(db)
+        action = "shared"
+    else:
+        action = "already_shared"
+
+    shortlist.share_mode = payload.share_mode
+    _touch_shortlist(shortlist)
+    db.commit()
+    db.refresh(shortlist)
+
+    share_token = str(shortlist.share_token_ref)
+    return ShortlistShareResponse(
+        action=action,
+        share_token=share_token,
+        share_mode=str(shortlist.share_mode or payload.share_mode),
+        share_url=f"/v1/shortlists/shared/{share_token}",
+        shortlist=_serialize_shared_shortlist_detail(db, shortlist, locale=locale),
+    )
+
+
+@router.get("/shortlists/shared/{share_token}", response_model=SharedShortlistResponse)
+def get_shared_shortlist(
+    share_token: str,
+    locale: str = Query(default="en", pattern=r"^(en|th)$"),
+    db: Session = Depends(get_db),
+) -> SharedShortlistResponse:
+    shortlist = db.scalar(
+        select(Shortlist)
+        .where(
+            Shortlist.share_token_ref == share_token,
+            Shortlist.share_mode == "public_read",
+            Shortlist.status == "active",
+        )
+        .limit(1)
+    )
+    if shortlist is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Shared shortlist not found",
+        )
+
+    return SharedShortlistResponse(
+        shortlist=_serialize_shared_shortlist_detail(db, shortlist, locale=locale)
     )

--- a/packages/core/schemas/property_api.py
+++ b/packages/core/schemas/property_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -157,6 +158,35 @@ class ShortlistItemSaveRequest(BaseModel):
 class ShortlistMutationResponse(BaseModel):
     action: str
     shortlist: ShortlistDetail | None = None
+
+
+class ShortlistShareRequest(BaseModel):
+    owner_type: str
+    owner_key: str
+    share_mode: Literal["public_read"] = "public_read"
+
+
+class SharedShortlistDetail(BaseModel):
+    id: UUID
+    title: str | None = None
+    intent: str | None = None
+    share_mode: str | None = None
+    created_at: datetime
+    updated_at: datetime
+    item_count: int
+    items: list[ShortlistPropertyItem]
+
+
+class ShortlistShareResponse(BaseModel):
+    action: str
+    share_token: str
+    share_mode: str
+    share_url: str
+    shortlist: SharedShortlistDetail
+
+
+class SharedShortlistResponse(BaseModel):
+    shortlist: SharedShortlistDetail
 
 
 class PropertyAdminListResponse(BaseModel):

--- a/tests/test_b19_shortlist_share_capability.py
+++ b/tests/test_b19_shortlist_share_capability.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+
+from packages.core.database import SessionLocal, init_db
+from packages.core.models import Area, Project, Property, Shortlist, ShortlistItem
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_tables() -> Generator[None, None, None]:
+    init_db()
+    with SessionLocal() as db:
+        db.query(ShortlistItem).delete()
+        db.query(Shortlist).delete()
+        db.query(Property).delete()
+        db.query(Project).delete()
+        db.query(Area).delete()
+        db.commit()
+    yield
+    with SessionLocal() as db:
+        db.query(ShortlistItem).delete()
+        db.query(Shortlist).delete()
+        db.query(Property).delete()
+        db.query(Project).delete()
+        db.query(Area).delete()
+        db.commit()
+
+
+def _seed_share_inventory() -> dict[str, str]:
+    owner_key = f"sess-b19-{uuid4()}"
+
+    with SessionLocal() as db:
+        area = Area(
+            slug=f"b19-area-{uuid4()}",
+            name="Na Jomtien",
+            city="Pattaya",
+            status="published",
+            summary={"en": "B19 area summary"},
+            cover_image_url="/media/library/b19-area.webp",
+        )
+        db.add(area)
+        db.flush()
+
+        project = Project(
+            slug=f"b19-project-{uuid4()}",
+            name="Na Jomtien Residence",
+            status="published",
+            area_id=area.id,
+            property_type="condo",
+            cover_image_url="/media/library/b19-project.webp",
+            summary={"en": "B19 project summary"},
+        )
+        db.add(project)
+        db.flush()
+
+        property_row = Property(
+            source_id=f"b19-property-{uuid4()}",
+            slug=f"b19-property-{uuid4()}",
+            title="B19 Property",
+            title_i18n={"en": "B19 Property EN", "th": "บี19 ยูนิต"},
+            type="resale",
+            property_type="condo",
+            status="active",
+            price=9300000,
+            bedrooms=2,
+            bathrooms=2,
+            size_sqm=73,
+            city="Pattaya",
+            address="B19 Address",
+            area_id=area.id,
+            project_id=project.id,
+            cover_image_url="/media/library/b19-property.webp",
+            local_images=["/media/library/b19-property.webp"],
+        )
+        db.add(property_row)
+        db.commit()
+
+        property_id = str(property_row.id)
+
+    return {
+        "owner_key": owner_key,
+        "property_id": property_id,
+    }
+
+
+def test_b19_shortlist_share_generates_reusable_public_token(client) -> None:
+    seeded = _seed_share_inventory()
+
+    client.post(
+        "/v1/shortlists/current/items",
+        json={
+            "owner_type": "session",
+            "owner_key": seeded["owner_key"],
+            "property_id": seeded["property_id"],
+            "source_surface": "compare",
+            "intent": "buy",
+            "title": "Shared picks",
+        },
+    )
+
+    created = client.post(
+        "/v1/shortlists/current/share?locale=th",
+        json={
+            "owner_type": "session",
+            "owner_key": seeded["owner_key"],
+            "share_mode": "public_read",
+        },
+    )
+    assert created.status_code == 200, created.text
+    created_body = created.json()
+    assert created_body["action"] == "shared"
+    assert created_body["share_mode"] == "public_read"
+    assert created_body["share_token"]
+    assert created_body["share_url"].endswith(created_body["share_token"])
+    assert created_body["shortlist"]["title"] == "Shared picks"
+    assert created_body["shortlist"]["items"][0]["title"] == "บี19 ยูนิต"
+
+    repeated = client.post(
+        "/v1/shortlists/current/share",
+        json={
+            "owner_type": "session",
+            "owner_key": seeded["owner_key"],
+            "share_mode": "public_read",
+        },
+    )
+    assert repeated.status_code == 200, repeated.text
+    repeated_body = repeated.json()
+    assert repeated_body["action"] == "already_shared"
+    assert repeated_body["share_token"] == created_body["share_token"]
+
+
+def test_b19_shared_shortlist_read_is_public_and_owner_safe(client) -> None:
+    seeded = _seed_share_inventory()
+
+    client.post(
+        "/v1/shortlists/current/items",
+        json={
+            "owner_type": "session",
+            "owner_key": seeded["owner_key"],
+            "property_id": seeded["property_id"],
+            "source_surface": "listing_card",
+        },
+    )
+    share = client.post(
+        "/v1/shortlists/current/share",
+        json={
+            "owner_type": "session",
+            "owner_key": seeded["owner_key"],
+            "share_mode": "public_read",
+        },
+    )
+    share_token = share.json()["share_token"]
+
+    public_response = client.get(f"/v1/shortlists/shared/{share_token}?locale=th")
+    assert public_response.status_code == 200, public_response.text
+    public_body = public_response.json()
+    shortlist = public_body["shortlist"]
+    assert shortlist["share_mode"] == "public_read"
+    assert shortlist["item_count"] == 1
+    assert shortlist["items"][0]["title"] == "บี19 ยูนิต"
+    assert "owner_key" not in shortlist
+    assert "owner_type" not in shortlist
+
+    missing = client.get("/v1/shortlists/shared/missing-token")
+    assert missing.status_code == 404, missing.text


### PR DESCRIPTION
## Summary
- add a token-based shortlist share endpoint for active owner-bound shortlists
- add a public read-only shared shortlist endpoint that omits owner identifiers
- add targeted backend tests for share token creation, token reuse, and public read behavior

## Scope
- Issue: #449
- replacement for stacked PR #450 after base branch merge
- V1 impact = none
- additive-only shortlist foundation work

## Guardrails
- no CRM changes
- no auth changes
- no lead-form changes
- no core-layout changes
- no homepage changes
- no advisory funnel changes

## Validation
- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m pytest -q tests/test_b16_shortlist_persistence.py tests/test_b17_shortlist_api.py tests/test_b18_shortlist_save_remove.py tests/test_b19_shortlist_share_capability.py
- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m ruff check apps/api/routes/v1/shortlists.py packages/core/schemas/property_api.py tests/test_b19_shortlist_share_capability.py
- git diff --check