### PR TITLE
feat: add shortlist share flow

### DIFF
--- a/admin-app/__tests__/shortlist_share_flow.test.tsx
+++ b/admin-app/__tests__/shortlist_share_flow.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { ShortlistListSurface } from '@/components/shortlist/ShortlistListSurface';
+
+describe('Shortlist share flow', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+  });
+
+  it('creates and copies a read-only share link from the shortlist surface', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        json: async () => ({
+          shortlist: {
+            id: 'shortlist-1',
+            owner_type: 'session',
+            owner_key: 'owner-1',
+            status: 'active',
+            title: null,
+            intent: null,
+            share_mode: null,
+            source_context: null,
+            created_at: '2026-03-15T00:00:00Z',
+            updated_at: '2026-03-15T00:00:00Z',
+            last_viewed_at: null,
+            item_count: 1,
+            items: [
+              {
+                property_id: 'property-1',
+                slug: 'alpha-residence',
+                title: 'Alpha Residence',
+                project: 'Alpha Project',
+                location: 'Central Pattaya',
+                price: 6200000,
+                size: 56,
+                bedrooms: 2,
+                bathrooms: 2,
+                image: null,
+                status: 'published',
+                foreign_quota: false,
+                position: 0,
+                added_at: '2026-03-15T00:00:00Z',
+                source_surface: 'property_detail',
+              },
+            ],
+          },
+        }),
+      }))
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        json: async () => ({
+          action: 'shared',
+          share_token: 'token-123',
+          share_mode: 'public_read',
+          share_url: '/v1/shortlists/shared/token-123',
+          shortlist: {
+            id: 'shortlist-1',
+            title: null,
+            intent: null,
+            share_mode: 'public_read',
+            created_at: '2026-03-15T00:00:00Z',
+            updated_at: '2026-03-15T00:00:00Z',
+            item_count: 1,
+            items: [],
+          },
+        }),
+      }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ShortlistListSurface locale="en" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Alpha Residence' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /create share link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('http://localhost:3000/en/shortlist/shared/token-123')).toBeTruthy();
+    });
+
+    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith('http://localhost:3000/en/shortlist/shared/token-123');
+    expect(screen.getByText(/share link copied/i)).toBeTruthy();
+  });
+});

--- a/admin-app/__tests__/shortlist_shared_surface.test.tsx
+++ b/admin-app/__tests__/shortlist_shared_surface.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { ShortlistSharedSurface } from '@/components/shortlist/ShortlistSharedSurface';
+
+describe('ShortlistSharedSurface', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a read-only shared shortlist from the share token route', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        shortlist: {
+          id: 'shortlist-1',
+          title: null,
+          intent: null,
+          share_mode: 'public_read',
+          created_at: '2026-03-15T00:00:00Z',
+          updated_at: '2026-03-15T00:00:00Z',
+          item_count: 1,
+          items: [
+            {
+              property_id: 'property-1',
+              slug: 'alpha-residence',
+              title: 'Alpha Residence',
+              project: 'Alpha Project',
+              location: 'Central Pattaya',
+              price: 6200000,
+              size: 56,
+              bedrooms: 2,
+              bathrooms: 2,
+              image: null,
+              status: 'published',
+              foreign_quota: true,
+              position: 0,
+              added_at: '2026-03-15T00:00:00Z',
+              source_surface: 'property_detail',
+            },
+          ],
+        },
+      }),
+    }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ShortlistSharedSurface locale="en" shareToken="token-123" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Alpha Residence' })).toBeTruthy();
+    });
+
+    expect(screen.getAllByText(/read-only/i).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: /remove from shortlist/i })).toBeNull();
+    expect(screen.getByRole('link', { name: /view listing details/i }).getAttribute('href')).toBe('/en/property/alpha-residence');
+  });
+});

--- a/admin-app/app/(site)/[locale]/shortlist/page.tsx
+++ b/admin-app/app/(site)/[locale]/shortlist/page.tsx
@@ -43,8 +43,8 @@ export default async function ShortlistPage(props: { params: Promise<{ locale: s
           <h1 className="headline">{locale === 'th' ? 'Shortlist ของคุณ' : 'Your shortlist'}</h1>
           <p className="subhead">
             {locale === 'th'
-              ? 'นี่คือ shortlist review surface ของ Slice 2 สำหรับทบทวนลำดับรายการที่บันทึกไว้ โดยยังไม่เปิด share หรือ remove workflow เต็มรูปแบบ'
-              : 'This Slice 2 shortlist review surface lets you review saved listings in order without opening share or full remove workflows yet.'}
+              ? 'ทบทวน shortlist, นำรายการออกเมื่อไม่ต้องการแล้ว, และสร้างลิงก์แชร์แบบ read-only ได้จาก surface นี้โดยไม่แตะ CRM หรือ flow การติดต่อ'
+              : 'Review your shortlist, remove listings when needed, and create a read-only share link from this surface without touching CRM or contact flows.'}
           </p>
         </Container>
       </section>

--- a/admin-app/app/(site)/[locale]/shortlist/shared/[shareToken]/page.tsx
+++ b/admin-app/app/(site)/[locale]/shortlist/shared/[shareToken]/page.tsx
@@ -1,0 +1,61 @@
+import { Breadcrumbs } from '@/components/layout/Breadcrumbs';
+import { Container } from '@/components/layout/Container';
+import { ShortlistSharedSurface } from '@/components/shortlist/ShortlistSharedSurface';
+import { getDictionary, normalizeLocale } from '@/app/_lib/i18n/get-dictionary';
+import { makePageMetadata } from '@/app/_lib/i18n/metadata';
+
+export const revalidate = 300;
+
+export async function generateMetadata(
+  props: {
+    params: Promise<{ locale: string; shareToken: string }>;
+  }
+) {
+  const params = await props.params;
+  const locale = normalizeLocale(params.locale);
+  const dict = getDictionary(locale);
+  return makePageMetadata(
+    locale,
+    'shortlist',
+    locale === 'th' ? 'Shortlist ที่แชร์' : 'Shared shortlist',
+    locale === 'th'
+      ? 'ดู shortlist แบบ read-only จากลิงก์ที่แชร์ไว้ โดยไม่เปิดการแก้ไขหรือ CRM flow'
+      : 'Open a read-only shortlist from a shared link without enabling editing or CRM flow.',
+    dict.brand.name,
+  );
+}
+
+export default async function SharedShortlistPage(props: {
+  params: Promise<{ locale: string; shareToken: string }>;
+}) {
+  const params = await props.params;
+  const locale = normalizeLocale(params.locale);
+
+  return (
+    <main id="main-content">
+      <Breadcrumbs
+        items={[
+          { label: locale === 'th' ? 'หน้าแรก' : 'Home', href: `/${locale}` },
+          { label: locale === 'th' ? 'Shortlist ที่แชร์' : 'Shared shortlist', href: `/${locale}/shortlist/shared/${params.shareToken}` },
+        ]}
+      />
+
+      <section className="hero hero--page">
+        <Container>
+          <h1 className="headline">{locale === 'th' ? 'Shortlist ที่แชร์' : 'Shared shortlist'}</h1>
+          <p className="subhead">
+            {locale === 'th'
+              ? 'หน้านี้เปิด shortlist แบบดูอย่างเดียวจากลิงก์ที่แชร์ไว้ โดยไม่เปิด save, remove, หรือ CRM workflow ใด ๆ'
+              : 'This page opens a read-only shortlist from a shared link without exposing save, remove, or CRM workflows.'}
+          </p>
+        </Container>
+      </section>
+
+      <section className="section section--alt">
+        <Container>
+          <ShortlistSharedSurface locale={locale} shareToken={params.shareToken} />
+        </Container>
+      </section>
+    </main>
+  );
+}

--- a/admin-app/app/globals.css
+++ b/admin-app/app/globals.css
@@ -2800,6 +2800,32 @@ summary.mobile-nav__trigger::-webkit-details-marker {
   gap: var(--space-4);
 }
 
+.shortlist-share-panel {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(10, 77, 140, 0.12);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: var(--shadow-card);
+}
+
+.shortlist-share-panel__label {
+  font-size: var(--font-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.shortlist-share-panel__input {
+  width: 100%;
+  min-height: 44px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-gray-200);
+  background: var(--color-white);
+  color: var(--color-text);
+}
+
 .shortlist-item-card {
   display: grid;
   gap: var(--space-4);

--- a/admin-app/components/shortlist/ShortlistListSurface.tsx
+++ b/admin-app/components/shortlist/ShortlistListSurface.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import { resolveImageUrl, formatPriceTHB } from '@/app/_lib/public-api-shared';
 import { withLocale } from '@/app/_lib/i18n/routing';
 import { EmptyStateCard, InlineStatusMessage, LoadingCardGrid } from '@/components/ui/StateBlocks';
-import { SHORTLIST_UPDATED_EVENT, fetchCurrentShortlist, readCachedShortlist, removePropertyFromShortlist, type ShortlistDetail, type ShortlistPropertyItem } from '@/lib/shortlist';
+import { SHORTLIST_UPDATED_EVENT, fetchCurrentShortlist, readCachedShortlist, removePropertyFromShortlist, shareCurrentShortlist, type ShortlistDetail, type ShortlistPropertyItem } from '@/lib/shortlist';
 
 const SHORTLIST_FALLBACK_IMAGE = '/images/property-placeholder.svg';
 
@@ -31,6 +31,9 @@ export function ShortlistListSurface({ locale }: { locale: 'en' | 'th' }) {
   const [items, setItems] = useState<ShortlistPropertyItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [pendingPropertyId, setPendingPropertyId] = useState<string | null>(null);
+  const [isSharing, setIsSharing] = useState(false);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [shareNotice, setShareNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   function syncFromShortlist(shortlist: ShortlistDetail | null) {
@@ -97,6 +100,31 @@ export function ShortlistListSurface({ locale }: { locale: 'en' | 'th' }) {
     }
   }
 
+  async function handleShare() {
+    if (isSharing) return;
+
+    setIsSharing(true);
+    setError(null);
+    setShareNotice(null);
+
+    try {
+      const response = await shareCurrentShortlist(locale);
+      const nextShareUrl = `${window.location.origin}${withLocale(locale, `/shortlist/shared/${response.share_token}`)}`;
+      setShareUrl(nextShareUrl);
+
+      try {
+        await window.navigator.clipboard?.writeText(nextShareUrl);
+        setShareNotice(locale === 'th' ? 'คัดลอกลิงก์แชร์แล้ว' : 'Share link copied.');
+      } catch {
+        setShareNotice(locale === 'th' ? 'สร้างลิงก์แชร์แล้ว คัดลอกต่อได้ด้านล่าง' : 'Share link created. Copy it below.');
+      }
+    } catch {
+      setError(locale === 'th' ? 'สร้างลิงก์แชร์ shortlist ไม่สำเร็จ' : 'Unable to create a shortlist share link.');
+    } finally {
+      setIsSharing(false);
+    }
+  }
+
   if (isLoading) {
     return <LoadingCardGrid cards={3} />;
   }
@@ -132,6 +160,13 @@ export function ShortlistListSurface({ locale }: { locale: 'en' | 'th' }) {
             : `This shortlist currently contains ${items.length} listings for review, while remaining separate from contact handoff and CRM flows.`}
         </div>
         <div className="card-actions">
+          <button type="button" className="btn btn-primary" onClick={handleShare} disabled={isSharing}>
+            {isSharing
+              ? (locale === 'th' ? 'กำลังสร้างลิงก์แชร์…' : 'Creating share link…')
+              : shareUrl
+                ? (locale === 'th' ? 'คัดลอกลิงก์แชร์อีกครั้ง' : 'Copy share link again')
+                : (locale === 'th' ? 'สร้างลิงก์แชร์' : 'Create share link')}
+          </button>
           <Link className="btn btn-secondary" href={withLocale(locale, '/buy')}>
             {locale === 'th' ? 'ดู buy listings เพิ่ม' : 'Browse buy listings'}
           </Link>
@@ -140,6 +175,25 @@ export function ShortlistListSurface({ locale }: { locale: 'en' | 'th' }) {
           </Link>
         </div>
       </div>
+
+      {shareUrl ? (
+        <div className="shortlist-share-panel" aria-live="polite">
+          <label className="shortlist-share-panel__label" htmlFor="shortlist-share-link">
+            {locale === 'th' ? 'ลิงก์แชร์แบบ read-only' : 'Read-only share link'}
+          </label>
+          <input
+            id="shortlist-share-link"
+            className="shortlist-share-panel__input"
+            type="text"
+            value={shareUrl}
+            readOnly
+            onFocus={(event) => event.currentTarget.select()}
+          />
+          <p className="guided-dialog__step mt-2">
+            {shareNotice ?? (locale === 'th' ? 'ลิงก์นี้เปิด shortlist แบบดูอย่างเดียวและไม่เชื่อมเข้า CRM' : 'This link opens a read-only shortlist view and does not connect to CRM.')}
+          </p>
+        </div>
+      ) : null}
 
       <div className="shortlist-surface__items">
         {items.map((item, index) => {

--- a/admin-app/components/shortlist/ShortlistSharedSurface.tsx
+++ b/admin-app/components/shortlist/ShortlistSharedSurface.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import { resolveImageUrl, formatPriceTHB } from '@/app/_lib/public-api-shared';
+import { withLocale } from '@/app/_lib/i18n/routing';
+import { EmptyStateCard, InlineStatusMessage, LoadingCardGrid } from '@/components/ui/StateBlocks';
+import { fetchSharedShortlist, type SharedShortlistDetail, type ShortlistPropertyItem } from '@/lib/shortlist';
+
+const SHORTLIST_FALLBACK_IMAGE = '/images/property-placeholder.svg';
+
+function formatShortlistSize(value: number | string | null, locale: 'en' | 'th'): string {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) {
+    return locale === 'th' ? 'ยังไม่ระบุขนาด' : 'Size not listed';
+  }
+  const rounded = Math.round(numericValue).toLocaleString();
+  return locale === 'th' ? `${rounded} ตร.ม.` : `${rounded} sqm`;
+}
+
+function buildPropertyHref(locale: 'en' | 'th', item: ShortlistPropertyItem): string {
+  if (item.slug) {
+    return withLocale(locale, `/property/${encodeURIComponent(item.slug)}`);
+  }
+  return withLocale(locale, '/buy');
+}
+
+export function ShortlistSharedSurface({ locale, shareToken }: { locale: 'en' | 'th'; shareToken: string }) {
+  const [shortlist, setShortlist] = useState<SharedShortlistDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isActive = true;
+
+    fetchSharedShortlist({ locale, shareToken })
+      .then((response) => {
+        if (!isActive) return;
+        setShortlist(response.shortlist);
+      })
+      .catch(() => {
+        if (!isActive) return;
+        setError(locale === 'th' ? 'ไม่พบ shortlist ที่แชร์ไว้หรือเปิดลิงก์นี้ไม่ได้แล้ว' : 'This shared shortlist is unavailable or no longer accessible.');
+      })
+      .finally(() => {
+        if (!isActive) return;
+        setIsLoading(false);
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [locale, shareToken]);
+
+  if (isLoading) {
+    return <LoadingCardGrid cards={3} />;
+  }
+
+  if (error) {
+    return <InlineStatusMessage tone="error" message={error} />;
+  }
+
+  if (!shortlist || !shortlist.items.length) {
+    return (
+      <EmptyStateCard
+        title={locale === 'th' ? 'Shortlist ที่แชร์นี้ยังไม่มีรายการ' : 'This shared shortlist has no listings'}
+        body={
+          locale === 'th'
+            ? 'ลิงก์นี้เป็นมุมมองแบบ read-only เท่านั้น หากต้องการเริ่ม shortlist ของคุณเอง ให้กลับไปที่หน้ารวม listings'
+            : 'This is a read-only shared view. To start your own shortlist, return to the listings overview.'
+        }
+        action={
+          <Link className="btn btn-secondary" href={withLocale(locale, '/buy')}>
+            {locale === 'th' ? 'ดู listings' : 'Browse listings'}
+          </Link>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="shortlist-surface">
+      <div className="cta-strip">
+        <div className="cta-strip__text">
+          {locale === 'th'
+            ? `ลิงก์นี้แชร์ shortlist แบบดูอย่างเดียวจำนวน ${shortlist.item_count} รายการ โดยไม่เปิดสิทธิ์แก้ไขหรือเชื่อมเข้า CRM`
+            : `This link shares a read-only shortlist with ${shortlist.item_count} listings and does not enable editing or CRM handoff.`}
+        </div>
+        <div className="card-actions">
+          <Link className="btn btn-secondary" href={withLocale(locale, '/buy')}>
+            {locale === 'th' ? 'ดู buy listings' : 'Browse buy listings'}
+          </Link>
+        </div>
+      </div>
+
+      <div className="shortlist-surface__items">
+        {shortlist.items.map((item, index) => {
+          const image = resolveImageUrl(item.image) ?? SHORTLIST_FALLBACK_IMAGE;
+          const propertyHref = buildPropertyHref(locale, item);
+          return (
+            <article key={`${item.property_id}-${item.position}`} className="shortlist-item-card">
+              <div className="shortlist-item-card__media">
+                <Image
+                  src={image}
+                  alt={item.title}
+                  fill
+                  unoptimized
+                  sizes="(min-width: 1024px) 280px, 100vw"
+                  className="object-cover"
+                />
+              </div>
+
+              <div className="shortlist-item-card__content">
+                <div className="shortlist-item-card__eyebrow">
+                  <span className="shortlist-item-card__badge">
+                    {locale === 'th' ? `แชร์ลำดับ ${index + 1}` : `Shared #${index + 1}`}
+                  </span>
+                  <span className="shortlist-item-card__badge shortlist-item-card__badge--accent">
+                    {locale === 'th' ? 'read-only' : 'Read-only'}
+                  </span>
+                </div>
+
+                <div>
+                  <h3 className="card-title">{item.title}</h3>
+                  <p className="card-subtitle mb-0">
+                    {[item.project, item.location].filter(Boolean).join(' • ') || (locale === 'th' ? 'กำลังรอรายละเอียดทำเล' : 'Location details pending')}
+                  </p>
+                </div>
+
+                <div className="shortlist-item-card__facts">
+                  <span>{formatPriceTHB(Number(item.price))}</span>
+                  <span>{formatShortlistSize(item.size, locale)}</span>
+                  <span>
+                    {locale === 'th'
+                      ? `${item.bedrooms ?? '-'} ห้องนอน • ${item.bathrooms ?? '-'} ห้องน้ำ`
+                      : `${item.bedrooms ?? '-'} beds • ${item.bathrooms ?? '-'} baths`}
+                  </span>
+                </div>
+
+                <div className="card-actions">
+                  <Link className="btn btn-primary" href={propertyHref}>
+                    {locale === 'th' ? 'ดูรายละเอียด listing' : 'View listing details'}
+                  </Link>
+                </div>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/admin-app/lib/shortlist.ts
+++ b/admin-app/lib/shortlist.ts
@@ -48,6 +48,29 @@ export type ShortlistMutationResponse = {
   shortlist: ShortlistDetail | null;
 };
 
+export type SharedShortlistDetail = {
+  id: string;
+  title: string | null;
+  intent: string | null;
+  share_mode: string | null;
+  created_at: string;
+  updated_at: string;
+  item_count: number;
+  items: ShortlistPropertyItem[];
+};
+
+export type ShortlistShareResponse = {
+  action: string;
+  share_token: string;
+  share_mode: string;
+  share_url: string;
+  shortlist: SharedShortlistDetail;
+};
+
+export type SharedShortlistResponse = {
+  shortlist: SharedShortlistDetail;
+};
+
 function safeWindow(): Window | null {
   return typeof window === 'undefined' ? null : window;
 }
@@ -170,4 +193,45 @@ export async function removePropertyFromShortlist(input: {
   const payload = (await response.json()) as ShortlistMutationResponse;
   publishShortlist(payload.shortlist ?? null);
   return payload;
+}
+
+export async function shareCurrentShortlist(locale: 'en' | 'th'): Promise<ShortlistShareResponse> {
+  const ownerKey = getOrCreateShortlistOwnerKey();
+  const params = new URLSearchParams({ locale });
+
+  const response = await fetch(`/api/v1/shortlists/current/share?${params.toString()}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      owner_type: 'session',
+      owner_key: ownerKey,
+      share_mode: 'public_read',
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to share shortlist (${response.status})`);
+  }
+
+  return (await response.json()) as ShortlistShareResponse;
+}
+
+export async function fetchSharedShortlist(input: {
+  locale: 'en' | 'th';
+  shareToken: string;
+}): Promise<SharedShortlistResponse> {
+  const params = new URLSearchParams({ locale: input.locale });
+  const response = await fetch(
+    `/api/v1/shortlists/shared/${encodeURIComponent(input.shareToken)}?${params.toString()}`,
+    {
+      method: 'GET',
+      cache: 'no-store',
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to load shared shortlist (${response.status})`);
+  }
+
+  return (await response.json()) as SharedShortlistResponse;
 }


### PR DESCRIPTION
## Summary
- add a controlled read-only shortlist share flow from the shortlist surface only
- expose a public shared shortlist route backed by the existing public_read API capability
- add focused coverage for share creation and shared shortlist rendering

## Validation
- npm --prefix admin-app run test -- __tests__/shortlist_save_button.test.tsx __tests__/shortlist_list_surface.test.tsx __tests__/shortlist_share_flow.test.tsx __tests__/shortlist_shared_surface.test.tsx __tests__/shortlist_entry_surfaces.test.tsx __tests__/investor_handoff_regression.test.ts
- git diff --check
- npm --prefix admin-app run build
- npm --prefix admin-app run test:smoke:admin

Closes #475