### PR TITLE
[V2][Sprint 2][Epic 2] Foreign Buyer Hub Document Guidance Module

### DIFF
--- a/apps/api/routes/v1/home_runtime.py
+++ b/apps/api/routes/v1/home_runtime.py
@@ -6488,6 +6488,21 @@ def _foreign_buyer_hub_copy(locale: str) -> dict[str, object]:
                 },
             ],
             "process_note": "workflow นี้เป็นคำอธิบายเชิงโครงสร้าง ไม่ใช่ checklist ทางกฎหมายที่ครบถ้วนสำหรับทุกกรณี",
+            "documents_title": "Document guidance module",
+            "documents_intro": "ส่วนนี้สรุปหมวดเอกสารที่มักถูกถามถึงบ่อย เพื่อช่วยให้ผู้ซื้อต่างชาติเตรียมตัวได้ดีขึ้นโดยไม่สื่อว่าเป็นรายการบังคับครบถ้วนสำหรับทุกดีล",
+            "documents_common_title": "Common preparation categories",
+            "documents_common_points": [
+                "identity/passport baseline สำหรับยืนยันตัวตนและข้อมูลผู้ซื้อ",
+                "หลักฐานการโอนเงินหรือ funds transfer evidence ที่เกี่ยวข้องกับเส้นทางการชำระเงิน",
+                "เอกสารสัญญาหรือเงื่อนไขที่ควรให้ advisor และทนายช่วย review ก่อนลงนาม",
+            ],
+            "documents_case_title": "Case-specific reminders",
+            "documents_case_points": [
+                "โครงการใหม่กับ resale อาจต้องใช้เอกสารประกอบไม่เหมือนกัน แม้จะอยู่ใน budget หรือทำเลใกล้กัน",
+                "บางกรณีอาจต้องมีเอกสารเพิ่มเติมตาม ownership path, ผู้ถือสิทธิ์ร่วม, หรือแหล่งที่มาของเงินโอน",
+                "หากรายการเอกสารยังไม่ชัดเจน ควรยืนยันกับ advisor และ legal review แทนการตีความจาก list ทั่วไปเพียงอย่างเดียว",
+            ],
+            "documents_note": "หมวดเอกสารด้านบนเป็น guidance เพื่อการเตรียมตัว ไม่ใช่คำแนะนำทางกฎหมายหรือรายการที่รับรองว่าเพียงพอในทุกกรณี",
             "review_title": "เมื่อใดที่ต้องขอ legal review",
             "review_points": [
                 "เมื่อ ownership path ไม่ชัดเจนจากข้อมูลโครงการหรือเอกสารเบื้องต้น",
@@ -6532,6 +6547,21 @@ def _foreign_buyer_hub_copy(locale: str) -> dict[str, object]:
             },
         ],
         "process_note": "This workflow is explanatory only. It is not a complete legal checklist or a guarantee that every case follows the same path.",
+        "documents_title": "Document guidance module",
+        "documents_intro": "This section groups the document categories foreign buyers often need to prepare, while keeping the guidance advisory-safe and non-exhaustive.",
+        "documents_common_title": "Common preparation categories",
+        "documents_common_points": [
+            "Identity and passport baseline for confirming buyer identity and core party details.",
+            "Funds-transfer evidence guidance for the payment path and supporting remittance context.",
+            "Contract documents or terms that should be reviewed with an advisor and lawyer before signature.",
+        ],
+        "documents_case_title": "Case-specific reminders",
+        "documents_case_points": [
+            "New-development and resale purchases may require different supporting documents even when they fit the same budget or location brief.",
+            "Some cases need additional supporting records based on the ownership path, co-buyers, or the source of transferred funds.",
+            "If the document list is still unclear, confirm the case with advisor and legal review instead of relying on a generic checklist alone.",
+        ],
+        "documents_note": "These document categories are preparation guidance only. They are not legal instructions and they are not guaranteed to be sufficient for every case.",
         "review_title": "When legal review is required",
         "review_points": [
             "When the ownership path is not clear from project facts or preliminary documents.",
@@ -6554,6 +6584,12 @@ def _render_foreign_buyer_hub_page(locale: str, request: Request, db: Session) -
         f'<article class="card"><h3>{escape(str(step["title"]))}</h3><p>{escape(str(step["body"]))}</p></article>'
         for step in copy["process_steps"]
     )
+    documents_common_html = "".join(
+        f"<li>{escape(point)}</li>" for point in copy["documents_common_points"]
+    )
+    documents_case_html = "".join(
+        f"<li>{escape(point)}</li>" for point in copy["documents_case_points"]
+    )
     review_html = "".join(f"<li>{escape(point)}</li>" for point in copy["review_points"])
     contact_href = f"/{locale}/contact?intent=consultation&source=foreign_buyer_hub"
     projects_href = f"/{locale}/projects?source=foreign_buyer_hub"
@@ -6561,6 +6597,7 @@ def _render_foreign_buyer_hub_page(locale: str, request: Request, db: Session) -
         f'<section id="foreign-buyer-coverage" class="card"><p class="muted">{escape(str(copy["eyebrow"]))}</p><h2>{escape(str(copy["coverage_title"]))}</h2><p>{escape(str(copy["coverage_body"]))}</p></section>'
         f'<section id="foreign-buyer-ownership" class="card"><h2>{escape(str(copy["ownership_title"]))}</h2><ul>{ownership_html}</ul></section>'
         f'<section id="foreign-buyer-process" class="stack"><div class="card"><h2>{escape(str(copy["process_title"]))}</h2><p>{escape(str(copy["process_intro"]))}</p><p class="muted">{escape(str(copy["process_note"]))}</p></div><div class="grid">{process_steps_html}</div></section>'
+        f'<section id="foreign-buyer-documents" class="stack"><div class="card"><h2>{escape(str(copy["documents_title"]))}</h2><p>{escape(str(copy["documents_intro"]))}</p><p class="muted">{escape(str(copy["documents_note"]))}</p></div><div class="grid"><article class="card"><h3>{escape(str(copy["documents_common_title"]))}</h3><ul>{documents_common_html}</ul></article><article class="card"><h3>{escape(str(copy["documents_case_title"]))}</h3><ul>{documents_case_html}</ul></article></div></section>'
         f'<section id="foreign-buyer-legal-review" class="card"><h2>{escape(str(copy["review_title"]))}</h2><ul>{review_html}</ul></section>'
         f'<section id="foreign-buyer-next-step" class="card"><h2>{escape(str(copy["advisory_title"]))}</h2><p>{escape(str(copy["advisory_body"]))}</p><div class="grid"><a class="btn" href="{escape(contact_href)}">{escape(str(copy["primary_cta"]))}</a><a class="btn" href="{escape(projects_href)}">{escape(str(copy["secondary_cta"]))}</a></div></section>'
     )

--- a/docs/contracts/AMP_V2_SPRINT_2_IMPLEMENTATION_GATE_2026-03-15.md
+++ b/docs/contracts/AMP_V2_SPRINT_2_IMPLEMENTATION_GATE_2026-03-15.md
@@ -10,7 +10,7 @@ Governance lock:
 This document opens the Sprint 2 implementation gate for:
 
 1. the completed Saved Shortlist foundation
-2. the first two approved Foreign Buyer Hub implementation slices
+2. the first three approved Foreign Buyer Hub implementation slices
 
 It does not activate Market Intelligence implementation.
 
@@ -21,7 +21,7 @@ It does not activate Market Intelligence implementation.
 Meaning:
 
 - Saved Shortlist foundation is completed and merged on `main`
-- Foreign Buyer Hub is partially unlocked for the approved ownership-basics and buying-process slices only
+- Foreign Buyer Hub is partially unlocked for the approved ownership-basics, buying-process, and document-guidance slices only
 - Market Intelligence Public Module remains planning only
 
 Top-line reporting remains:
@@ -57,6 +57,7 @@ Allowed execution order:
 4. Shortlist share capability
 5. `#453` Foreign Buyer Hub Ownership Basics Slice
 6. `#455` Foreign Buyer Hub Buying Process Module
+7. `#457` Foreign Buyer Hub Document Guidance Module
 
 No later step may begin until the prior step is merged and validated.
 
@@ -76,7 +77,15 @@ Foreign Buyer Hub slice `#455` is constrained to:
 
 The following Foreign Buyer Hub layers remain blocked after `#455` until separately approved and merged:
 
-- document guidance module
+Foreign Buyer Hub slice `#457` is constrained to:
+
+- document categories overview only
+- advisory-safe explanations only
+- the existing contact/advisor CTA path only
+- no legal instructions or upload behavior
+
+The following Foreign Buyer Hub layers remain blocked after `#457` until separately approved and merged:
+
 - FAQ and advisory decision module beyond the approved first slice
 - any calculator, shortlist-integration, or funnel-behavior expansion
 

--- a/tests/test_a12_foreign_buyer_hub_runtime.py
+++ b/tests/test_a12_foreign_buyer_hub_runtime.py
@@ -13,6 +13,11 @@ def test_a12_foreign_buyer_hub_routes_render_conservative_guidance(client) -> No
     assert "Reservation and due diligence stage" in en_html
     assert "Transfer preparation" in en_html
     assert "Post-transfer support expectations" in en_html
+    assert "Document guidance module" in en_html
+    assert "Common preparation categories" in en_html
+    assert "Identity and passport baseline" in en_html
+    assert "Funds-transfer evidence guidance" in en_html
+    assert "These document categories are preparation guidance only" in en_html
     assert "It is not a legal, tax, or eligibility guarantee" in en_html
     assert "It is not a complete legal checklist" in en_html
     assert 'href="/en/contact?intent=consultation&amp;source=foreign_buyer_hub"' in en_html
@@ -31,6 +36,9 @@ def test_a12_foreign_buyer_hub_routes_render_conservative_guidance(client) -> No
     assert "Buying process module" in th_html
     assert "ลำดับด้านล่างเป็น roadmap เชิงอธิบายสำหรับผู้ซื้อต่างชาติ" in th_html
     assert "1. Discovery and shortlist review" in th_html
+    assert "Document guidance module" in th_html
+    assert "หมวดเอกสารด้านบนเป็น guidance เพื่อการเตรียมตัว" in th_html
+    assert "identity/passport baseline" in th_html
     assert "workflow นี้เป็นคำอธิบายเชิงโครงสร้าง" in th_html
     assert 'href="/th/contact?intent=consultation&amp;source=foreign_buyer_hub"' in th_html
     assert "เมื่อใดที่ต้องขอ legal review" in th_html


### PR DESCRIPTION
## Summary
- unlock Sprint 2 gate for issue #457 document guidance slice only
- add advisory-safe document guidance content to the existing foreign buyer hub runtime route
- extend the targeted foreign buyer hub runtime test for the new section

## Scope
- document categories overview only
- advisory-safe explanations only
- existing advisor/contact CTA only

## Validation
- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m pytest -q tests/test_a12_foreign_buyer_hub_runtime.py
- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m pytest -q tests/test_a10_contact_about_sell_runtime.py tests/test_a11_smart_finder_compare_runtime.py
- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m ruff check apps/api/routes/v1/home_runtime.py tests/test_a12_foreign_buyer_hub_runtime.py
- git diff --check

Closes #457