### PR TITLE
feat: explain investment snapshots

### DIFF
--- a/admin-app/__tests__/project_deep_review.test.tsx
+++ b/admin-app/__tests__/project_deep_review.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ProjectDeepReview } from '@/components/projects/ProjectDeepReview';
+
+describe('ProjectDeepReview', () => {
+  it('renders snapshot explanation blocks with descriptive guardrails', () => {
+    render(
+      <ProjectDeepReview
+        locale="en"
+        evaluation={{
+          evaluation_version: 'v1',
+          project: {
+            id: 'project-1',
+            slug: 'alpha-residence',
+            name: 'Alpha Residence',
+            status: 'published',
+            created_at: '2026-03-16T00:00:00Z',
+            updated_at: '2026-03-16T00:00:00Z',
+          },
+          area_statistics: {
+            area_id: 'area-1',
+            avg_price_sqm: '120000',
+            avg_rent_monthly: '28000',
+            avg_roi_percent: '5.8',
+            total_projects: 12,
+            total_units: 1800,
+            as_of_date: '2026-03-01',
+            avg_price: 'THB 5.2M',
+            avg_rent: 'THB 28K',
+            roi_percent: '5.8%',
+            as_of: '2026-03-01',
+          },
+          badges: [
+            { key: 'roi_snapshot', label: 'ROI snapshot available' },
+            { key: 'area_stats_available', label: 'Area stats available' },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText(/how to read this snapshot/i)).toBeTruthy();
+    expect(screen.getByText(/not a promised return for alpha residence/i)).toBeTruthy();
+    expect(screen.getByText(/side-by-side comparison context, not as forward-looking projections/i)).toBeTruthy();
+    expect(screen.getByText(/anchored to 2026-03-01/i)).toBeTruthy();
+  });
+});

--- a/admin-app/components/projects/ProjectDeepReview.tsx
+++ b/admin-app/components/projects/ProjectDeepReview.tsx
@@ -59,6 +59,30 @@ export function ProjectDeepReview({
   if (evaluation.area_statistics?.as_of) invLines.push(`${dict.deepReview.asOfLabel}: ${evaluation.area_statistics.as_of}`);
   if (!invLines.length) invLines.push(dict.deepReview.noSnapshots);
 
+  const snapshotExplanation = [
+    evaluation.area_statistics?.roi_percent
+      ? (locale === 'th'
+          ? `ค่า ROI snapshot ที่เห็นตอนนี้เป็นภาพอ่านจากข้อมูลที่เผยแพร่ในปัจจุบัน ไม่ใช่คำรับประกันผลตอบแทนของโครงการ ${evaluation.project.name}`
+          : `The current ROI snapshot is a read of published data in the system, not a promised return for ${evaluation.project.name}.`)
+      : (locale === 'th'
+          ? 'ถ้ายังไม่มี ROI snapshot ให้ใช้บล็อกนี้เพื่อเช็กว่าควรตั้งคำถามอะไรต่อ มากกว่าจะสรุปผลการลงทุนทันที'
+          : 'If ROI is still missing, use this block to frame the next questions rather than force an investment conclusion.'),
+    evaluation.area_statistics?.avg_price || evaluation.area_statistics?.avg_rent
+      ? (locale === 'th'
+          ? 'ตัวเลขราคาและค่าเช่าในบล็อกนี้เหมาะกับการเทียบทางเลือกแบบ side-by-side มากกว่าการใช้เป็นตัวเลขคาดการณ์ล่วงหน้า'
+          : 'The price and rent figures here work best as side-by-side comparison context, not as forward-looking projections.')
+      : (locale === 'th'
+          ? 'เมื่อราคาและค่าเช่ายังไม่ครบ ให้ถือว่าบล็อกนี้อยู่ในโหมด conservative และควรอ่านควบคู่กับ compare หรือ area context'
+          : 'When price and rent data are incomplete, treat this block as conservative context and read it together with compare or area signals.'),
+    evaluation.area_statistics?.as_of
+      ? (locale === 'th'
+          ? `snapshot นี้อิงข้อมูล ณ ${evaluation.area_statistics.as_of} จึงควรใช้เป็นภาพ ณ เวลานั้น ไม่ใช่การันตีว่าตลาดจะเคลื่อนไปทางเดิม`
+          : `This snapshot is anchored to ${evaluation.area_statistics.as_of}, so use it as point-in-time evidence rather than assuming the market will keep moving the same way.`)
+      : (locale === 'th'
+          ? 'หากไม่มีวันที่อัปเดตชัดเจน ให้ยกระดับไปยัง advisor path เดิมก่อนใช้เป็นฐานตัดสินใจขั้นสุดท้าย'
+          : 'If the update date is unclear, escalate through the existing advisor path before treating it as final-decision evidence.'),
+  ];
+
   const riskLabel = score >= 70 ? dict.compare.riskHigh : score >= 35 ? dict.compare.riskMedium : dict.compare.riskLow;
 
   return (
@@ -102,6 +126,14 @@ export function ProjectDeepReview({
             <li key={l}>{l}</li>
           ))}
         </ul>
+
+        <div className="insight-list mt-4" aria-label={locale === 'th' ? 'วิธีอ่าน snapshot นี้' : 'How to read this snapshot'}>
+          {snapshotExplanation.map((line) => (
+            <div key={line} className="insight-list__item">
+              <span className="insight-list__body">{line}</span>
+            </div>
+          ))}
+        </div>
 
         <div className="cta-row mt-3">
           <Link className="btn btn-cta" href={withLocale(locale, '/contact?topic=investment_plan')}>


### PR DESCRIPTION
## Scope
- add descriptive explanation blocks to existing investment snapshot reads on the project deep-review surface
- keep the explanation grounded in current snapshot fields only
- avoid recommendation, forecast, and guarantee language

## Why now
- Slice 3 in the approved Investor Decision Tools gate is Investment Snapshot Explanation Blocks
- the compare and shortlist handoff slices are already merged, so the next safe improvement is helping users interpret current snapshot data before advisor escalation

## Files touched
- admin-app/components/projects/ProjectDeepReview.tsx
- admin-app/__tests__/project_deep_review.test.tsx

## Guardrail check
- V1 untouched
- CRM untouched
- lead forms untouched
- homepage untouched
- advisory funnel untouched
- core layout untouched
- no schema change required
- no advisor-only data exposed
- no recommendation, forecast, or guarantee language added

## Validation
- npm --prefix admin-app run test -- __tests__/project_deep_review.test.tsx __tests__/compare_area_surface.test.tsx __tests__/shortlist_entry_surfaces.test.tsx
- npm --prefix admin-app run build
- git diff --check

## Risk
- explanation copy depends on current snapshot completeness, so sparse snapshots intentionally render conservative guidance
- the block is interpretive only and does not introduce new scoring or decision automation

## Rollback
- revert commit 275466aa

Closes #481