### PR TITLE
Remove lingering public published-copy jargon

### DIFF
--- a/admin-app/app/(site)/[locale]/about/page.tsx
+++ b/admin-app/app/(site)/[locale]/about/page.tsx
@@ -88,28 +88,28 @@ export default async function AboutPage(
       title:
         teamMembers.length > 0
           ? locale === 'th'
-            ? `${teamMembers.length} โปรไฟล์ทีมที่เผยแพร่แล้ว`
-            : `${teamMembers.length} published team profiles`
+            ? `${teamMembers.length} โปรไฟล์ทีมพร้อมให้คำแนะนำ`
+            : `${teamMembers.length} team profiles ready to guide you`
           : dict.about.missionCards[0]?.title || (locale === 'th' ? 'ข้อมูลทีม' : 'Team data'),
       body:
         teamMembers.length > 0
           ? locale === 'th'
-            ? 'ทีมที่แสดงในหน้านี้ดึงจาก backadmin โดยตรงและอัปเดตตามสถานะ publish จริง'
-            : 'The team section is driven directly from backadmin and reflects only live published profiles.'
+            ? 'ทีมที่แสดงในหน้านี้อัปเดตจากข้อมูลจริงของบริษัท และพร้อมพาคุณไปยังขั้นถัดไปที่ชัดเจน'
+            : 'The team section is sourced from live company data and highlights the advisors available for the next step.'
           : dict.about.missionCards[0]?.body || '',
     },
     {
       title:
         testimonials.length > 0
           ? locale === 'th'
-            ? `${testimonials.length} รีวิวลูกค้าที่เผยแพร่แล้ว`
-            : `${testimonials.length} published client reviews`
+            ? `${testimonials.length} เสียงจากลูกค้า`
+            : `${testimonials.length} client reviews`
           : dict.about.missionCards[1]?.title || (locale === 'th' ? 'รีวิวลูกค้า' : 'Client reviews'),
       body:
         testimonials.length > 0
           ? locale === 'th'
-            ? 'รีวิวในหน้านี้ใช้เฉพาะรายการที่ publish แล้วจากระบบหลังบ้านเท่านั้น'
-            : 'The review section only uses testimonial records that are already published from the admin system.'
+            ? 'รีวิวในหน้านี้ใช้เพื่อสะท้อนประสบการณ์จริงของลูกค้า และช่วยให้คุณเห็นภาพการทำงานของทีมชัดขึ้น'
+            : 'These reviews are shown to reflect real client experience and make the team\'s working style easier to assess.'
           : dict.about.missionCards[1]?.body || '',
     },
     {

--- a/admin-app/app/(site)/[locale]/how-we-work/page.tsx
+++ b/admin-app/app/(site)/[locale]/how-we-work/page.tsx
@@ -252,13 +252,13 @@ export default async function HowWeWorkPage(
             <div>
               <h2 className="cta-title">
                 {locale === 'th'
-                  ? `ทีมที่เผยแพร่แล้วตอนนี้ ${teamMembers.length} คน`
+                  ? `ตอนนี้มีทีมที่พร้อมช่วยคุณ ${teamMembers.length} คน`
                   : `${teamMembers.length} live team profile${teamMembers.length === 1 ? '' : 's'} available now`}
               </h2>
               <p className="cta-body">
                 {locale === 'th'
-                  ? 'เมื่อพร้อมส่งรายละเอียดให้ทีม ให้ข้ามไปที่หน้าติดต่อ หรือตรวจรายชื่อทีมที่เผยแพร่แล้วในหน้าแนะนำทีม'
-                  : 'When you are ready to brief the team, move into contact or review the published team roster on the about page.'}
+                  ? 'เมื่อพร้อมส่งรายละเอียด ให้ข้ามไปที่หน้าติดต่อ หรือดูรายชื่อทีมในหน้าแนะนำทีมก่อนตัดสินใจขั้นถัดไป'
+                  : 'When you are ready to brief the team, move into contact or review the team roster on the about page.'}
               </p>
             </div>
             <div className="cta-row">

--- a/admin-app/app/(site)/[locale]/projects/loading.tsx
+++ b/admin-app/app/(site)/[locale]/projects/loading.tsx
@@ -7,7 +7,7 @@ function resolveCopy(locale: string) {
   if (locale === 'th') {
     return {
       title: 'โครงการ',
-      subtitle: 'คลังโครงการที่เผยแพร่แล้วสำหรับรายการคัดไว้และการเปรียบเทียบ',
+      subtitle: 'คลังโครงการสำหรับเริ่มคัดตัวเลือกและเปรียบเทียบต่อ',
       contact: 'คุยกับที่ปรึกษา',
       finder: 'ใช้ตัวช่วยคัดตัวเลือก',
       loading: 'AMP Project Collection',
@@ -21,13 +21,13 @@ function resolveCopy(locale: string) {
 
   return {
     title: 'Projects',
-    subtitle: 'Published project inventory for shortlist and comparison flows.',
+    subtitle: 'Project inventory for shortlist and comparison flows.',
     contact: 'Speak to an Advisor',
     finder: 'Use Smart Finder',
     loading: 'AMP Project Collection',
     sampleTitle: 'Projects curated for comparison',
     sampleBody: 'Use this section to review project context and continue into the shortlist that matches your goals.',
-    signalOne: 'Published projects ready for review',
+    signalOne: 'Projects ready for review',
     signalTwo: 'Details that can move into compare or consultation',
     signalThree: 'The team can still prepare a shortlist directly from your brief',
   };


### PR DESCRIPTION
## What changed
- removed the remaining admin-facing `published` wording from the public projects loading state
- rewrote about-page proof card copy so it no longer references backadmin/publish-state internals
- cleaned the how-we-work CTA so public visitors see team/help language instead of publish-state language

## Why it changed
- post-deploy validation on the live site surfaced leftover public copy that still read like CMS/admin state rather than customer-facing guidance
- this hotfix closes the last visible wording leak from the public listing polish release

## What was validated
- `python -m ruff format d:/FlowBiz/flowbiz-client-amp`
- `python -m ruff check d:/FlowBiz/flowbiz-client-amp`
- `python -m pytest -q tests` -> 276 passed
- `npm --prefix admin-app run test -- --reporter=basic` -> 121 files / 512 tests passed
- `npm --prefix admin-app run build`

## Risks / watch items
- wording-only hotfix on three public files; functional behavior is unchanged
- watch CDN/public cache propagation on about/projects surfaces after deploy

## Rollback focus
- revert commit `bd1d8109` if this wording cleanup needs to be undone

## Deploy notes
- deploy after merge with `./scripts/deploy_prod.ps1`
- re-check `/en/about`, `/th/about`, `/en/projects`, `/th/projects`, and the projects loading surface through a cache-busted request

## Smoke checklist
- [ ] `/api/platform/version` reports the merged hotfix SHA
- [ ] `/en/about` and `/th/about` no longer leak admin-facing publish wording
- [ ] `/en/projects` loading surface no longer shows `Published projects ready for review`
- [ ] standard production smoke endpoints remain green
