### PR TITLE
[V2][Sprint 2][Epic 2] Foreign Buyer Hub FAQ Clarification Module

### DIFF
--- a/apps/api/routes/v1/home_runtime.py
+++ b/apps/api/routes/v1/home_runtime.py
@@ -6503,6 +6503,27 @@ def _foreign_buyer_hub_copy(locale: str) -> dict[str, object]:
                 "หากรายการเอกสารยังไม่ชัดเจน ควรยืนยันกับ advisor และ legal review แทนการตีความจาก list ทั่วไปเพียงอย่างเดียว",
             ],
             "documents_note": "หมวดเอกสารด้านบนเป็น guidance เพื่อการเตรียมตัว ไม่ใช่คำแนะนำทางกฎหมายหรือรายการที่รับรองว่าเพียงพอในทุกกรณี",
+            "faq_title": "FAQ / clarification module",
+            "faq_intro": "คำถามด้านล่างตอบข้อสงสัยที่พบบ่อยในระดับภาพรวม เพื่อช่วยจัดลำดับการถามทีมที่ปรึกษาโดยไม่แทนคำแนะนำเฉพาะเคส",
+            "faq_items": [
+                {
+                    "question": "การซื้อของผู้ซื้อต่างชาติมักใช้เวลานานแค่ไหน?",
+                    "answer": "timeline ต่างกันตามประเภททรัพย์, readiness ของเอกสาร, และจังหวะ review ของคู่สัญญา จึงควรใช้ช่วงเวลาใน hub นี้เป็นแนวคิด ไม่ใช่กำหนดการที่รับประกันได้",
+                },
+                {
+                    "question": "ควรถามเรื่องค่าใช้จ่ายอะไรตั้งแต่ต้น?",
+                    "answer": "ควรเริ่มจากภาพรวมของราคาซื้อ ค่าจอง ค่าธรรมเนียมวันโอน และค่าใช้จ่ายหลังโอนที่อาจตามมา แต่ตัวเลขจริงต้องยืนยันกับทีมและเอกสารของดีลนั้น",
+                },
+                {
+                    "question": "ถ้ายังไม่แน่ใจเรื่อง ownership path ควรทำอย่างไร?",
+                    "answer": "อย่าตัดสินจากคำอธิบายทั่วไปเพียงอย่างเดียว ควรให้ advisor ช่วยคัด inventory ที่เข้ากรอบเบื้องต้นและชี้จุดที่ต้องมี legal review เพิ่ม",
+                },
+                {
+                    "question": "เมื่อไรควร escalate ไปหา advisor หรือ lawyer?",
+                    "answer": "หากมีความไม่ชัดเจนเรื่องสิทธิ์ถือครอง, ค่าใช้จ่าย, เงื่อนไขสัญญา, หรือเอกสารที่ต้องใช้ ควรกลับเข้าสู่ advisor path เดิมและยกระดับไป legal review ก่อน commit",
+                },
+            ],
+            "faq_note": "FAQ นี้ออกแบบมาเพื่อ clarification ระดับต้น ไม่ใช่ชุดคำตอบทางกฎหมาย การเงิน หรือภาษีที่ใช้แทนการ review รายกรณี",
             "review_title": "เมื่อใดที่ต้องขอ legal review",
             "review_points": [
                 "เมื่อ ownership path ไม่ชัดเจนจากข้อมูลโครงการหรือเอกสารเบื้องต้น",
@@ -6562,6 +6583,27 @@ def _foreign_buyer_hub_copy(locale: str) -> dict[str, object]:
             "If the document list is still unclear, confirm the case with advisor and legal review instead of relying on a generic checklist alone.",
         ],
         "documents_note": "These document categories are preparation guidance only. They are not legal instructions and they are not guaranteed to be sufficient for every case.",
+        "faq_title": "FAQ / clarification module",
+        "faq_intro": "These short answers address recurring foreign-buyer questions at a high level, while preserving the advisor path for case-specific advice.",
+        "faq_items": [
+            {
+                "question": "How long does a foreign-buyer purchase usually take?",
+                "answer": "Timing varies by property type, document readiness, and how quickly the parties can complete reviews, so any timeline here should be treated as orientation only rather than a guarantee.",
+            },
+            {
+                "question": "Which costs should be clarified early?",
+                "answer": "Start with the purchase price, reservation amount, transfer-day fees, and likely post-transfer costs, then confirm the actual numbers against the live deal documents and advisor guidance.",
+            },
+            {
+                "question": "What if the ownership path is still unclear?",
+                "answer": "Do not rely on generic summaries alone. Use the advisor path to narrow eligible inventory first and identify where legal review needs to step in.",
+            },
+            {
+                "question": "When should the case be escalated to an advisor or lawyer?",
+                "answer": "If ownership eligibility, costs, contract terms, or required documents remain unclear, the case should move back into the existing advisor path and legal review before commitment.",
+            },
+        ],
+        "faq_note": "This FAQ is for early clarification only. It is not legal, financial, or tax advice and it should not replace case-specific review.",
         "review_title": "When legal review is required",
         "review_points": [
             "When the ownership path is not clear from project facts or preliminary documents.",
@@ -6590,6 +6632,10 @@ def _render_foreign_buyer_hub_page(locale: str, request: Request, db: Session) -
     documents_case_html = "".join(
         f"<li>{escape(point)}</li>" for point in copy["documents_case_points"]
     )
+    faq_html = "".join(
+        f'<article class="card"><h3>{escape(str(item["question"]))}</h3><p>{escape(str(item["answer"]))}</p></article>'
+        for item in copy["faq_items"]
+    )
     review_html = "".join(f"<li>{escape(point)}</li>" for point in copy["review_points"])
     contact_href = f"/{locale}/contact?intent=consultation&source=foreign_buyer_hub"
     projects_href = f"/{locale}/projects?source=foreign_buyer_hub"
@@ -6598,6 +6644,7 @@ def _render_foreign_buyer_hub_page(locale: str, request: Request, db: Session) -
         f'<section id="foreign-buyer-ownership" class="card"><h2>{escape(str(copy["ownership_title"]))}</h2><ul>{ownership_html}</ul></section>'
         f'<section id="foreign-buyer-process" class="stack"><div class="card"><h2>{escape(str(copy["process_title"]))}</h2><p>{escape(str(copy["process_intro"]))}</p><p class="muted">{escape(str(copy["process_note"]))}</p></div><div class="grid">{process_steps_html}</div></section>'
         f'<section id="foreign-buyer-documents" class="stack"><div class="card"><h2>{escape(str(copy["documents_title"]))}</h2><p>{escape(str(copy["documents_intro"]))}</p><p class="muted">{escape(str(copy["documents_note"]))}</p></div><div class="grid"><article class="card"><h3>{escape(str(copy["documents_common_title"]))}</h3><ul>{documents_common_html}</ul></article><article class="card"><h3>{escape(str(copy["documents_case_title"]))}</h3><ul>{documents_case_html}</ul></article></div></section>'
+        f'<section id="foreign-buyer-faq" class="stack"><div class="card"><h2>{escape(str(copy["faq_title"]))}</h2><p>{escape(str(copy["faq_intro"]))}</p><p class="muted">{escape(str(copy["faq_note"]))}</p></div><div class="grid">{faq_html}</div></section>'
         f'<section id="foreign-buyer-legal-review" class="card"><h2>{escape(str(copy["review_title"]))}</h2><ul>{review_html}</ul></section>'
         f'<section id="foreign-buyer-next-step" class="card"><h2>{escape(str(copy["advisory_title"]))}</h2><p>{escape(str(copy["advisory_body"]))}</p><div class="grid"><a class="btn" href="{escape(contact_href)}">{escape(str(copy["primary_cta"]))}</a><a class="btn" href="{escape(projects_href)}">{escape(str(copy["secondary_cta"]))}</a></div></section>'
     )

--- a/docs/contracts/AMP_V2_SPRINT_2_IMPLEMENTATION_GATE_2026-03-15.md
+++ b/docs/contracts/AMP_V2_SPRINT_2_IMPLEMENTATION_GATE_2026-03-15.md
@@ -10,7 +10,7 @@ Governance lock:
 This document opens the Sprint 2 implementation gate for:
 
 1. the completed Saved Shortlist foundation
-2. the first three approved Foreign Buyer Hub implementation slices
+2. the first four approved Foreign Buyer Hub implementation slices
 
 It does not activate Market Intelligence implementation.
 
@@ -21,7 +21,7 @@ It does not activate Market Intelligence implementation.
 Meaning:
 
 - Saved Shortlist foundation is completed and merged on `main`
-- Foreign Buyer Hub is partially unlocked for the approved ownership-basics, buying-process, and document-guidance slices only
+- Foreign Buyer Hub is partially unlocked for the approved ownership-basics, buying-process, document-guidance, and FAQ/clarification slices only
 - Market Intelligence Public Module remains planning only
 
 Top-line reporting remains:
@@ -58,6 +58,7 @@ Allowed execution order:
 5. `#453` Foreign Buyer Hub Ownership Basics Slice
 6. `#455` Foreign Buyer Hub Buying Process Module
 7. `#457` Foreign Buyer Hub Document Guidance Module
+8. `#459` Foreign Buyer Hub FAQ Clarification Module
 
 No later step may begin until the prior step is merged and validated.
 
@@ -84,9 +85,15 @@ Foreign Buyer Hub slice `#457` is constrained to:
 - the existing contact/advisor CTA path only
 - no legal instructions or upload behavior
 
-The following Foreign Buyer Hub layers remain blocked after `#457` until separately approved and merged:
+Foreign Buyer Hub slice `#459` is constrained to:
 
-- FAQ and advisory decision module beyond the approved first slice
+- short FAQ and clarification blocks only
+- common foreign-buyer concerns only
+- advisory-safe wording only
+- the existing contact/advisor CTA path only
+
+The following Foreign Buyer Hub layers remain blocked after `#459` until separately approved and merged:
+
 - any calculator, shortlist-integration, or funnel-behavior expansion
 
 ## Explicitly Blocked Scope

--- a/tests/test_a12_foreign_buyer_hub_runtime.py
+++ b/tests/test_a12_foreign_buyer_hub_runtime.py
@@ -18,6 +18,10 @@ def test_a12_foreign_buyer_hub_routes_render_conservative_guidance(client) -> No
     assert "Identity and passport baseline" in en_html
     assert "Funds-transfer evidence guidance" in en_html
     assert "These document categories are preparation guidance only" in en_html
+    assert "FAQ / clarification module" in en_html
+    assert "How long does a foreign-buyer purchase usually take?" in en_html
+    assert "Which costs should be clarified early?" in en_html
+    assert "This FAQ is for early clarification only" in en_html
     assert "It is not a legal, tax, or eligibility guarantee" in en_html
     assert "It is not a complete legal checklist" in en_html
     assert 'href="/en/contact?intent=consultation&amp;source=foreign_buyer_hub"' in en_html
@@ -39,6 +43,9 @@ def test_a12_foreign_buyer_hub_routes_render_conservative_guidance(client) -> No
     assert "Document guidance module" in th_html
     assert "หมวดเอกสารด้านบนเป็น guidance เพื่อการเตรียมตัว" in th_html
     assert "identity/passport baseline" in th_html
+    assert "FAQ / clarification module" in th_html
+    assert "การซื้อของผู้ซื้อต่างชาติมักใช้เวลานานแค่ไหน?" in th_html
+    assert "FAQ นี้ออกแบบมาเพื่อ clarification ระดับต้น" in th_html
     assert "workflow นี้เป็นคำอธิบายเชิงโครงสร้าง" in th_html
     assert 'href="/th/contact?intent=consultation&amp;source=foreign_buyer_hub"' in th_html
     assert "เมื่อใดที่ต้องขอ legal review" in th_html


### PR DESCRIPTION
## Scope\n- add a short FAQ / clarification module to the existing Foreign Buyer Hub\n- answer common foreign buyer questions with conservative advisory-safe wording\n- keep the existing contact/advisor CTA path unchanged\n\n## Why now\n- the basics, buying process, and document guidance slices are already merged on main\n- this is the next smallest approved Foreign Buyer Hub slice that improves clarification without opening new funnel or CRM scope\n\n## Files touched\n- docs/contracts/AMP_V2_SPRINT_2_IMPLEMENTATION_GATE_2026-03-15.md\n- apps/api/routes/v1/home_runtime.py\n- tests/test_a12_foreign_buyer_hub_runtime.py\n\n## Guardrail check\n- additive only\n- existing hub route extended in place\n- V1 pages untouched\n- CRM untouched\n- lead forms untouched\n- core layout untouched\n- homepage/advisory funnel untouched\n- Market Intelligence still blocked\n\n## Validation\n- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m pytest -q tests/test_a12_foreign_buyer_hub_runtime.py\n- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m pytest -q tests/test_a10_contact_about_sell_runtime.py tests/test_a11_smart_finder_compare_runtime.py\n- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m ruff check apps/api/routes/v1/home_runtime.py tests/test_a12_foreign_buyer_hub_runtime.py\n- git diff --check\n\n## Risk\n- low; additive content-only expansion on an existing public information route\n\n## Rollback\n- revert this PR to remove the FAQ module and restore the prior hub output\n\nCloses #459