### PR TITLE
feat: add shortlist review surface

### DIFF
--- a/admin-app/__tests__/shortlist_list_surface.test.tsx
+++ b/admin-app/__tests__/shortlist_list_surface.test.tsx
@@ -1,0 +1,117 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { ShortlistListSurface } from '@/components/shortlist/ShortlistListSurface';
+
+describe('ShortlistListSurface', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders saved shortlist items in shortlist order with listing links', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        shortlist: {
+          id: 'shortlist-1',
+          owner_type: 'session',
+          owner_key: 'owner-1',
+          status: 'active',
+          title: null,
+          intent: null,
+          share_mode: null,
+          source_context: null,
+          created_at: '2026-03-15T00:00:00Z',
+          updated_at: '2026-03-15T00:00:00Z',
+          last_viewed_at: null,
+          item_count: 2,
+          items: [
+            {
+              property_id: 'property-2',
+              slug: 'beta-residence',
+              title: 'Beta Residence',
+              project: 'Beta Project',
+              location: 'Jomtien',
+              price: 4900000,
+              size: 48,
+              bedrooms: 1,
+              bathrooms: 1,
+              image: null,
+              status: 'published',
+              foreign_quota: false,
+              position: 1,
+              added_at: '2026-03-15T00:00:00Z',
+              source_surface: 'buy_listing_card',
+            },
+            {
+              property_id: 'property-1',
+              slug: 'alpha-residence',
+              title: 'Alpha Residence',
+              project: 'Alpha Project',
+              location: 'Central Pattaya',
+              price: 6200000,
+              size: 56,
+              bedrooms: 2,
+              bathrooms: 2,
+              image: null,
+              status: 'published',
+              foreign_quota: true,
+              position: 0,
+              added_at: '2026-03-15T00:00:00Z',
+              source_surface: 'property_detail',
+            },
+          ],
+        },
+      }),
+    }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ShortlistListSurface locale="en" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Alpha Residence' })).toBeTruthy();
+    });
+
+    expect(screen.getAllByRole('heading', { level: 3 }).map((node) => node.textContent)).toEqual([
+      'Alpha Residence',
+      'Beta Residence',
+    ]);
+    expect(screen.getAllByRole('link', { name: /view listing details/i })[0]?.getAttribute('href')).toBe('/en/property/alpha-residence');
+    expect(screen.getByText(/foreign quota signal/i)).toBeTruthy();
+  });
+
+  it('renders an empty state when the shortlist has no items', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        shortlist: {
+          id: 'shortlist-1',
+          owner_type: 'session',
+          owner_key: 'owner-1',
+          status: 'active',
+          title: null,
+          intent: null,
+          share_mode: null,
+          source_context: null,
+          created_at: '2026-03-15T00:00:00Z',
+          updated_at: '2026-03-15T00:00:00Z',
+          last_viewed_at: null,
+          item_count: 0,
+          items: [],
+        },
+      }),
+    }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ShortlistListSurface locale="en" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/your shortlist is still empty/i)).toBeTruthy();
+    });
+
+    expect(screen.getByRole('link', { name: /browse shortlist-ready listings/i }).getAttribute('href')).toBe('/en/buy');
+  });
+});

--- a/admin-app/__tests__/shortlist_save_button.test.tsx
+++ b/admin-app/__tests__/shortlist_save_button.test.tsx
@@ -45,6 +45,8 @@ describe('ShortlistSaveButton', () => {
       expect(screen.getByRole('button', { name: /saved \(2\)/i })).toBeTruthy();
     });
 
+    expect(screen.getByRole('link', { name: /view shortlist \(2\)/i }).getAttribute('href')).toBe('/en/shortlist');
+
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(localStorage.getItem('amp_shortlist_owner_v1')).toBeTruthy();
   });
@@ -74,5 +76,7 @@ describe('ShortlistSaveButton', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /saved \(3\)/i })).toBeTruthy();
     });
+
+    expect(screen.getByRole('link', { name: /view shortlist \(3\)/i }).getAttribute('href')).toBe('/en/shortlist');
   });
 });

--- a/admin-app/app/(site)/[locale]/shortlist/page.tsx
+++ b/admin-app/app/(site)/[locale]/shortlist/page.tsx
@@ -1,0 +1,59 @@
+import { Breadcrumbs } from '@/components/layout/Breadcrumbs';
+import { Container } from '@/components/layout/Container';
+import { ShortlistListSurface } from '@/components/shortlist/ShortlistListSurface';
+import { getDictionary, normalizeLocale } from '@/app/_lib/i18n/get-dictionary';
+import { makePageMetadata } from '@/app/_lib/i18n/metadata';
+
+export const revalidate = 300;
+
+export async function generateMetadata(
+  props: {
+    params: Promise<{ locale: string }>;
+  }
+) {
+  const params = await props.params;
+  const locale = normalizeLocale(params.locale);
+  const dict = getDictionary(locale);
+  return makePageMetadata(
+    locale,
+    'shortlist',
+    locale === 'th' ? 'Shortlist ของคุณ' : 'Your Shortlist',
+    locale === 'th'
+      ? 'ทบทวน listing ที่บันทึกไว้ พร้อมข้อมูลสั้นที่ใช้ตัดสินใจต่อได้ทันที'
+      : 'Review your saved listings with concise facts and clear next steps.',
+    dict.brand.name,
+  );
+}
+
+export default async function ShortlistPage(props: { params: Promise<{ locale: string }> }) {
+  const params = await props.params;
+  const locale = normalizeLocale(params.locale);
+
+  return (
+    <main id="main-content">
+      <Breadcrumbs
+        items={[
+          { label: locale === 'th' ? 'หน้าแรก' : 'Home', href: `/${locale}` },
+          { label: locale === 'th' ? 'Shortlist' : 'Shortlist', href: `/${locale}/shortlist` },
+        ]}
+      />
+
+      <section className="hero hero--page">
+        <Container>
+          <h1 className="headline">{locale === 'th' ? 'Shortlist ของคุณ' : 'Your shortlist'}</h1>
+          <p className="subhead">
+            {locale === 'th'
+              ? 'นี่คือ shortlist review surface ของ Slice 2 สำหรับทบทวนลำดับรายการที่บันทึกไว้ โดยยังไม่เปิด share หรือ remove workflow เต็มรูปแบบ'
+              : 'This Slice 2 shortlist review surface lets you review saved listings in order without opening share or full remove workflows yet.'}
+          </p>
+        </Container>
+      </section>
+
+      <section className="section section--alt">
+        <Container>
+          <ShortlistListSurface locale={locale} />
+        </Container>
+      </section>
+    </main>
+  );
+}

--- a/admin-app/app/globals.css
+++ b/admin-app/app/globals.css
@@ -2776,6 +2776,96 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   padding: 0 var(--space-lg) var(--space-lg);
 }
 
+.shortlist-inline-link {
+  display: inline-flex;
+  margin-top: var(--space-2);
+  color: var(--color-primary);
+  font-size: var(--font-sm);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.shortlist-inline-link:hover {
+  color: var(--color-primary-dark);
+  text-decoration: underline;
+}
+
+.shortlist-surface {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.shortlist-surface__items {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.shortlist-item-card {
+  display: grid;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-gray-100);
+  background: var(--color-white);
+  box-shadow: var(--shadow-card);
+}
+
+.shortlist-item-card__media {
+  position: relative;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  min-height: 220px;
+  background: var(--color-gray-100);
+}
+
+.shortlist-item-card__content {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.shortlist-item-card__eyebrow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.shortlist-item-card__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: 0 var(--space-3);
+  border-radius: 999px;
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+  font-size: var(--font-sm);
+  font-weight: 600;
+}
+
+.shortlist-item-card__badge--accent {
+  background: rgba(176, 92, 55, 0.12);
+  color: var(--color-accent);
+}
+
+.shortlist-item-card__facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  color: var(--color-text-secondary);
+  font-size: var(--font-sm);
+}
+
+@media (min-width: 900px) {
+  .shortlist-item-card {
+    grid-template-columns: minmax(240px, 280px) 1fr;
+    align-items: stretch;
+  }
+
+  .shortlist-item-card__media {
+    min-height: 100%;
+  }
+}
+
 /* Phase 5 Spec: Restrained hover (-4px Y), no scaling, no opacity fade-ins on mount */
 .property-card:hover {
   transform: translateY(-4px);

--- a/admin-app/components/shortlist/ShortlistListSurface.tsx
+++ b/admin-app/components/shortlist/ShortlistListSurface.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import { resolveImageUrl, formatPriceTHB } from '@/app/_lib/public-api-shared';
+import { withLocale } from '@/app/_lib/i18n/routing';
+import { EmptyStateCard, InlineStatusMessage, LoadingCardGrid } from '@/components/ui/StateBlocks';
+import { fetchCurrentShortlist, type ShortlistPropertyItem } from '@/lib/shortlist';
+
+const SHORTLIST_FALLBACK_IMAGE = '/images/property-placeholder.svg';
+
+function formatShortlistSize(value: number | string | null, locale: 'en' | 'th'): string {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) {
+    return locale === 'th' ? 'ยังไม่ระบุขนาด' : 'Size not listed';
+  }
+  const rounded = Math.round(numericValue).toLocaleString();
+  return locale === 'th' ? `${rounded} ตร.ม.` : `${rounded} sqm`;
+}
+
+function buildPropertyHref(locale: 'en' | 'th', item: ShortlistPropertyItem): string {
+  if (item.slug) {
+    return withLocale(locale, `/property/${encodeURIComponent(item.slug)}`);
+  }
+  return withLocale(locale, '/buy');
+}
+
+export function ShortlistListSurface({ locale }: { locale: 'en' | 'th' }) {
+  const [items, setItems] = useState<ShortlistPropertyItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isActive = true;
+
+    fetchCurrentShortlist(locale)
+      .then((response) => {
+        if (!isActive) return;
+        const shortlistItems = [...(response.shortlist?.items ?? [])].sort((left, right) => left.position - right.position);
+        setItems(shortlistItems);
+      })
+      .catch(() => {
+        if (!isActive) return;
+        setError(locale === 'th' ? 'ยังโหลด shortlist ไม่สำเร็จ' : 'Unable to load the shortlist right now.');
+      })
+      .finally(() => {
+        if (!isActive) return;
+        setIsLoading(false);
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [locale]);
+
+  if (isLoading) {
+    return <LoadingCardGrid cards={3} />;
+  }
+
+  if (error) {
+    return <InlineStatusMessage tone="error" message={error} />;
+  }
+
+  if (!items.length) {
+    return (
+      <EmptyStateCard
+        title={locale === 'th' ? 'Shortlist ของคุณยังว่างอยู่' : 'Your shortlist is still empty'}
+        body={
+          locale === 'th'
+            ? 'เริ่มจากการบันทึก listing ที่สนใจจากหน้า buy, rent, หรือ property detail แล้วกลับมาทบทวนที่นี่'
+            : 'Save listings from buy, rent, or property detail surfaces first, then return here to review them.'
+        }
+        action={
+          <Link className="btn btn-secondary" href={withLocale(locale, '/buy')}>
+            {locale === 'th' ? 'ดู listings ที่บันทึกได้' : 'Browse shortlist-ready listings'}
+          </Link>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="shortlist-surface">
+      <div className="cta-strip">
+        <div className="cta-strip__text">
+          {locale === 'th'
+            ? `Shortlist นี้มี ${items.length} รายการสำหรับทบทวนต่อ โดยยังแยกจาก flow การติดต่อและ CRM ตาม guardrail เดิม`
+            : `This shortlist currently contains ${items.length} listings for review, while remaining separate from contact handoff and CRM flows.`}
+        </div>
+        <div className="card-actions">
+          <Link className="btn btn-secondary" href={withLocale(locale, '/buy')}>
+            {locale === 'th' ? 'ดู buy listings เพิ่ม' : 'Browse buy listings'}
+          </Link>
+          <Link className="btn btn-tertiary" href={withLocale(locale, '/contact')}>
+            {locale === 'th' ? 'คุยกับที่ปรึกษา' : 'Speak to an advisor'}
+          </Link>
+        </div>
+      </div>
+
+      <div className="shortlist-surface__items">
+        {items.map((item, index) => {
+          const image = resolveImageUrl(item.image) ?? SHORTLIST_FALLBACK_IMAGE;
+          const propertyHref = buildPropertyHref(locale, item);
+          return (
+            <article key={`${item.property_id}-${item.position}`} className="shortlist-item-card">
+              <div className="shortlist-item-card__media">
+                <Image
+                  src={image}
+                  alt={item.title}
+                  fill
+                  unoptimized
+                  sizes="(min-width: 1024px) 280px, 100vw"
+                  className="object-cover"
+                />
+              </div>
+
+              <div className="shortlist-item-card__content">
+                <div className="shortlist-item-card__eyebrow">
+                  <span className="shortlist-item-card__badge">
+                    {locale === 'th' ? `ลำดับ ${index + 1}` : `Saved #${index + 1}`}
+                  </span>
+                  {item.foreign_quota ? (
+                    <span className="shortlist-item-card__badge shortlist-item-card__badge--accent">
+                      {locale === 'th' ? 'มีสัญญาณ foreign quota' : 'Foreign quota signal'}
+                    </span>
+                  ) : null}
+                </div>
+
+                <div>
+                  <h3 className="card-title">{item.title}</h3>
+                  <p className="card-subtitle mb-0">
+                    {[item.project, item.location].filter(Boolean).join(' • ') || (locale === 'th' ? 'กำลังรอรายละเอียดทำเล' : 'Location details pending')}
+                  </p>
+                </div>
+
+                <div className="shortlist-item-card__facts">
+                  <span>{formatPriceTHB(Number(item.price))}</span>
+                  <span>{formatShortlistSize(item.size, locale)}</span>
+                  <span>
+                    {locale === 'th'
+                      ? `${item.bedrooms ?? '-'} ห้องนอน • ${item.bathrooms ?? '-'} ห้องน้ำ`
+                      : `${item.bedrooms ?? '-'} beds • ${item.bathrooms ?? '-'} baths`}
+                  </span>
+                </div>
+
+                <div className="card-actions">
+                  <Link className="btn btn-primary" href={propertyHref}>
+                    {locale === 'th' ? 'ดูรายละเอียด listing' : 'View listing details'}
+                  </Link>
+                  <Link className="btn btn-tertiary" href={withLocale(locale, '/buy')}>
+                    {locale === 'th' ? 'ดู inventory เพิ่ม' : 'Browse more inventory'}
+                  </Link>
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/admin-app/components/shortlist/ShortlistSaveButton.tsx
+++ b/admin-app/components/shortlist/ShortlistSaveButton.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { usePathname } from 'next/navigation';
 
+import { withLocale } from '@/app/_lib/i18n/routing';
 import { trackEvent } from '@/lib/analytics';
 import { fetchCurrentShortlist, savePropertyToShortlist } from '@/lib/shortlist';
 
@@ -90,6 +92,13 @@ export function ShortlistSaveButton({
       <button type="button" className={className} onClick={handleClick} disabled={isSaving || isSaved}>
         {label}
       </button>
+      {typeof itemCount === 'number' && itemCount > 0 ? (
+        <div>
+          <Link className="shortlist-inline-link" href={withLocale(locale, '/shortlist')}>
+            {locale === 'th' ? `ดู shortlist (${itemCount})` : `View shortlist (${itemCount})`}
+          </Link>
+        </div>
+      ) : null}
       {error ? <p className="guided-dialog__step mt-2">{error}</p> : null}
     </div>
   );

--- a/admin-app/lib/shortlist.ts
+++ b/admin-app/lib/shortlist.ts
@@ -4,10 +4,34 @@ const SHORTLIST_OWNER_KEY = 'amp_shortlist_owner_v1';
 
 export type ShortlistPropertyItem = {
   property_id: string;
+  slug: string | null;
+  title: string;
+  project: string | null;
+  location: string | null;
+  price: number | string;
+  size: number | string | null;
+  bedrooms: number | null;
+  bathrooms: number | null;
+  image: string | null;
+  status: string;
+  foreign_quota: boolean;
   position: number;
+  added_at: string;
+  source_surface: string | null;
 };
 
 export type ShortlistDetail = {
+  id: string;
+  owner_type: string;
+  owner_key: string;
+  status: string;
+  title: string | null;
+  intent: string | null;
+  share_mode: string | null;
+  source_context: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+  last_viewed_at: string | null;
   item_count: number;
   items: ShortlistPropertyItem[];
 };


### PR DESCRIPTION
## Summary
- add the public /[locale]/shortlist review surface for the approved Slice 2 shortlist list view
- expose the shortlist page from saved-state shortlist CTAs without opening remove or share workflows yet
- cover the new shortlist review surface with focused frontend tests

## Guardrails
- V1 impact = none
- CRM unchanged
- lead forms unchanged
- core layout unchanged
- homepage and advisory funnel unchanged
- session-first shortlist ownership unchanged

## Validation
- npm --prefix admin-app run test -- __tests__/shortlist_save_button.test.tsx __tests__/shortlist_list_surface.test.tsx __tests__/shortlist_entry_surfaces.test.tsx
- npm --prefix admin-app run build
- npm --prefix admin-app run test:smoke:admin
- git diff --check

Closes #471