### PR TITLE
[V2][Sprint 2][Market Intelligence] Data Source Classification Layer

### DIFF
--- a/apps/api/routes/v1/home_runtime.py
+++ b/apps/api/routes/v1/home_runtime.py
@@ -6678,16 +6678,156 @@ def _market_intelligence_copy(locale: str) -> dict[str, object]:
     }
 
 
+def _market_intelligence_source_classes(locale: str) -> list[dict[str, object]]:
+    if locale == "th":
+        return [
+            {
+                "slug": "public",
+                "title": "Public",
+                "summary": "ใช้กับข้อมูลที่เผยแพร่สู่สาธารณะได้อยู่แล้วและตรวจสอบซ้ำได้จากแหล่งที่ผ่านการกำกับ",
+                "examples": [
+                    "approved public inventory counts",
+                    "published area or project statistics",
+                    "approved methodology and disclosure copy",
+                ],
+                "freshness": "รองรับ cadence แบบ fast หรือ governed ตามชนิดของข้อมูล",
+                "public_note": "เผยแพร่บนหน้า public ได้เมื่อมี source, freshness, และ disclosure รองรับ",
+            },
+            {
+                "slug": "curated",
+                "title": "Curated",
+                "summary": "ใช้กับบทสรุปหรือ synthesis ที่ผ่านการ review แล้วและปลอดภัยสำหรับ public แม้ไม่ใช่ raw self-serve data",
+                "examples": [
+                    "editorial market commentary",
+                    "governed directional summaries",
+                    "approved narrative interpretation tied to dated inputs",
+                ],
+                "freshness": "ต้องมี review rhythm หรือ freshness disclosure ที่มองเห็นได้",
+                "public_note": "เผยแพร่ได้เมื่อผ่าน governance review และไม่ยกระดับความมั่นใจเกิน source ที่รองรับ",
+            },
+            {
+                "slug": "advisor-only",
+                "title": "Advisor-only",
+                "summary": "ใช้กับข้อมูลภายในที่ช่วยการตีความของทีม แต่ห้ามแสดงออกสู่ public module ใน gate นี้",
+                "examples": [
+                    "unpublished operator observations",
+                    "deal-specific negotiation context",
+                    "private shortlist recommendations",
+                ],
+                "freshness": "ใช้ได้เฉพาะในการ review ภายใน ไม่ใช่ cadence สำหรับ public publication",
+                "public_note": "จัดเป็น boundary class เพื่อบอกสิ่งที่ห้ามเผยแพร่ ไม่ใช่ source class ที่ render เป็น market claim สาธารณะ",
+            },
+        ]
+    return [
+        {
+            "slug": "public",
+            "title": "Public",
+            "summary": "Use this class for information already approved for public presentation and reproducible from governed public-facing sources.",
+            "examples": [
+                "Approved public inventory counts",
+                "Published area or project statistics",
+                "Approved methodology and disclosure copy",
+            ],
+            "freshness": "Supports fast or governed cadence depending on the data type.",
+            "public_note": "This class may appear on the public route when source, freshness, and disclosure support are visible.",
+        },
+        {
+            "slug": "curated",
+            "title": "Curated",
+            "summary": "Use this class for reviewed synthesis that is public-safe even when it is not exposed as raw self-serve data.",
+            "examples": [
+                "Editorial market commentary",
+                "Governed directional summaries",
+                "Approved narrative interpretation tied to dated inputs",
+            ],
+            "freshness": "Requires a visible review rhythm or equivalent freshness disclosure.",
+            "public_note": "This class may publish only after governance review and must not overstate confidence beyond the supporting source inputs.",
+        },
+        {
+            "slug": "advisor-only",
+            "title": "Advisor-only",
+            "summary": "Use this class for internal context that can assist advisory review but must not surface on the public module during this gate.",
+            "examples": [
+                "Unpublished operator observations",
+                "Deal-specific negotiation context",
+                "Private shortlist recommendations",
+            ],
+            "freshness": "Internal review only, not a public publication cadence.",
+            "public_note": "This is a boundary class that defines what stays excluded from public market claims.",
+        },
+    ]
+
+
+def _market_intelligence_report_regions(locale: str) -> list[dict[str, object]]:
+    if locale == "th":
+        return [
+            {
+                "title": "Market overview region",
+                "allowed_classes": "public, curated",
+                "rule": "เริ่มจาก directional snapshot ที่มี source class ชัดเจน และยังไม่ใช้ advisor-only commentary",
+            },
+            {
+                "title": "Area comparison region",
+                "allowed_classes": "public, curated",
+                "rule": "เปรียบเทียบได้เฉพาะสัญญาณที่กำกับแหล่งข้อมูลและความสดใหม่ได้อย่างชัดเจน",
+            },
+            {
+                "title": "Investment signals region",
+                "allowed_classes": "public, curated",
+                "rule": "ใช้ได้เฉพาะ confidence-qualified public context และยังไม่เปิด deal-specific strategy",
+            },
+            {
+                "title": "Methodology / disclaimer region",
+                "allowed_classes": "public",
+                "rule": "ต้องเป็น disclosure ที่อนุมัติแล้วและใช้เป็น boundary ของทั้งหน้า",
+            },
+        ]
+    return [
+        {
+            "title": "Market overview region",
+            "allowed_classes": "public, curated",
+            "rule": "Start with directional snapshots that already carry a clear source class and do not depend on advisor-only commentary.",
+        },
+        {
+            "title": "Area comparison region",
+            "allowed_classes": "public, curated",
+            "rule": "Only compare signals whose source and freshness can be governed clearly on the public route.",
+        },
+        {
+            "title": "Investment signals region",
+            "allowed_classes": "public, curated",
+            "rule": "Use confidence-qualified public context only and keep deal-specific strategy outside this slice.",
+        },
+        {
+            "title": "Methodology / disclaimer region",
+            "allowed_classes": "public",
+            "rule": "This region must stay on approved disclosure language and act as the page-level boundary note.",
+        },
+    ]
+
+
 def _render_market_intelligence_page(locale: str, request: Request, db: Session) -> HTMLResponse:
     copy = _market_intelligence_copy(locale)
+    source_classes = _market_intelligence_source_classes(locale)
+    report_regions = _market_intelligence_report_regions(locale)
     boundary_html = "".join(f"<li>{escape(point)}</li>" for point in copy["boundary_points"])
     freshness_html = "".join(f"<li>{escape(point)}</li>" for point in copy["freshness_points"])
     next_html = "".join(f"<li>{escape(point)}</li>" for point in copy["next_points"])
+    source_class_html = "".join(
+        f'<article class="card"><p class="muted">{escape(str(source_class["slug"]))}</p><h3>{escape(str(source_class["title"]))}</h3><p>{escape(str(source_class["summary"]))}</p><p><strong>{"Examples" if locale == "en" else "Examples"}:</strong></p><ul>{"".join(f"<li>{escape(str(example))}</li>" for example in source_class["examples"])}</ul><p><strong>{"Freshness" if locale == "en" else "Freshness"}:</strong> {escape(str(source_class["freshness"]))}</p><p class="muted">{escape(str(source_class["public_note"]))}</p></article>'
+        for source_class in source_classes
+    )
+    report_region_html = "".join(
+        f'<article class="card"><h3>{escape(str(region["title"]))}</h3><p><strong>{"Allowed classes" if locale == "en" else "Allowed classes"}:</strong> {escape(str(region["allowed_classes"]))}</p><p>{escape(str(region["rule"]))}</p></article>'
+        for region in report_regions
+    )
     contact_href = f"/{locale}/contact?intent=consultation&source=market_intelligence"
     methodology_href = f"/{locale}/investment/methodology?source=market_intelligence"
     body = (
         f'<section id="market-intelligence-overview" class="card"><p class="muted">{escape(str(copy["eyebrow"]))}</p><h2>{escape(str(copy["overview_title"]))}</h2><p>{escape(str(copy["overview_body"]))}</p><p class="muted">{escape(str(copy["note"]))}</p></section>'
         f'<section id="market-intelligence-boundary" class="card"><h2>{escape(str(copy["boundary_title"]))}</h2><ul>{boundary_html}</ul></section>'
+        f'<section id="market-intelligence-source-classes" class="stack"><div class="card"><h2>{"Source classification layer" if locale == "en" else "Source classification layer"}</h2><p>{"Every public block in this module must resolve to a governed source class before later chart or interpretation slices expand." if locale == "en" else "ทุก block ที่เผยแพร่บน module นี้ต้องผูกกับ source class ที่กำกับได้ก่อนที่ slice ถัดไปจะขยายไปสู่ charts หรือ interpretation"}</p></div><div class="grid">{source_class_html}</div></section>'
+        f'<section id="market-intelligence-region-contract" class="stack"><div class="card"><h2>{"Report region contract" if locale == "en" else "Report region contract"}</h2><p>{"This slice prepares the runtime structure for later chart and report regions without enabling those deeper layers yet." if locale == "en" else "slice นี้เตรียมโครงสร้าง runtime สำหรับ report regions ถัดไป โดยยังไม่เปิดใช้งาน layers ที่ลึกกว่านี้"}</p></div><div class="grid">{report_region_html}</div></section>'
         f'<section id="market-intelligence-freshness" class="card"><h2>{escape(str(copy["freshness_title"]))}</h2><ul>{freshness_html}</ul></section>'
         f'<section id="market-intelligence-next" class="card"><h2>{escape(str(copy["next_title"]))}</h2><ul>{next_html}</ul></section>'
         f'<section id="market-intelligence-next-step" class="card"><h2>{"Advisor follow-up" if locale == "en" else "การคุยต่อกับทีมที่ปรึกษา"}</h2><div class="grid"><a class="btn" href="{escape(contact_href)}">{escape(str(copy["primary_cta"]))}</a><a class="btn" href="{escape(methodology_href)}">{escape(str(copy["secondary_cta"]))}</a></div></section>'

--- a/tests/test_a13_market_intelligence_runtime.py
+++ b/tests/test_a13_market_intelligence_runtime.py
@@ -9,9 +9,20 @@ def test_a13_market_intelligence_route_owner_renders_public_safe_shell(client) -
     assert "Market Intelligence" in en_html
     assert "What this slice activates" in en_html
     assert "Public-safe boundary" in en_html
+    assert "Source classification layer" in en_html
+    assert "Report region contract" in en_html
     assert "Freshness and methodology framing" in en_html
     assert "What later slices add" in en_html
     assert "This page shell is not a full market report yet" in en_html
+    assert "Approved public inventory counts" in en_html
+    assert "Editorial market commentary" in en_html
+    assert "Advisor-only" in en_html
+    assert (
+        "This is a boundary class that defines what stays excluded from public market claims."
+        in en_html
+    )
+    assert "Allowed classes" in en_html
+    assert "Methodology / disclaimer region" in en_html
     assert 'href="/en/contact?intent=consultation&amp;source=market_intelligence"' in en_html
     assert 'href="/en/investment/methodology?source=market_intelligence"' in en_html
     assert "Advisor-only signals, negotiation notes" in en_html
@@ -27,9 +38,15 @@ def test_a13_market_intelligence_route_owner_renders_public_safe_shell(client) -
     assert "Market Intelligence" in th_html
     assert "หน้านี้เป็น route owner สำหรับ Market Intelligence module" in th_html
     assert "Public-safe boundary" in th_html
+    assert "Source classification layer" in th_html
+    assert "Report region contract" in th_html
     assert "Freshness and methodology framing" in th_html
     assert "สิ่งที่จะตามมาใน slice ถัดไป" in th_html
     assert "page shell นี้ยังไม่ใช่รายงานตลาดฉบับสมบูรณ์" in th_html
+    assert "approved public inventory counts" in th_html
+    assert "editorial market commentary" in th_html
+    assert "จัดเป็น boundary class เพื่อบอกสิ่งที่ห้ามเผยแพร่" in th_html
+    assert "Methodology / disclaimer region" in th_html
     assert 'href="/th/contact?intent=consultation&amp;source=market_intelligence"' in th_html
     assert 'href="/th/investment/methodology?source=market_intelligence"' in th_html
     assert "ข้อมูล advisor-only, negotiation notes" in th_html


### PR DESCRIPTION
## Scope\n- implement slice 2 from the Market Intelligence implementation gate\n- define the public module source classes in runtime/code form\n- separate public-safe, curated, and advisor-only boundaries without exposing advisor-only data\n- prepare the runtime structure for later chart/report slices\n\n## Why now\n- slice 1 route owner and page shell is already merged on main\n- later chart and interpretation slices need a governed source-class contract before they can expand safely\n\n## Files touched\n- apps/api/routes/v1/home_runtime.py\n- tests/test_a13_market_intelligence_runtime.py\n\n## Guardrail check\n- additive only\n- V1 pages untouched\n- CRM untouched\n- lead forms untouched\n- core layout untouched\n- homepage/advisory funnel untouched\n- no advisor-only data exposed publicly\n\n## Validation\n- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m pytest -q tests/test_a13_market_intelligence_runtime.py\n- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m pytest -q tests/test_a12_foreign_buyer_hub_runtime.py tests/test_a10_contact_about_sell_runtime.py tests/test_a11_smart_finder_compare_runtime.py\n- d:/FlowBiz/flowbiz-client-amp/.venv/Scripts/python.exe -m ruff check apps/api/routes/v1/home_runtime.py tests/test_a13_market_intelligence_runtime.py\n- git diff --check\n\n## Risk\n- low; this slice only adds classification metadata and public-safe boundary structure for later Market Intelligence layers\n\n## Rollback\n- revert this PR to remove the source classification layer and restore the slice 1 Market Intelligence shell\n\nCloses #463