### PR TITLE
feat: add decision support summary

### DIFF
--- a/admin-app/__tests__/compare_decision_support_summary.test.tsx
+++ b/admin-app/__tests__/compare_decision_support_summary.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import ComparePage from '@/app/(site)/[locale]/compare/page';
+
+vi.mock('@/app/_lib/public-api-server', async () => {
+  const actual = await vi.importActual<typeof import('@/app/_lib/public-api-server')>('@/app/_lib/public-api-server');
+  return {
+    ...actual,
+    fetchProjectEvaluation: vi.fn(async (projectId: string) => {
+      if (projectId === 'project-1') {
+        return {
+          evaluation_version: 'v1',
+          project: {
+            id: 'project-1',
+            slug: 'alpha-residence',
+            name: 'Alpha Residence',
+            area_id: 'area-1',
+            status: 'published',
+            created_at: '2026-03-16T00:00:00Z',
+            updated_at: '2026-03-16T00:00:00Z',
+          },
+          area_statistics: {
+            area_id: 'area-1',
+            avg_price_sqm: '120000',
+            avg_rent_monthly: '28000',
+            avg_roi_percent: '5.8',
+            total_projects: 12,
+            total_units: 1800,
+            as_of_date: '2026-03-01',
+            avg_price: 'THB 5.2M',
+            avg_rent: 'THB 28K',
+            roi_percent: '5.8%',
+            as_of: '2026-03-01',
+          },
+          badges: [{ key: 'roi_snapshot', label: 'ROI snapshot available' }],
+        };
+      }
+
+      return {
+        evaluation_version: 'v1',
+        project: {
+          id: 'project-2',
+          slug: 'beta-bay',
+          name: 'Beta Bay',
+          area_id: 'area-2',
+          status: 'published',
+          created_at: '2026-03-16T00:00:00Z',
+          updated_at: '2026-03-16T00:00:00Z',
+        },
+        area_statistics: {
+          area_id: 'area-2',
+          avg_price_sqm: '98000',
+          avg_rent_monthly: '24000',
+          avg_roi_percent: null,
+          total_projects: 9,
+          total_units: 1400,
+          as_of_date: '2026-03-01',
+          avg_price: 'THB 4.6M',
+          avg_rent: 'THB 24K',
+          roi_percent: null,
+          as_of: '2026-03-01',
+        },
+        badges: [{ key: 'area_stats_available', label: 'Area stats available' }],
+      };
+    }),
+    fetchProjectBySlug: vi.fn(async (slug: string) => ({
+      id: slug === 'alpha-residence' ? 'project-1' : 'project-2',
+      slug,
+      name: slug === 'alpha-residence' ? 'Alpha Residence' : 'Beta Bay',
+      status: 'published',
+      property_type: 'condo',
+      summary: { en: 'Summary', th: 'สรุป' },
+      description: { en: 'Description', th: 'รายละเอียด' },
+      amenities: [],
+      investment_snapshot: null,
+      location: null,
+      area: slug === 'alpha-residence'
+        ? { id: 'area-1', slug: 'jomtien', name: 'Jomtien' }
+        : { id: 'area-2', slug: 'pratumnak', name: 'Pratumnak' },
+      created_at: '2026-03-16T00:00:00Z',
+      updated_at: '2026-03-16T00:00:00Z',
+    })),
+  };
+});
+
+describe('compare decision support summary', () => {
+  it('renders a descriptive summary layer instead of a recommendation', async () => {
+    render(
+      await ComparePage({
+        params: Promise.resolve({ locale: 'en' }),
+        searchParams: Promise.resolve({ ids: 'project-1,project-2' }),
+      }),
+    );
+
+    expect(screen.getByRole('heading', { name: /decision support summary/i })).toBeTruthy();
+    expect(screen.getByText(/you are currently reading 2 projects in one frame: alpha residence, beta bay/i)).toBeTruthy();
+    expect(screen.getByText(/location is still an active decision variable because this set spans 2 different areas/i)).toBeTruthy();
+    expect(screen.getByText(/1\/2 projects currently expose ROI snapshots, and 2\/2 projects have enough price or rent context/i)).toBeTruthy();
+    expect(screen.getByText(/not to produce an investment verdict/i)).toBeTruthy();
+  });
+});

--- a/admin-app/app/(site)/[locale]/compare/page.tsx
+++ b/admin-app/app/(site)/[locale]/compare/page.tsx
@@ -171,6 +171,39 @@ async function buildAreaComparisonEntries(
   return Array.from(areaMap.values());
 }
 
+function buildDecisionSupportSummary(input: {
+  locale: 'en' | 'th';
+  items: ProjectEvaluationResponse[];
+  areaComparisons: AreaComparisonEntry[];
+}): string[] {
+  const roiCount = input.items.filter((item) => Boolean(item.area_statistics?.roi_percent)).length;
+  const areaStatsCount = input.items.filter((item) => Boolean(item.area_statistics?.avg_price || item.area_statistics?.avg_rent)).length;
+  const projectNames = input.items.map((item) => item.project.name).filter(Boolean);
+
+  return [
+    input.locale === 'th'
+      ? `ตอนนี้คุณกำลังอ่าน ${projectNames.length} โครงการในเฟรมเดียวกัน: ${projectNames.join(', ')}`
+      : `You are currently reading ${projectNames.length} projects in one frame: ${projectNames.join(', ')}.`,
+    input.areaComparisons.length >= 2
+      ? (input.locale === 'th'
+          ? `การตัดสินใจยังขึ้นกับทำเลอยู่ เพราะชุดนี้ครอบ ${input.areaComparisons.length} ทำเลที่แตกต่างกัน`
+          : `Location is still an active decision variable because this set spans ${input.areaComparisons.length} different areas.`)
+      : (input.locale === 'th'
+          ? 'ชุดนี้ยังอยู่ในทำเลเดียวกันเป็นหลัก ดังนั้นน้ำหนักการตัดสินใจรอบนี้ควรอยู่ที่ความต่างของโครงการและความครบของ snapshot'
+          : 'This set is still concentrated in one area, so the next decision weight should stay on project-level trade-offs and snapshot completeness.'),
+    input.locale === 'th'
+      ? `${roiCount}/${input.items.length} โครงการมี ROI snapshot และ ${areaStatsCount}/${input.items.length} โครงการมีราคา/ค่าเช่าเพียงพอสำหรับใช้เทียบเชิงบริบท`
+      : `${roiCount}/${input.items.length} projects currently expose ROI snapshots, and ${areaStatsCount}/${input.items.length} projects have enough price or rent context for side-by-side reading.`,
+    roiCount === input.items.length && areaStatsCount === input.items.length
+      ? (input.locale === 'th'
+          ? 'เมื่อ snapshot ครบทุกตัวเลือกแล้ว บล็อกนี้ช่วยชี้ว่าควรพาโครงการไหนไปคุยเชิงลึกต่อ ไม่ได้ชี้ว่าควรซื้อโครงการใด'
+          : 'With snapshot coverage across all options, this layer helps you decide which project deserves deeper discussion next, not which project to buy.')
+      : (input.locale === 'th'
+          ? 'เมื่อ snapshot บางส่วนยังขาด ให้ใช้ summary นี้เพื่อระบุคำถามค้างก่อนยกระดับไป advisor review เดิม'
+          : 'When some snapshot fields are still missing, use this summary to identify the open questions before escalating through the existing advisor review path.'),
+  ];
+}
+
 export default async function ComparePage(
   props: {
     params: Promise<{ locale: string }>;
@@ -317,6 +350,7 @@ export default async function ComparePage(
   const missing = ids.filter((_, idx) => evals[idx] == null);
   const items = evals.filter(Boolean) as ProjectEvaluationResponse[];
   const areaComparisons = await buildAreaComparisonEntries(items, locale);
+  const decisionSupportSummary = buildDecisionSupportSummary({ locale, items, areaComparisons });
 
   return (
     <main id="main-content">
@@ -468,6 +502,22 @@ export default async function ComparePage(
               </p>
             </div>
           ) : null}
+
+          <div className="card reveal mb-4">
+            <h2 className="card-title">{locale === 'th' ? 'Decision support summary' : 'Decision support summary'}</h2>
+            <p className="card-subtitle">
+              {locale === 'th'
+                ? 'สรุปชั้นนี้มีไว้เพื่อจัดลำดับคำถามและ next step ของการเปรียบเทียบ ไม่ใช่เพื่อฟันธงการลงทุน'
+                : 'This layer is meant to organize the remaining questions and next step from the comparison, not to produce an investment verdict.'}
+            </p>
+            <div className="insight-list mt-4">
+              {decisionSupportSummary.map((line) => (
+                <div key={line} className="insight-list__item">
+                  <span className="insight-list__body">{line}</span>
+                </div>
+              ))}
+            </div>
+          </div>
 
           <div className="card reveal">
             <h2 className="card-title">{dict.compare.comparisonTable}</h2>


### PR DESCRIPTION
## Scope
- add a decision support summary layer to the existing compare surface
- summarize project, area, and snapshot coverage without producing a recommendation
- keep the output descriptive, comparative, and advisory-safe

## Why now
- Slice 4 in the approved Investor Decision Tools gate is Decision Support Summary Layer
- Slices 1-3 are already merged, so the compare experience can now close with a conservative summary layer built on the same public-safe signals

## Files touched
- admin-app/app/(site)/[locale]/compare/page.tsx
- admin-app/__tests__/compare_decision_support_summary.test.tsx

## Guardrail check
- V1 untouched
- CRM untouched
- lead forms untouched
- homepage untouched
- advisory funnel untouched
- core layout untouched
- no schema change required
- no advisor-only data exposed
- no recommendation, forecast, or guarantee language added

## Validation
- npm --prefix admin-app run test -- __tests__/compare_decision_support_summary.test.tsx __tests__/compare_area_surface.test.tsx __tests__/investor_handoff_regression.test.ts
- npm --prefix admin-app run build
- git diff --check

## Risk
- the summary layer depends on current compare inputs, so missing snapshot fields intentionally produce conservative open-question language
- this layer organizes the readout only and does not automate a ranking or winner selection

## Rollback
- revert commit 960d9f9e

Closes #483