### PR TITLE
Align production smoke check with project detail contract

### DIFF
--- a/scripts/prod_smoke_check.sh
+++ b/scripts/prod_smoke_check.sh
@@ -198,7 +198,7 @@ if project_detail_path:
             "project_detail_contract",
             all(marker in project_html for marker in [
                 'id="project_consultation_primary"',
-                'id="project_compare_secondary"',
+                'id="project_self_serve_secondary"',
                 'id="project-brief-section"',
                 'id="project-decision-lens"',
                 'id="project-related-reads"',


### PR DESCRIPTION
## What changed
- updated scripts/prod_smoke_check.sh to assert the current project detail CTA marker project_self_serve_secondary
- removed the stale project_compare_secondary marker from the project-detail smoke contract

## Why it changed
- post-deploy validation on PR #527 failed on project_detail_contract
- investigation showed the live page and the app test suite both use project_self_serve_secondary; the smoke script had drifted behind the real DOM contract

## Validation
- uff format
- uff check
- pytest
- live production verification of the current project detail DOM showed all expected markers except the stale one

## Risks / watch items
- low risk: this is a validation-only change
- watch for any future rename of project detail CTA ids; smoke and app tests should stay aligned

## Rollback focus
- revert this PR if the smoke checker needs to be restored to the previous contract for any reason

## Deploy notes
- deploy after merge so the VPS active repo and release copy include the corrected smoke contract
- rerun scripts/prod_smoke_check.sh on the VPS against https://amppattaya.com

## Smoke checklist
- [x] uff format
- [x] uff check
- [x] pytest
- [x] confirm project_self_serve_secondary exists on live /en/projects/aquarous-jomtien-pattaya
- [ ] merge + deploy
- [ ] rerun production smoke on VPS