### PR TITLE
[V2][Sprint 2][Epic 2] Foreign Buyer Hub Ownership Basics Slice

### DIFF
--- a/apps/api/routes/v1/home_runtime.py
+++ b/apps/api/routes/v1/home_runtime.py
@@ -63,6 +63,7 @@ _PUBLIC_ROUTE_SUFFIXES = {
     "/terms",
     "/cookies",
     "/investment/methodology",
+    "/foreign-buyer-hub",
 }
 _DEFAULT_MEDIA_FALLBACK = "/media/library/variants/05032d16-54ae-45f4-bb89-3ae1fc2fa52f.webp"
 _MEDIA_ROOTS = [
@@ -6452,6 +6453,83 @@ def _render_how_we_work_page(locale: str, request: Request, db: Session) -> HTML
     )
 
 
+def _foreign_buyer_hub_copy(locale: str) -> dict[str, object]:
+    if locale == "th":
+        return {
+            "title": "Foreign Buyer Hub",
+            "intro": "ศูนย์ข้อมูลนี้เป็น guidance เชิงภาพรวมสำหรับผู้ซื้อต่างชาติในพัทยาเท่านั้น ไม่ใช่คำรับรองทางกฎหมาย ภาษี หรือสิทธิ์ที่ใช้ได้กับทุกกรณี",
+            "eyebrow": "Foreign Buyer Advisory",
+            "coverage_title": "สิ่งที่ slice แรกครอบคลุม",
+            "coverage_body": "เริ่มจาก ownership และ eligibility basics ก่อน เพื่อรวม guidance หลักไว้ในจุดเดียวโดยไม่เปลี่ยน funnel เดิมหรือหน้า V1 ที่มีอยู่",
+            "ownership_title": "Ownership and eligibility basics",
+            "ownership_points": [
+                "คอนโดบางยูนิตอาจเข้ากรอบ foreign quota ได้ แต่ availability และเอกสารต้องตรวจสอบเป็นรายทรัพย์",
+                "โครงสร้างการถือครองแบบอื่น เช่น leasehold หรือ company holding ต้องให้ที่ปรึกษาและทนายช่วยประเมินเป็นกรณี",
+                "หน้า hub นี้อธิบายจุดเริ่มต้นของการประเมินสิทธิ์ ไม่ใช่คำยืนยันว่าธุรกรรมจะทำได้โดยอัตโนมัติ",
+            ],
+            "review_title": "เมื่อใดที่ต้องขอ legal review",
+            "review_points": [
+                "เมื่อ ownership path ไม่ชัดเจนจากข้อมูลโครงการหรือเอกสารเบื้องต้น",
+                "เมื่อมีคำถามเรื่อง quota, สัญญา, ภาษี หรือการโอนเงินจากต่างประเทศ",
+                "เมื่อกรณีซื้อมีหลายผู้ถือสิทธิ์ หลายสัญชาติ หรือมีโครงสร้างที่ไม่ใช่มาตรฐาน",
+            ],
+            "advisory_title": "ขั้นตอนถัดไปที่ปลอดภัย",
+            "advisory_body": "หากต้องการประเมิน eligibility ของเคสจริง ให้ใช้ช่องทางติดต่อเดิมเพื่อให้ทีมช่วยคัด inventory ที่เหมาะสมและระบุจุดที่ควรให้ทนายตรวจเพิ่ม",
+            "primary_cta": "คุยกับทีมที่ปรึกษา",
+            "secondary_cta": "ดูโครงการที่เผยแพร่",
+        }
+    return {
+        "title": "Foreign Buyer Hub",
+        "intro": "This hub provides conservative, high-level guidance for foreign buyers in Pattaya. It is not a legal, tax, or eligibility guarantee for every case.",
+        "eyebrow": "Foreign Buyer Advisory",
+        "coverage_title": "What this first slice covers",
+        "coverage_body": "This first implementation slice opens the hub with ownership and eligibility basics only, keeping current V1 pages and the existing advisory funnel unchanged.",
+        "ownership_title": "Ownership and eligibility basics",
+        "ownership_points": [
+            "Some condo inventory may fit foreign-quota ownership, but availability and supporting documents must be checked case by case.",
+            "Other holding paths such as leasehold or company structures require advisor and legal review before they are treated as viable.",
+            "This hub explains the starting framework for ownership review. It does not certify that a transaction is automatically eligible.",
+        ],
+        "review_title": "When legal review is required",
+        "review_points": [
+            "When the ownership path is not clear from project facts or preliminary documents.",
+            "When quota, contract, tax, or funds-transfer questions affect the purchase decision.",
+            "When the purchase involves multiple owners, multiple jurisdictions, or a non-standard holding structure.",
+        ],
+        "advisory_title": "Safe next step",
+        "advisory_body": "For a live case, use the existing advisory path so the team can shortlist eligible inventory and flag where lawyer review is needed.",
+        "primary_cta": "Speak to an Advisor",
+        "secondary_cta": "Browse Published Projects",
+    }
+
+
+def _render_foreign_buyer_hub_page(locale: str, request: Request, db: Session) -> HTMLResponse:
+    copy = _foreign_buyer_hub_copy(locale)
+    ownership_html = "".join(
+        f"<li>{escape(point)}</li>" for point in copy["ownership_points"]
+    )
+    review_html = "".join(f"<li>{escape(point)}</li>" for point in copy["review_points"])
+    contact_href = f"/{locale}/contact?intent=consultation&source=foreign_buyer_hub"
+    projects_href = f"/{locale}/projects?source=foreign_buyer_hub"
+    body = (
+        f'<section id="foreign-buyer-coverage" class="card"><p class="muted">{escape(str(copy["eyebrow"]))}</p><h2>{escape(str(copy["coverage_title"]))}</h2><p>{escape(str(copy["coverage_body"]))}</p></section>'
+        f'<section id="foreign-buyer-ownership" class="card"><h2>{escape(str(copy["ownership_title"]))}</h2><ul>{ownership_html}</ul></section>'
+        f'<section id="foreign-buyer-legal-review" class="card"><h2>{escape(str(copy["review_title"]))}</h2><ul>{review_html}</ul></section>'
+        f'<section id="foreign-buyer-next-step" class="card"><h2>{escape(str(copy["advisory_title"]))}</h2><p>{escape(str(copy["advisory_body"]))}</p><div class="grid"><a class="btn" href="{escape(contact_href)}">{escape(str(copy["primary_cta"]))}</a><a class="btn" href="{escape(projects_href)}">{escape(str(copy["secondary_cta"]))}</a></div></section>'
+    )
+    return HTMLResponse(
+        _render_page_shell(
+            locale,
+            title=str(copy["title"]),
+            intro=str(copy["intro"]),
+            body=body,
+            request=request,
+            db=db,
+            meta_description=str(copy["intro"]),
+        )
+    )
+
+
 def _render_contact_page(locale: str, request: Request, db: Session) -> HTMLResponse:
     row = db.scalar(select(CompanyInfo).where(CompanyInfo.slug == "contact"))
     raw_content = str(row.content if row is not None else "").strip()
@@ -7237,3 +7315,10 @@ def render_investment_methodology(request: Request, db: Session = Depends(get_db
     )
     title = "Investment Methodology" if locale == "en" else "Investment Methodology"
     return _company_page(locale, "investment-methodology", title, fallback, request, db)
+
+
+@router.get("/en/foreign-buyer-hub", response_class=HTMLResponse)
+@router.get("/th/foreign-buyer-hub", response_class=HTMLResponse)
+def render_foreign_buyer_hub(request: Request, db: Session = Depends(get_db)) -> HTMLResponse:
+    locale = _request_locale(request)
+    return _render_foreign_buyer_hub_page(locale, request, db)

--- a/docs/contracts/AMP_V2_SPRINT_2_IMPLEMENTATION_GATE_2026-03-15.md
+++ b/docs/contracts/AMP_V2_SPRINT_2_IMPLEMENTATION_GATE_2026-03-15.md
@@ -7,9 +7,12 @@ Governance lock:
 
 ## Purpose
 
-This document opens the Sprint 2 implementation gate for the Saved Shortlist foundation only.
+This document opens the Sprint 2 implementation gate for:
 
-It does not activate Foreign Buyer Hub or Market Intelligence implementation.
+1. the completed Saved Shortlist foundation
+2. the first approved Foreign Buyer Hub implementation slice
+
+It does not activate Market Intelligence implementation.
 
 ## Gate Status
 
@@ -17,8 +20,8 @@ It does not activate Foreign Buyer Hub or Market Intelligence implementation.
 
 Meaning:
 
-- Saved Shortlist foundation work may begin in the approved execution order
-- Foreign Buyer Hub remains planning only
+- Saved Shortlist foundation is completed and merged on `main`
+- Foreign Buyer Hub is partially unlocked for the first approved ownership-basics slice only
 - Market Intelligence Public Module remains planning only
 
 Top-line reporting remains:
@@ -44,7 +47,7 @@ Sprint 1 completion reference:
 
 ## Allowed Implementation Scope
 
-Only the Saved Shortlist foundation is unlocked by this gate.
+Only these Sprint 2 scopes are unlocked by this gate:
 
 Allowed execution order:
 
@@ -52,8 +55,22 @@ Allowed execution order:
 2. Shortlist API
 3. Shortlist save/remove behavior
 4. Shortlist share capability
+5. `#453` Foreign Buyer Hub Ownership Basics Slice
 
 No later step may begin until the prior step is merged and validated.
+
+Foreign Buyer Hub slice `#453` is constrained to:
+
+- a new additive public runtime route family for the hub
+- ownership and eligibility guidance only
+- conservative advisory language only
+- an existing contact/advisor CTA path only
+
+The following Foreign Buyer Hub layers remain blocked after `#453` until separately approved and merged:
+
+- purchase process module expansion
+- document guidance module
+- FAQ and advisory decision module beyond the approved first slice
 
 ## Explicitly Blocked Scope
 
@@ -75,11 +92,11 @@ Every Sprint 2 implementation PR under this gate must:
 1. reference exactly one active Sprint 2 issue as primary scope
 2. state `V1 impact = none` unless an additive shared-surface touch is explicitly justified
 3. confirm no changes to CRM, lead forms, core layout, homepage structure, or advisory funnel
-4. stay within Saved Shortlist foundation scope only
+4. stay within the currently unlocked Sprint 2 slice only
 5. stop after CI and merge before moving to the next issue
 
 ## Exit Rule For This Stage
 
-This partial Sprint 2 gate remains valid only while shortlist foundation is executed in order.
+This partial Sprint 2 gate remains valid only while unlocked Sprint 2 slices are executed in order.
 
-If scope expands beyond shortlist foundation, implementation must stop and return to planning/governance review.
+If scope expands beyond the unlocked shortlist and Foreign Buyer Hub slice boundaries, implementation must stop and return to planning/governance review.

--- a/tests/test_a12_foreign_buyer_hub_runtime.py
+++ b/tests/test_a12_foreign_buyer_hub_runtime.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+
+def test_a12_foreign_buyer_hub_routes_render_conservative_guidance(client) -> None:
+    en_response = client.get("/en/foreign-buyer-hub")
+    assert en_response.status_code == 200, en_response.text
+    en_html = en_response.text
+
+    assert "Foreign Buyer Hub" in en_html
+    assert "ownership and eligibility basics" in en_html
+    assert "It is not a legal, tax, or eligibility guarantee" in en_html
+    assert 'href="/en/contact?intent=consultation&amp;source=foreign_buyer_hub"' in en_html
+    assert 'href="/en/projects?source=foreign_buyer_hub"' in en_html
+    assert "Some condo inventory may fit foreign-quota ownership" in en_html
+    assert "When legal review is required" in en_html
+    assert "<form" not in en_html
+
+    th_response = client.get("/th/foreign-buyer-hub")
+    assert th_response.status_code == 200, th_response.text
+    th_html = th_response.text
+
+    assert "Foreign Buyer Hub" in th_html
+    assert "ศูนย์ข้อมูลนี้เป็น guidance เชิงภาพรวมสำหรับผู้ซื้อต่างชาติในพัทยาเท่านั้น" in th_html
+    assert "Ownership and eligibility basics" in th_html
+    assert 'href="/th/contact?intent=consultation&amp;source=foreign_buyer_hub"' in th_html
+    assert "เมื่อใดที่ต้องขอ legal review" in th_html


### PR DESCRIPTION
## Scope
- open the first approved Foreign Buyer Hub runtime route family under `/en/foreign-buyer-hub` and `/th/foreign-buyer-hub`
- implement the ownership and eligibility module only
- keep the module advisory-only and link to the existing contact path without changing funnel ownership
- update the Sprint 2 implementation gate to unlock this slice only

## Why now
- Saved Shortlist foundation is complete and merged on `main` at `673f5a6d`
- Foreign Buyer Hub is the next approved Sprint 2 scope
- this slice opens the smallest governed public surface before any later process, document, or FAQ expansion

## Files touched
- `docs/contracts/AMP_V2_SPRINT_2_IMPLEMENTATION_GATE_2026-03-15.md`
- `apps/api/routes/v1/home_runtime.py`
- `tests/test_a12_foreign_buyer_hub_runtime.py`

## Guardrail check
- V1 pages untouched
- CRM untouched
- lead forms untouched
- core layout untouched
- homepage untouched
- advisory funnel untouched
- Market Intelligence untouched

## Validation
- `d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m pytest -q tests/test_a12_foreign_buyer_hub_runtime.py`
- `d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m pytest -q tests/test_a12_foreign_buyer_hub_runtime.py tests/test_a2_home_runtime_real_route.py -k ''foreign_buyer_hub or runtime_public_info_routes''`
- `d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m ruff check apps/api/routes/v1/home_runtime.py tests/test_a12_foreign_buyer_hub_runtime.py`
- `git diff --check`

## Risk
- conservative ownership wording could still be interpreted too broadly if later edits weaken the disclaimers
- route naming and section IDs become the base for later hub slices, so follow-on issues should extend rather than redesign them

## Rollback
- revert this PR to remove the route and restore the previous Sprint 2 gate text
- no data migration, CRM branching, or lead-flow rollback is required

Closes #453