### PR TITLE
feat: add area comparison surface

### DIFF
--- a/admin-app/__tests__/compare_area_surface.test.tsx
+++ b/admin-app/__tests__/compare_area_surface.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import ComparePage from '@/app/(site)/[locale]/compare/page';
+
+vi.mock('@/app/_lib/public-api-server', async () => {
+  const actual = await vi.importActual<typeof import('@/app/_lib/public-api-server')>('@/app/_lib/public-api-server');
+  return {
+    ...actual,
+    fetchProjectEvaluation: vi.fn(async (projectId: string) => {
+      if (projectId === 'project-1') {
+        return {
+          evaluation_version: 'v1',
+          project: {
+            id: 'project-1',
+            slug: 'alpha-residence',
+            name: 'Alpha Residence',
+            area_id: 'area-1',
+            status: 'published',
+            created_at: '2026-03-16T00:00:00Z',
+            updated_at: '2026-03-16T00:00:00Z',
+          },
+          area_statistics: {
+            area_id: 'area-1',
+            avg_price_sqm: '120000',
+            avg_rent_monthly: '28000',
+            avg_roi_percent: '5.8',
+            total_projects: 12,
+            total_units: 1800,
+            as_of_date: '2026-03-01',
+            avg_price: 'THB 5.2M',
+            avg_rent: 'THB 28K',
+            roi_percent: '5.8%',
+            as_of: '2026-03-01',
+          },
+          badges: [{ key: 'area_stats_available', label: 'Area stats available' }],
+        };
+      }
+
+      return {
+        evaluation_version: 'v1',
+        project: {
+          id: 'project-2',
+          slug: 'beta-bay',
+          name: 'Beta Bay',
+          area_id: 'area-2',
+          status: 'published',
+          created_at: '2026-03-16T00:00:00Z',
+          updated_at: '2026-03-16T00:00:00Z',
+        },
+        area_statistics: {
+          area_id: 'area-2',
+          avg_price_sqm: '98000',
+          avg_rent_monthly: '24000',
+          avg_roi_percent: '6.4',
+          total_projects: 9,
+          total_units: 1400,
+          as_of_date: '2026-03-01',
+          avg_price: 'THB 4.6M',
+          avg_rent: 'THB 24K',
+          roi_percent: '6.4%',
+          as_of: '2026-03-01',
+        },
+        badges: [{ key: 'roi_snapshot', label: 'ROI snapshot' }],
+      };
+    }),
+    fetchProjectBySlug: vi.fn(async (slug: string) => {
+      if (slug === 'alpha-residence') {
+        return {
+          id: 'project-1',
+          slug,
+          name: 'Alpha Residence',
+          status: 'published',
+          property_type: 'condo',
+          summary: { en: 'Summary', th: 'สรุป' },
+          description: { en: 'Description', th: 'รายละเอียด' },
+          amenities: [],
+          investment_snapshot: null,
+          location: null,
+          area: { id: 'area-1', slug: 'jomtien', name: 'Jomtien' },
+          created_at: '2026-03-16T00:00:00Z',
+          updated_at: '2026-03-16T00:00:00Z',
+        };
+      }
+
+      return {
+        id: 'project-2',
+        slug,
+        name: 'Beta Bay',
+        status: 'published',
+        property_type: 'condo',
+        summary: { en: 'Summary', th: 'สรุป' },
+        description: { en: 'Description', th: 'รายละเอียด' },
+        amenities: [],
+        investment_snapshot: null,
+        location: null,
+        area: { id: 'area-2', slug: 'pratumnak', name: 'Pratumnak' },
+        created_at: '2026-03-16T00:00:00Z',
+        updated_at: '2026-03-16T00:00:00Z',
+      };
+    }),
+  };
+});
+
+describe('compare area surface', () => {
+  it('renders an area comparison read when compared projects resolve to different areas', async () => {
+    render(
+      await ComparePage({
+        params: Promise.resolve({ locale: 'en' }),
+        searchParams: Promise.resolve({ ids: 'project-1,project-2' }),
+      }),
+    );
+
+    expect(screen.getByRole('heading', { name: /area comparison read/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Jomtien' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Pratumnak' })).toBeTruthy();
+    expect(screen.getByText(/currently represented by alpha residence/i)).toBeTruthy();
+    expect(screen.getByText(/currently represented by beta bay/i)).toBeTruthy();
+    expect(screen.getAllByText('THB 5.2M')[0]).toBeTruthy();
+    expect(screen.getAllByText('THB 4.6M')[0]).toBeTruthy();
+    expect(screen.getAllByRole('link', { name: /open area brief/i }).map((link) => link.getAttribute('href'))).toEqual([
+      '/en/areas/jomtien',
+      '/en/areas/pratumnak',
+    ]);
+  });
+});

--- a/admin-app/app/(site)/[locale]/compare/page.tsx
+++ b/admin-app/app/(site)/[locale]/compare/page.tsx
@@ -13,7 +13,7 @@ import { getDictionary, normalizeLocale } from '@/app/_lib/i18n/get-dictionary';
 import { makePageMetadata } from '@/app/_lib/i18n/metadata';
 import { withLocale } from '@/app/_lib/i18n/routing';
 import type { Dictionary } from '@/app/_lib/i18n/types';
-import { fetchProjectEvaluation, type ProjectEvaluationResponse } from '@/app/_lib/public-api-server';
+import { fetchProjectBySlug, fetchProjectEvaluation, type ProjectEvaluationResponse } from '@/app/_lib/public-api-server';
 import { PublicAdvisoryHero } from '@/components/public/PublicAdvisoryHero';
 
 export const revalidate = 300;
@@ -109,6 +109,66 @@ function weaknesses(ev: ProjectEvaluationResponse, dict: Dictionary): string[] {
   if (!keys.has('has_cover_image')) out.push(dict.compare.coverImageMissing);
   if (!out.length) out.push('—');
   return out;
+}
+
+type AreaComparisonEntry = {
+  areaId: string;
+  areaName: string;
+  areaSlug: string | null;
+  projectNames: string[];
+  avgPrice: string | null;
+  avgRent: string | null;
+  roiPercent: string | null;
+  totalProjects: number | null;
+  asOf: string | null;
+};
+
+async function buildAreaComparisonEntries(
+  items: ProjectEvaluationResponse[],
+  locale: 'en' | 'th',
+): Promise<AreaComparisonEntry[]> {
+  const projectDetails = await Promise.all(
+    items.map((item) => (item.project.slug ? fetchProjectBySlug(item.project.slug) : Promise.resolve(null))),
+  );
+
+  const areaMap = new Map<string, AreaComparisonEntry>();
+
+  items.forEach((item, index) => {
+    const detail = projectDetails[index];
+    const stats = item.area_statistics;
+    const areaId = detail?.area?.id ?? stats?.area_id ?? null;
+    if (!areaId) {
+      return;
+    }
+
+    const existing = areaMap.get(areaId);
+    const projectName = item.project.name || item.project.slug || item.project.id;
+    if (existing) {
+      if (!existing.projectNames.includes(projectName)) {
+        existing.projectNames.push(projectName);
+      }
+      if (!existing.avgPrice && stats?.avg_price) existing.avgPrice = stats.avg_price;
+      if (!existing.avgRent && stats?.avg_rent) existing.avgRent = stats.avg_rent;
+      if (!existing.roiPercent && stats?.roi_percent) existing.roiPercent = stats.roi_percent;
+      if (!existing.totalProjects && typeof stats?.total_projects === 'number') existing.totalProjects = stats.total_projects;
+      if (!existing.asOf && stats?.as_of) existing.asOf = stats.as_of;
+      return;
+    }
+
+    areaMap.set(areaId, {
+      areaId,
+      areaName: detail?.area?.name ?? (locale === 'th' ? 'ทำเลกำลังรอรายละเอียด' : 'Area details pending'),
+      areaSlug: detail?.area?.slug ?? null,
+      projectNames: [projectName],
+      avgPrice: stats?.avg_price ?? null,
+      avgRent: stats?.avg_rent ?? null,
+      roiPercent: stats?.roi_percent ?? null,
+      totalProjects: typeof stats?.total_projects === 'number' ? stats.total_projects : null,
+      asOf: stats?.as_of ?? null,
+    });
+  });
+
+  return Array.from(areaMap.values());
 }
 
 export default async function ComparePage(
@@ -256,6 +316,7 @@ export default async function ComparePage(
   const evals = await Promise.all(ids.map((id) => fetchProjectEvaluation(id)));
   const missing = ids.filter((_, idx) => evals[idx] == null);
   const items = evals.filter(Boolean) as ProjectEvaluationResponse[];
+  const areaComparisons = await buildAreaComparisonEntries(items, locale);
 
   return (
     <main id="main-content">
@@ -330,6 +391,81 @@ export default async function ComparePage(
             <div className="trust-box mb-4">
               <h2 className="trust-box__title">{dict.compare.someNotFound}</h2>
               <p className="section-subtitle">ids: {missing.join(', ')}</p>
+            </div>
+          ) : null}
+
+          {areaComparisons.length >= 2 ? (
+            <div className="card reveal mb-4">
+              <h2 className="card-title">{locale === 'th' ? 'Area comparison read' : 'Area comparison read'}</h2>
+              <p className="card-subtitle">
+                {locale === 'th'
+                  ? 'ก่อนตัดสินใจที่ระดับโครงการ ลองอ่านบริบทของแต่ละทำเลแบบ side-by-side จากราคา ค่าเช่า และ ROI snapshot ที่มีอยู่จริง'
+                  : 'Before narrowing the decision at project level, read the location context side by side using live pricing, rent, and ROI snapshots where available.'}
+              </p>
+              <div className="signal-grid signal-grid--two-up mt-4">
+                {areaComparisons.map((area) => (
+                  <section key={area.areaId} className="authority-card">
+                    <div className="section-header">
+                      <h3 className="section-title section-title--sm">{area.areaName}</h3>
+                      <p className="section-subtitle">
+                        {locale === 'th'
+                          ? `กำลังเทียบจาก ${area.projectNames.join(', ')}`
+                          : `Currently represented by ${area.projectNames.join(', ')}`}
+                      </p>
+                    </div>
+                    <div className="signal-grid signal-grid--two-up">
+                      <div className="metric-card">
+                        <span className="metric-card__label">{locale === 'th' ? 'ราคาเฉลี่ย' : 'Average price'}</span>
+                        <strong className="metric-card__value">{area.avgPrice ?? '—'}</strong>
+                      </div>
+                      <div className="metric-card">
+                        <span className="metric-card__label">{locale === 'th' ? 'ค่าเช่าเฉลี่ย' : 'Average rent'}</span>
+                        <strong className="metric-card__value">{area.avgRent ?? '—'}</strong>
+                      </div>
+                      <div className="metric-card">
+                        <span className="metric-card__label">{locale === 'th' ? 'ROI snapshot' : 'ROI snapshot'}</span>
+                        <strong className="metric-card__value">{area.roiPercent ?? '—'}</strong>
+                      </div>
+                      <div className="metric-card">
+                        <span className="metric-card__label">{locale === 'th' ? 'จำนวนโครงการใน snapshot' : 'Projects in snapshot'}</span>
+                        <strong className="metric-card__value">{area.totalProjects ?? '—'}</strong>
+                      </div>
+                    </div>
+                    <div className="insight-list mt-4">
+                      <div className="insight-list__item">
+                        <span className="insight-list__body">
+                          {area.asOf
+                            ? (locale === 'th' ? `อัปเดตข้อมูลล่าสุด ${area.asOf}` : `Snapshot last updated ${area.asOf}.`)
+                            : (locale === 'th' ? 'ใช้เป็นบริบทของทำเล ไม่ใช่คำพยากรณ์ของผลตอบแทน' : 'Use this as location context, not as a forecast of returns.')}
+                        </span>
+                      </div>
+                      <div className="insight-list__item">
+                        <span className="insight-list__body">
+                          {locale === 'th'
+                            ? 'ชั้นนี้ช่วยแยก “ทำเลที่เหมาะ” ออกจาก “โครงการที่เหมาะ” ก่อนเข้าสู่ shortlist รอบถัดไป'
+                            : 'This layer helps separate the right area from the right project before the next shortlist cut.'}
+                        </span>
+                      </div>
+                    </div>
+                    {area.areaSlug ? (
+                      <div className="card-actions mt-3">
+                        <Link className="btn btn-secondary" href={withLocale(locale, `/areas/${encodeURIComponent(area.areaSlug)}`)}>
+                          {locale === 'th' ? 'เปิด area brief' : 'Open area brief'}
+                        </Link>
+                      </div>
+                    ) : null}
+                  </section>
+                ))}
+              </div>
+            </div>
+          ) : areaComparisons.length === 1 ? (
+            <div className="trust-box mb-4">
+              <h2 className="trust-box__title">{locale === 'th' ? 'Area context ยังอยู่ทำเลเดียวกัน' : 'Area context is still concentrated in one zone'}</h2>
+              <p className="section-subtitle">
+                {locale === 'th'
+                  ? `โครงการที่กำลังเทียบตอนนี้ยังผูกอยู่กับ ${areaComparisons[0].areaName} เป็นหลัก ดังนั้นการตัดสินใจรอบนี้ควรอ่านความต่างที่ระดับโครงการเป็นหลัก`
+                  : `The current set still resolves mainly to ${areaComparisons[0].areaName}, so this round of decision-making should focus on project-level trade-offs first.`}
+              </p>
             </div>
           ) : null}
 


### PR DESCRIPTION
## Scope
- add an area comparison layer to the existing public compare surface
- derive area context from current project evaluation and project detail contracts only
- keep the new layer descriptive, comparative, and separate from CRM or advisory-only data

## Why now
- Slice 2 in the approved Investor Decision Tools gate is Area Comparison Surface
- Slice 1 is already merged, so the compare flow can now expand from project trade-offs into location-level context without opening a new route or changing schemas

## Files touched
- admin-app/app/(site)/[locale]/compare/page.tsx
- admin-app/__tests__/compare_area_surface.test.tsx

## Guardrail check
- V1 untouched
- CRM untouched
- lead forms untouched
- homepage untouched
- advisory funnel untouched
- core layout untouched
- no schema change required
- no advisor-only data exposed
- no recommendation, forecast, or guarantee language added

## Validation
- npm --prefix admin-app run test -- __tests__/compare_area_surface.test.tsx __tests__/investor_handoff_regression.test.ts __tests__/shortlist_entry_surfaces.test.tsx
- npm --prefix admin-app run build
- git diff --check

## Risk
- area comparison depends on area context being present in existing project detail responses
- when compared projects resolve to one area only, the surface intentionally falls back to a same-area note instead of forcing a false comparison

## Rollback
- revert commit 676917a1

Closes #479
