### PR TITLE
feat(amp-public): add public shell header footer mobile menu

### DIFF
--- a/admin-app/app/(site)/[locale]/layout.tsx
+++ b/admin-app/app/(site)/[locale]/layout.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from 'react';
 import { Suspense } from 'react';
 import { headers } from 'next/headers';
 
-import { Footer } from '@/components/layout/Footer';
-import { Header } from '@/components/layout/Header';
+import { SiteFooter } from '@/components/layout/Footer';
+import { SiteHeader } from '@/components/layout/Header';
 import { PublicClientEnhancements } from '@/components/layout/PublicClientEnhancements';
 import { resolveLayoutCms, SITE_LAYOUT_CMS_SLUG } from '@/app/_lib/layout-cms';
 import { fetchCompanyInfoBySlug } from '@/app/_lib/public-api-server';
@@ -82,9 +82,9 @@ export default async function SiteLayout(
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLd }} />
       <div className="public-site-shell" data-locale={locale}>
-        <Header locale={locale} cms={layoutCms.header} />
+        <SiteHeader locale={locale} cms={layoutCms.header} />
         {children}
-        <Footer locale={locale} cms={layoutCms.footer} />
+        <SiteFooter locale={locale} cms={layoutCms.footer} />
         <div aria-live="polite" aria-atomic="true" id="amp-live-region" className="sr-only" />
         <Suspense fallback={null}>
           <PublicClientEnhancements />
@@ -93,4 +93,3 @@ export default async function SiteLayout(
     </>
   );
 }
-

--- a/admin-app/app/_lib/public-navigation.ts
+++ b/admin-app/app/_lib/public-navigation.ts
@@ -1,0 +1,275 @@
+import type { ResolvedLayoutCms, ResolvedLayoutLink } from '@/app/_lib/layout-cms';
+import type { Dictionary, Locale } from '@/app/_lib/i18n/types';
+import { CTA } from '@/app/_lib/public-cta';
+
+export type PublicNavItem = {
+  key: string;
+  label: string;
+  href?: string;
+  items?: PublicNavDropdownItem[];
+};
+
+export type PublicNavDropdownItem = ResolvedLayoutLink & {
+  desc?: string;
+};
+
+export type PublicQuickPath = {
+  href: string;
+  label: string;
+  detail: string;
+};
+
+export type PublicCtaItem = {
+  key: 'shortlist' | 'whatsapp' | 'contact';
+  label: string;
+  href: string;
+  external?: boolean;
+  tone: 'utility' | 'secondary' | 'primary';
+};
+
+export type FooterLinkGroup = {
+  key: 'quick' | 'property' | 'buyer' | 'company' | 'legal';
+  title: string;
+  items: ResolvedLayoutLink[];
+};
+
+type HeaderCms = ResolvedLayoutCms['header'];
+type FooterCms = ResolvedLayoutCms['footer'];
+
+function fromCmsPrimaryLinks(cms?: HeaderCms): PublicNavItem[] {
+  return (cms?.primaryLinks || []).map((item, index) => ({
+    key: `cms-${index}`,
+    label: item.label,
+    href: item.href,
+  }));
+}
+
+export function getPublicNavItems(locale: Locale, dict: Dictionary, cms?: HeaderCms): PublicNavItem[] {
+  const cmsNavItems = fromCmsPrimaryLinks(cms);
+  if (cmsNavItems.length > 0) return cmsNavItems;
+
+  const investLabel = locale === 'th' ? 'วางแผนลงทุน' : 'Investment Guides';
+  const smartFinderLabel = locale === 'th' ? 'ตัวช่วยคัดตัวเลือก' : 'Smart Finder';
+  const compareLabel = locale === 'th' ? 'เทียบตัวเลือก' : 'Compare';
+  const marketplaceLabel = locale === 'th' ? 'ประกาศทั้งหมด' : 'Marketplace';
+  const rentLabel = locale === 'th' ? 'เช่า' : 'Rent';
+  const sellLabel = locale === 'th' ? 'ขาย' : 'Sell';
+  const aboutLabel = locale === 'th' ? 'เกี่ยวกับ AMP' : 'About';
+
+  return [
+    { key: 'home', label: dict.nav.home, href: '/' },
+    {
+      key: 'buy',
+      label: dict.nav.buy,
+      href: '/buy',
+      items: [
+        {
+          href: '/buy',
+          label: dict.nav.buy,
+          desc: locale === 'th'
+            ? 'เส้นทางซื้อสำหรับผู้ซื้อชาวต่างชาติและผู้ที่มองหาบ้านพักตากอากาศ'
+            : 'Buyer route for foreign nationals and second-home clients',
+        },
+        {
+          href: '/projects',
+          label: dict.nav.projects,
+          desc: locale === 'th'
+            ? 'ดูโครงการใหม่และโครงการที่ผ่านการคัดกรอง'
+            : 'Review vetted projects and launches first',
+        },
+        {
+          href: '/marketplace',
+          label: marketplaceLabel,
+          desc: locale === 'th'
+            ? 'ดูรายการที่ยังเปิดขายอยู่ในระบบ'
+            : 'Open active inventory across the catalogue',
+        },
+        {
+          href: '/invest',
+          label: dict.nav.invest,
+          desc: locale === 'th'
+            ? 'กรอบคิดก่อนซื้อเพื่ออยู่เอง ลงทุน หรือปล่อยเช่า'
+            : 'Investment framing before buying, holding, or renting out',
+        },
+      ],
+    },
+    { key: 'rent', label: rentLabel, href: '/rent' },
+    { key: 'projects', label: dict.nav.projects, href: '/projects' },
+    { key: 'sell', label: sellLabel, href: '/sell' },
+    { key: 'about', label: aboutLabel, href: '/about' },
+    { key: 'contact', label: dict.nav.contact, href: '/contact' },
+    {
+      key: 'area-guide',
+      label: dict.nav.areaGuide,
+      href: '/area-guide',
+      items: [
+        {
+          href: '/area-guide',
+          label: dict.nav.areaGuide,
+          desc: locale === 'th' ? 'ภาพรวมแต่ละโซนในพัทยา' : 'Understand Pattaya zone differences',
+        },
+        {
+          href: '/smart-finder',
+          label: smartFinderLabel,
+          desc: locale === 'th'
+            ? 'ช่วยคัดจากงบประมาณและโจทย์ของคุณ'
+            : 'Guided matching by budget and brief',
+        },
+        {
+          href: '/compare',
+          label: compareLabel,
+          desc: locale === 'th'
+            ? 'เทียบตัวเลือกแบบวางข้างกันอย่างชัดเจน'
+            : 'Compare options side-by-side',
+        },
+        {
+          href: '/investment',
+          label: investLabel,
+          desc: locale === 'th'
+            ? 'ผลตอบแทน ดีมานด์ และความเสี่ยงของพัทยา'
+            : 'Yield, demand, and risk framing for Pattaya',
+        },
+      ],
+    },
+  ];
+}
+
+export function getHomePublicNavItems(locale: Locale, dict: Dictionary): PublicNavItem[] {
+  const homeAreaLabel = locale === 'th' ? 'พื้นที่' : 'Areas';
+
+  return [
+    { key: 'home-buy', label: dict.nav.buy, href: '/buy' },
+    { key: 'home-rent', label: locale === 'th' ? 'เช่า' : 'Rent', href: '/rent' },
+    { key: 'home-projects', label: dict.nav.projects, href: '/projects' },
+    { key: 'home-sell', label: locale === 'th' ? 'ขาย' : 'Sell', href: '/sell' },
+    { key: 'home-areas', label: homeAreaLabel, href: '/area-guide' },
+    { key: 'home-contact', label: dict.nav.contact, href: '/contact' },
+  ];
+}
+
+export function getHomeMobileNavItems(locale: Locale, dict: Dictionary): PublicNavItem[] {
+  const homeAreaLabel = locale === 'th' ? 'พื้นที่' : 'Areas';
+
+  return [
+    { key: 'home-mobile-projects', label: dict.nav.projects, href: '/projects' },
+    { key: 'home-mobile-areas', label: homeAreaLabel, href: '/area-guide' },
+    { key: 'home-mobile-about', label: locale === 'th' ? 'เกี่ยวกับ AMP' : 'About', href: '/about' },
+    { key: 'home-mobile-contact', label: dict.nav.contact, href: '/contact' },
+  ];
+}
+
+export function getMobileQuickPaths(locale: Locale): PublicQuickPath[] {
+  return [
+    {
+      href: '/buy',
+      label: locale === 'th' ? 'ซื้อ' : 'Buy',
+      detail: locale === 'th' ? 'ซื้อในพัทยา' : 'Buy in Pattaya',
+    },
+    {
+      href: '/rent',
+      label: locale === 'th' ? 'เช่า' : 'Rent',
+      detail: locale === 'th' ? 'เช่าหรือย้ายมาอยู่' : 'Rent or relocate',
+    },
+    {
+      href: '/projects',
+      label: locale === 'th' ? 'โครงการ' : 'Projects',
+      detail: locale === 'th' ? 'โครงการใหม่และโครงการคัดกรอง' : 'New and vetted launches',
+    },
+    {
+      href: '/sell',
+      label: locale === 'th' ? 'ขาย' : 'Sell',
+      detail: locale === 'th' ? 'ขายหรือปล่อยเช่า' : 'Sell or rent out',
+    },
+  ];
+}
+
+export function getPublicCtaItems(locale: Locale, dict: Dictionary, cms?: HeaderCms): PublicCtaItem[] {
+  const contactCta = cms?.contactCta || { href: '/contact', label: dict.cta.speakToAdvisor };
+
+  return [
+    {
+      key: 'shortlist',
+      label: locale === 'th' ? 'รายการคัดไว้' : 'Shortlist',
+      href: '/shortlist',
+      tone: 'utility',
+    },
+    {
+      key: 'whatsapp',
+      label: dict.cta.whatsapp,
+      href: CTA.whatsAppUrl,
+      external: true,
+      tone: 'secondary',
+    },
+    {
+      key: 'contact',
+      label: contactCta.label,
+      href: contactCta.href,
+      tone: 'primary',
+    },
+  ];
+}
+
+export function getFooterLinkGroups(locale: Locale, dict: Dictionary, cms?: FooterCms): FooterLinkGroup[] {
+  const quickLinks = cms?.quickLinks?.length
+    ? cms.quickLinks
+    : [
+        { href: '/', label: dict.nav.home },
+        { href: '/buy', label: dict.nav.buy },
+        { href: '/rent', label: locale === 'th' ? 'เช่า' : 'Rent' },
+        { href: '/projects', label: dict.nav.projects },
+        { href: '/contact', label: dict.nav.contact },
+      ];
+
+  const legalLinks = cms?.legalLinks?.length
+    ? cms.legalLinks
+    : [
+        { href: '/terms', label: locale === 'th' ? 'ข้อตกลงการใช้งาน' : 'Terms' },
+        { href: '/privacy', label: dict.common.privacyPolicy || 'Privacy' },
+      ];
+
+  return [
+    {
+      key: 'quick',
+      title: locale === 'th' ? 'ลิงก์ด่วน' : 'Quick links',
+      items: quickLinks,
+    },
+    {
+      key: 'property',
+      title: locale === 'th' ? 'อสังหาฯ พัทยา' : 'Property',
+      items: [
+        { href: '/buy', label: locale === 'th' ? 'คอนโดและบ้านสำหรับซื้อ' : 'Buy property' },
+        { href: '/rent', label: locale === 'th' ? 'เช่าคอนโดและบ้าน' : 'Rent property' },
+        { href: '/projects', label: locale === 'th' ? 'โครงการใหม่' : 'New projects' },
+        { href: '/area-guide', label: dict.nav.areaGuide },
+        { href: '/marketplace', label: locale === 'th' ? 'ประกาศทั้งหมด' : 'Marketplace' },
+      ],
+    },
+    {
+      key: 'buyer',
+      title: locale === 'th' ? 'เครื่องมือผู้ซื้อ' : 'Buyer resources',
+      items: [
+        { href: '/smart-finder', label: locale === 'th' ? 'ตัวช่วยคัดตัวเลือก' : 'Smart Finder' },
+        { href: '/compare', label: locale === 'th' ? 'เทียบตัวเลือก' : 'Compare' },
+        { href: '/buying-cost-estimator', label: locale === 'th' ? 'คำนวณต้นทุนซื้อ' : 'Buying cost estimator' },
+        { href: '/investment', label: locale === 'th' ? 'คู่มือลงทุน' : 'Investment guide' },
+        { href: '/shortlist', label: locale === 'th' ? 'รายการคัดไว้' : 'Shortlist' },
+      ],
+    },
+    {
+      key: 'company',
+      title: locale === 'th' ? 'บริษัท' : 'Company',
+      items: [
+        { href: '/about', label: locale === 'th' ? 'เกี่ยวกับ AMP' : 'About AMP' },
+        { href: '/how-we-work', label: locale === 'th' ? 'วิธีทำงานกับเรา' : 'How we work' },
+        { href: '/sell', label: locale === 'th' ? 'ขายกับ AMP' : 'Sell with AMP' },
+        { href: '/blog', label: locale === 'th' ? 'บทความและข่าวสาร' : 'Blog' },
+        { href: '/contact', label: dict.nav.contact },
+      ],
+    },
+    {
+      key: 'legal',
+      title: locale === 'th' ? 'กฎหมาย' : 'Legal',
+      items: legalLinks,
+    },
+  ];
+}

--- a/admin-app/components/layout/Footer.tsx
+++ b/admin-app/components/layout/Footer.tsx
@@ -5,253 +5,190 @@ import type { ResolvedLayoutCms } from '../../app/_lib/layout-cms';
 import type { Dictionary, Locale } from '../../app/_lib/i18n/types';
 import { withLocale } from '../../app/_lib/i18n/routing';
 import { CTA } from '../../app/_lib/public-cta';
+import { getFooterLinkGroups } from '../../app/_lib/public-navigation';
 import { en } from '../../app/_lib/i18n/en';
 import { th } from '../../app/_lib/i18n/th';
 import { getPublicButtonClassName } from '../public-system/tokens/publicUiTokens';
 
 type FooterCms = ResolvedLayoutCms['footer'];
 
-export function Footer({
-  locale,
-  dict: dictProp,
-  cms,
-}: {
+type FooterProps = {
   locale: Locale;
   dict?: Dictionary;
   cms?: FooterCms;
-}) {
-  const dict = dictProp ?? (locale === 'th' ? th : en);
+};
 
-  // Column definitions with i18n labels
-  const columns = {
-    browse: {
-      title: locale === 'th' ? 'เรียกดูโครงการ' : 'Browse',
-      items: [
-        { label: locale === 'th' ? 'โครงการใหม่' : 'New projects', href: '/projects' },
-        { label: locale === 'th' ? 'คอนโดมือสอง' : 'Resale condos', href: '/buy' },
-        { label: locale === 'th' ? 'พูลวิลล่า' : 'Pool villas', href: '/buy' },
-        { label: locale === 'th' ? 'ข้อเสนอพรีเซล' : 'Off-plan deals', href: '/invest' },
-        { label: locale === 'th' ? 'ลดราคาพิเศษ' : 'Recently reduced', href: '/buy' },
-      ],
-    },
-    invest: {
-      title: locale === 'th' ? 'สำหรับนักลงทุน' : 'Invest',
-      items: [
-        { label: locale === 'th' ? 'กรรมสิทธิ์คนต่างชาติ' : 'Foreign ownership', href: '/invest' },
-        { label: locale === 'th' ? 'ผลตอบแทนการเช่า' : 'Rental yields', href: '/invest' },
-        { label: locale === 'th' ? 'เครื่องคำนวณต้นทุน' : 'Cost calculator', href: '/calculator' },
-        { label: locale === 'th' ? 'การเติบโตของราคา' : 'Capital gains', href: '/invest' },
-        { label: locale === 'th' ? 'ภาษีและกฎหมาย' : 'Tax & legal', href: '/how-we-work' },
-      ],
-    },
-    company: {
-      title: locale === 'th' ? 'บริษัท' : 'Company',
-      items: [
-        { label: locale === 'th' ? 'เกี่ยวกับ AMP' : 'About AMP', href: '/how-we-work' },
-        { label: locale === 'th' ? 'ทีมที่ปรึกษา' : 'Our team', href: '/how-we-work' },
-        { label: locale === 'th' ? 'ข่าวสาร & บล็อก' : 'Press', href: '/blog' },
-        { label: locale === 'th' ? 'นโยบายความเป็นส่วนตัว' : 'Privacy', href: '/privacy' },
-        { label: locale === 'th' ? 'ร่วมงานกับเรา' : 'Careers', href: '/how-we-work' },
-      ],
-    },
-  };
+export function SiteFooter({
+  locale,
+  dict: dictProp,
+  cms,
+}: FooterProps) {
+  const dict = dictProp ?? (locale === 'th' ? th : en);
+  const footerLinkGroups = getFooterLinkGroups(locale, dict, cms);
+  const visibleLinkGroups = footerLinkGroups.filter((group) => group.key !== 'legal').slice(0, 4);
+  const legalGroup = footerLinkGroups.find((group) => group.key === 'legal');
+  const legalLinks = legalGroup?.items.length
+    ? legalGroup.items
+    : [
+        { href: '/terms', label: dict.common.termsOfService },
+        { href: '/privacy', label: dict.common.privacyPolicy },
+      ];
+  const contactEmail = cms?.contact.email || dict.common.contactEmail || 'hello@amppattaya.com';
+  const facebookUrl = cms?.contact.facebookUrl || dict.common.facebookUrl;
+  const facebookLabel = cms?.contact.facebookLabel || dict.common.facebookLabel || 'Facebook';
 
   const brandDesc = locale === 'th'
     ? 'ที่ปรึกษาอสังหาริมทรัพย์ระดับผู้เชี่ยวชาญของพัทยา ได้รับใบอนุญาตจัดตั้งปี 2018 สมาชิกสมาคมอสังหาริมทรัพย์ไทย'
     : "Pattaya's investor-grade property advisory. Licensed brokerage est. 2018. Member, Thai Real Estate Association.";
 
-  const officeTitle = locale === 'th' ? 'สำนักงาน' : 'Office';
   const officeAddress = locale === 'th' ? (
     <>
       333/12 ถนนพระตำหนัก<br />
       อ.บางละมุง จ.ชลบุรี 20150<br />
-      จันทร์–เสาร์ · 9:00–19:00 ICT
+      จันทร์-เสาร์ · 9:00-19:00 ICT
     </>
   ) : (
     <>
       333/12 Pratumnak Road<br />
       Banglamung, Chonburi 20150<br />
-      Mon–Sat · 9:00–19:00 ICT
+      Mon-Sat · 9:00-19:00 ICT
     </>
   );
 
   const pdpaText = dict.common.pdpaNotice ?? 'PDPA & GDPR Compliant';
 
   return (
-    <footer 
-      className="relative w-full text-[var(--public-color-bone, #f8f4ea)] pt-16 pb-8 border-t border-[rgba(248,244,234,0.1)] overflow-hidden" 
+    <footer
+      className="site-footer footer relative w-full text-[var(--public-color-bone, #f8f4ea)] pt-16 pb-8 border-t border-[rgba(248,244,234,0.1)] overflow-hidden"
       style={{ background: 'var(--public-color-ink, #0e3a3a)' }}
-      role="contentinfo" 
+      role="contentinfo"
       data-locale={locale}
     >
       <Container variant="wide">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-12 gap-10 lg:gap-8 pb-12">
-          {/* Column 1: Brand (4/12 width) */}
           <div className="lg:col-span-4 flex flex-col items-start">
             <Link href={withLocale(locale, '/')} prefetch={false} className="flex items-center text-white mb-4 hover:opacity-90 transition-opacity">
-              <svg width="24" height="24" viewBox="0 0 32 32" className="shrink-0 mr-1 text-white" style={{ fill: 'none' }}>
-                <rect x="0.5" y="0.5" width="31" height="31" rx="6" fill="none" stroke="currentColor" strokeWidth="1.2"/>
-                <path d="M9 23 L16 9 L23 23 M12 18 L20 18" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+              <svg width="24" height="24" viewBox="0 0 32 32" className="shrink-0 mr-1 text-white" style={{ fill: 'none' }} aria-hidden="true">
+                <rect x="0.5" y="0.5" width="31" height="31" rx="6" fill="none" stroke="currentColor" strokeWidth="1.2" />
+                <path d="M9 23 L16 9 L23 23 M12 18 L20 18" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
               <span className="font-serif font-normal tracking-[0.04em] text-xl flex items-center leading-none text-white">
                 AMP <span className="italic ml-1 font-normal text-white">Pattaya</span>
               </span>
             </Link>
-            <p className="footer-brand__promise text-sm leading-relaxed text-[var(--public-color-bone, #f8f4ea)]/70 max-w-[280px] mb-6">
+
+            <p className="footer-brand__promise text-sm leading-relaxed text-[var(--public-color-bone, #f8f4ea)]/70 max-w-[300px] mb-6">
               {brandDesc}
             </p>
-            {/* Social Icons row */}
+
+            <div className="footer-contact-block mb-6 text-sm leading-relaxed text-[var(--public-color-bone, #f8f4ea)]/80">
+              <span className="block font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--public-color-bone, #f8f4ea)]/50 mb-3 font-semibold">
+                {locale === 'th' ? 'ติดต่อ AMP Pattaya' : 'Contact AMP Pattaya'}
+              </span>
+              <p className="mb-3">{officeAddress}</p>
+              <a href={CTA.phoneTel} className="block text-white hover:text-[var(--public-color-champagne)] transition-colors duration-200 font-medium">
+                {CTA.phoneTel.replace('tel:', '')}
+              </a>
+              <a href={`mailto:${contactEmail}`} className="block text-[var(--public-color-bone, #f8f4ea)]/80 hover:text-white transition-colors duration-200">
+                {contactEmail}
+              </a>
+            </div>
+
+            <Link
+              href={withLocale(locale, '/contact')}
+              prefetch={false}
+              className={getPublicButtonClassName({
+                variant: 'coral',
+                size: 'sm',
+                className: 'footer-cta-link mb-5',
+              })}
+            >
+              {locale === 'th' ? 'คุยกับที่ปรึกษา' : 'Speak to an advisor'}
+            </Link>
+
             <div className="footer-signal-list flex items-center gap-2">
-              {/* WhatsApp Button */}
-              <a 
-                href={CTA.whatsAppUrl} 
-                target="_blank" 
+              <a
+                href={CTA.whatsAppUrl}
+                target="_blank"
                 rel="noreferrer"
                 className="footer-action footer-action--primary w-9 h-9 rounded-full flex items-center justify-center bg-[rgba(248,244,234,0.08)] border border-[rgba(248,244,234,0.12)] hover:bg-[rgba(248,244,234,0.18)] hover:scale-105 transition-all text-white"
                 aria-label="WhatsApp"
               >
-                <svg className="w-4 h-4 fill-current" viewBox="0 0 24 24">
-                  <path d="M.057 24l1.687-6.163c-1.041-1.804-1.588-3.849-1.587-5.946C.06 5.348 5.397.01 12.008.01c3.202.001 6.212 1.246 8.477 3.514 2.266 2.268 3.507 5.28 3.505 8.484-.004 6.657-5.34 11.997-11.953 11.997-2.005-.001-3.973-.502-5.733-1.458L0 24zm6.59-4.846c1.6.95 3.188 1.449 4.825 1.451 5.436 0 9.86-4.42 9.863-9.864.001-2.636-1.026-5.112-2.893-6.979C16.576 1.897 14.1 .87 11.464.87c-5.437 0-9.866 4.418-9.87 9.864 0 1.702.449 3.361 1.305 4.832L1.87 21.05l5.777-1.516l-.001-.001zm10.742-7.403c-.29-.145-1.716-.848-1.982-.944-.266-.096-.46-.145-.652.145-.19.29-.74.944-.908 1.134-.167.19-.334.213-.624.069-.29-.145-1.22-.45-2.324-1.434-.86-.767-1.44-1.715-1.608-2.005-.168-.29-.018-.447.127-.592.13-.13.29-.34.435-.508.145-.168.193-.29.29-.483.097-.193.048-.362-.024-.507-.073-.145-.652-1.57-.893-2.15c-.234-.569-.47-.492-.652-.501-.17-.008-.363-.01-.557-.01-.193 0-.507.073-.772.362-.266.29-1.014.992-1.014 2.422 0 1.43 1.039 2.81 1.184 3.002.145.193 2.044 3.12 4.953 4.382.692.3 1.232.478 1.652.612.696.22 1.33.19 1.83.115.556-.084 1.717-.7 1.96-1.378.243-.678.243-1.258.17-1.379-.073-.12-.266-.193-.556-.339z" />
+                <svg className="w-4 h-4 fill-current" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M.057 24l1.687-6.163c-1.041-1.804-1.588-3.849-1.587-5.946C.06 5.348 5.397.01 12.008.01c3.202.001 6.212 1.246 8.477 3.514 2.266 2.268 3.507 5.28 3.505 8.484-.004 6.657-5.34 11.997-11.953 11.997-2.005-.001-3.973-.502-5.733-1.458L0 24zm6.59-4.846c1.6.95 3.188 1.449 4.825 1.451 5.436 0 9.86-4.42 9.863-9.864.001-2.636-1.026-5.112-2.893-6.979C16.576 1.897 14.1.87 11.464.87c-5.437 0-9.866 4.418-9.87 9.864 0 1.702.449 3.361 1.305 4.832L1.87 21.05l5.777-1.516l-.001-.001zm10.742-7.403c-.29-.145-1.716-.848-1.982-.944-.266-.096-.46-.145-.652.145-.19.29-.74.944-.908 1.134-.167.19-.334.213-.624.069-.29-.145-1.22-.45-2.324-1.434-.86-.767-1.44-1.715-1.608-2.005-.168-.29-.018-.447.127-.592.13-.13.29-.34.435-.508.145-.168.193-.29.29-.483.097-.193.048-.362-.024-.507-.073-.145-.652-1.57-.893-2.15c-.234-.569-.47-.492-.652-.501-.17-.008-.363-.01-.557-.01-.193 0-.507.073-.772.362-.266.29-1.014.992-1.014 2.422 0 1.43 1.039 2.81 1.184 3.002.145.193 2.044 3.12 4.953 4.382.692.3 1.232.478 1.652.612.696.22 1.33.19 1.83.115.556-.084 1.717-.7 1.96-1.378.243-.678.243-1.258.17-1.379-.073-.12-.266-.193-.556-.339z" />
                 </svg>
               </a>
-              {/* LINE Button */}
-              <a 
-                href={CTA.lineUrl} 
-                target="_blank" 
+              <a
+                href={CTA.lineUrl}
+                target="_blank"
                 rel="noreferrer"
                 className="w-9 h-9 rounded-full flex items-center justify-center bg-[rgba(248,244,234,0.08)] border border-[rgba(248,244,234,0.12)] hover:bg-[rgba(248,244,234,0.18)] hover:scale-105 transition-all text-white"
                 aria-label="LINE"
               >
-                <svg className="w-4 h-4 fill-current" viewBox="0 0 24 24">
+                <svg className="w-4 h-4 fill-current" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M24 10.304c0-5.369-5.383-9.738-12-9.738-6.616 0-12 4.369-12 9.738 0 4.814 4.269 8.846 10.036 9.564.39.084.922.258 1.058.592.12.296.079.759.038 1.059l-.171 1.027c-.052.31-.252 1.213 1.085.662 1.337-.552 7.218-4.249 9.852-7.276 2.115-2.348 3.102-4.707 3.102-6.928zm-15.004 2.923h-2.148c-.287 0-.52-.232-.52-.52v-4.086c0-.287.233-.52.52-.52h2.148c.287 0 .52.233.52.52v.72c0 .287-.233.52-.52.52h-1.428v.797h1.428c.287 0 .52.233.52.52v.72c0 .287-.233.52-.52.52h-1.428v.803h1.428c.287 0 .52.233.52.52v.72c0 .288-.233.521-.52.521zm4.195 0h-1.628c-.288 0-.52-.232-.52-.52v-4.086c0-.287.232-.52.52-.52h.72c.287 0 .52.233.52.52v3.366h.388c.287 0 .52.233.52.52v.72c0 .288-.233.52-.52.52zm1.624-.52v-4.086c0-.287.232-.52.52-.52h.72c.287 0 .52.233.52.52v4.086c0 .288-.233.52-.52.52h-.72c-.288 0-.52-.232-.52-.52zm6.305 0c0 .288-.232.52-.52.52h-.768l-2.028-2.793v2.273c0 .288-.233.52-.52.52h-.72c-.287 0-.52-.232-.52-.52v-4.086c0-.287.233-.52.52-.52h.768l2.028 2.793v-2.273c0-.287.233-.52.52-.52h.72c.287 0 .52.233.52.52v4.086z" />
                 </svg>
               </a>
-              {/* Mail Button */}
-              <a 
-                href={`mailto:${dict.common.contactEmail || 'hello@amppattaya.com'}`} 
+              <a
+                href={`mailto:${contactEmail}`}
                 className="w-9 h-9 rounded-full flex items-center justify-center bg-[rgba(248,244,234,0.08)] border border-[rgba(248,244,234,0.12)] hover:bg-[rgba(248,244,234,0.18)] hover:scale-105 transition-all text-white"
                 aria-label="Email"
               >
-                <svg className="w-4 h-4 fill-none stroke-current" viewBox="0 0 24 24" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg className="w-4 h-4 fill-none stroke-current" viewBox="0 0 24 24" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                 </svg>
               </a>
-              {/* Phone Button */}
-              <a 
-                href={CTA.phoneTel} 
-                className="w-9 h-9 rounded-full flex items-center justify-center bg-[rgba(248,244,234,0.08)] border border-[rgba(248,244,234,0.12)] hover:bg-[rgba(248,244,234,0.18)] hover:scale-105 transition-all text-white"
-                aria-label="Phone"
-              >
-                <svg className="w-4 h-4 fill-none stroke-current" viewBox="0 0 24 24" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M3 5a2 2 0 012-2h3.28a1 1 0 01.94.725l.548 2.2a1 1 0 00.996.808H12a1 1 0 00.996-.808l.548-2.2A1 1 0 0114.48 3H17.72a2 2 0 012 2v1.5a12.5 12.5 0 01-12.5 12.5H3V5z" />
-                </svg>
-              </a>
             </div>
           </div>
 
-          {/* Column 2: Browse (2/12 width) */}
-          <div className="lg:col-span-2">
-            <span className="block font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--public-color-bone, #f8f4ea)]/50 mb-4 font-semibold">
-              {columns.browse.title}
-            </span>
-            <ul className="flex flex-col gap-3">
-              {columns.browse.items.map((item, idx) => (
-                <li key={idx}>
-                  <Link 
-                    href={withLocale(locale, item.href)} 
-                    prefetch={false}
-                    className="text-sm text-[var(--public-color-bone, #f8f4ea)]/80 hover:text-white transition-colors duration-200"
-                  >
-                    {item.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Column 3: Invest (2/12 width) */}
-          <div className="lg:col-span-2">
-            <span className="block font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--public-color-bone, #f8f4ea)]/50 mb-4 font-semibold">
-              {columns.invest.title}
-            </span>
-            <ul className="flex flex-col gap-3">
-              {columns.invest.items.map((item, idx) => (
-                <li key={idx}>
-                  <Link 
-                    href={withLocale(locale, item.href)} 
-                    prefetch={false}
-                    className="text-sm text-[var(--public-color-bone, #f8f4ea)]/80 hover:text-white transition-colors duration-200"
-                  >
-                    {item.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Column 4: Company (2/12 width) */}
-          <div className="lg:col-span-2">
-            <span className="block font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--public-color-bone, #f8f4ea)]/50 mb-4 font-semibold">
-              {columns.company.title}
-            </span>
-            <ul className="flex flex-col gap-3">
-              {columns.company.items.map((item, idx) => (
-                <li key={idx}>
-                  <Link 
-                    href={withLocale(locale, item.href)} 
-                    prefetch={false}
-                    className="text-sm text-[var(--public-color-bone, #f8f4ea)]/80 hover:text-white transition-colors duration-200"
-                  >
-                    {item.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Column 5: Office (2/12 width) */}
-          <div className="lg:col-span-2">
-            <span className="block font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--public-color-bone, #f8f4ea)]/50 mb-4 font-semibold">
-              {officeTitle}
-            </span>
-            <p className="text-sm leading-relaxed text-[var(--public-color-bone, #f8f4ea)]/80 mb-3 font-normal">
-              {officeAddress}
-            </p>
-            <div>
-              <a 
-                href={CTA.phoneTel} 
-                className="text-sm text-white hover:text-[var(--public-color-champagne)] transition-colors duration-200 font-medium"
-              >
-                {CTA.phoneTel.replace('tel:', '')}
-              </a>
+          {visibleLinkGroups.map((group) => (
+            <div key={group.key} className="lg:col-span-2">
+              <span className="block font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--public-color-bone, #f8f4ea)]/50 mb-4 font-semibold">
+                {group.title}
+              </span>
+              <ul className="flex flex-col gap-3">
+                {group.items.map((item) => (
+                  <li key={`${group.key}-${item.href}`}>
+                    <Link
+                      href={withLocale(locale, item.href)}
+                      prefetch={false}
+                      className="text-sm text-[var(--public-color-bone, #f8f4ea)]/80 hover:text-white transition-colors duration-200"
+                    >
+                      {item.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
             </div>
-          </div>
+          ))}
         </div>
 
-        {/* Bottom border & legal copyright footer */}
         <div className="mt-12 pt-6 border-t border-[rgba(248,244,234,0.1)] flex flex-col md:flex-row items-center justify-between gap-4 text-xs text-[var(--public-color-bone, #f8f4ea)]/50">
           <div>
             <span>© {new Date().getFullYear()} AMP Pattaya Property Co., Ltd · License #BR-2018-0992</span>
-            {dict.common.facebookUrl && !/flowbiz/i.test(dict.common.facebookUrl) && (
+            {facebookUrl && !/flowbiz/i.test(facebookUrl) ? (
               <span className="ml-3">
                 ·{' '}
-                <a href={dict.common.facebookUrl} target="_blank" rel="noreferrer" className="hover:text-white transition-colors">
-                  Facebook
+                <a href={facebookUrl} target="_blank" rel="noreferrer" className="hover:text-white transition-colors">
+                  {facebookLabel}
                 </a>
               </span>
-            )}
+            ) : null}
           </div>
-          <div className="flex gap-4">
-            <Link href={withLocale(locale, '/terms')} prefetch={false} className="hover:text-white transition-colors">
-              {locale === 'th' ? 'ข้อตกลงการใช้งาน' : 'Terms'}
-            </Link>
-            <Link href={withLocale(locale, '/privacy')} prefetch={false} className="hover:text-white transition-colors">
-              {dict.common.privacyPolicy || 'Privacy'}
-            </Link>
+          <div className="flex flex-wrap justify-center gap-4">
+            {legalLinks.map((item) => (
+              <Link key={item.href} href={withLocale(locale, item.href)} prefetch={false} className="hover:text-white transition-colors">
+                {item.label}
+              </Link>
+            ))}
             <span>{pdpaText}</span>
           </div>
         </div>
       </Container>
     </footer>
   );
+}
+
+export function Footer(props: FooterProps) {
+  return <SiteFooter {...props} />;
 }

--- a/admin-app/components/layout/Header.tsx
+++ b/admin-app/components/layout/Header.tsx
@@ -7,29 +7,20 @@ import { useEffect, useRef, useState } from 'react';
 import type { ResolvedLayoutCms } from '../../app/_lib/layout-cms';
 import type { Dictionary, Locale } from '../../app/_lib/i18n/types';
 import { switchLocaleInPathname, withLocale } from '../../app/_lib/i18n/routing';
-import { CTA, getPublicCtaSurface, routeOwnsPrimaryCta } from '../../app/_lib/public-cta';
+import { getPublicCtaSurface, routeOwnsPrimaryCta } from '../../app/_lib/public-cta';
+import {
+  getHomeMobileNavItems,
+  getHomePublicNavItems,
+  getMobileQuickPaths,
+  getPublicCtaItems,
+  getPublicNavItems,
+  type PublicCtaItem,
+  type PublicNavItem,
+} from '../../app/_lib/public-navigation';
 import { en } from '../../app/_lib/i18n/en';
 import { th } from '../../app/_lib/i18n/th';
 import { useCurrency, CURRENCIES, type CurrencyCode } from '@/lib/currency';
-
-type DropdownItem = {
-  href: string;
-  label: string;
-  desc?: string;
-};
-
-type NavGroup = {
-  key: string;
-  label: string;
-  href?: string;
-  items?: DropdownItem[];
-};
-
-type QuickPath = {
-  href: string;
-  label: string;
-  detail: string;
-};
+import { MobileMenu } from '@/components/layout/MobileMenu';
 
 function ChevronDown({ open }: { open: boolean }) {
   return (
@@ -64,7 +55,7 @@ function DesktopNavGroup({
   locale,
   isActive,
 }: {
-  group: NavGroup;
+  group: PublicNavItem;
   locale: Locale;
   isActive: (href: string) => boolean;
 }) {
@@ -148,65 +139,28 @@ function DesktopNavGroup({
   );
 }
 
-function MobileSection({
-  group,
-  locale,
-  onNavClick,
-}: {
-  group: NavGroup;
-  locale: Locale;
-  onNavClick: () => void;
-}) {
-  const [expanded, setExpanded] = useState(false);
-
-  if (!group.items?.length) {
-    return (
-      <Link href={withLocale(locale, group.href ?? '/')} prefetch={false} className="mobile-nav__item" onClick={onNavClick}>
-        {group.label}
-      </Link>
-    );
-  }
-
-  return (
-    <div className="mobile-nav__section">
-      <button
-        type="button"
-        className={`mobile-nav__trigger ${expanded ? 'mobile-nav__trigger--open' : ''}`}
-        aria-expanded={expanded}
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <span>{group.label}</span>
-        <ChevronDown open={expanded} />
-      </button>
-      {expanded ? (
-        <div className="mobile-nav__sub">
-          {group.items.map((item) => (
-            <Link key={item.href} href={withLocale(locale, item.href)} prefetch={false} className="mobile-nav__sub-item" onClick={onNavClick}>
-              <span className="mobile-nav__sub-label">{item.label}</span>
-              {item.desc ? <span className="mobile-nav__sub-desc">{item.desc}</span> : null}
-            </Link>
-          ))}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
 type HeaderCms = ResolvedLayoutCms['header'];
 
-export function Header({
-  locale,
-  dict: dictProp,
-  cms,
-}: {
+type HeaderProps = {
   locale: Locale;
   dict?: Dictionary;
   cms?: HeaderCms;
-}) {
+};
+
+function resolveCtaHref(locale: Locale, item: PublicCtaItem): string {
+  if (item.external || !item.href.startsWith('/')) return item.href;
+  return withLocale(locale, item.href);
+}
+
+export function SiteHeader({
+  locale,
+  dict: dictProp,
+  cms,
+}: HeaderProps) {
   const dict = dictProp ?? (locale === 'th' ? th : en);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [homeHeaderScrolled, setHomeHeaderScrolled] = useState(false);
-  const mobileMenuRef = useRef<HTMLDivElement>(null);
+  const mobileMenuRef = useRef<HTMLElement>(null);
   const hamburgerRef = useRef<HTMLButtonElement>(null);
 
   const { currency, setCurrency } = useCurrency();
@@ -231,98 +185,18 @@ export function Header({
   const pathname = usePathname();
   const currentPathname = pathname ?? `/${locale}`;
 
-  const investLabel = locale === 'th' ? 'วางแผนลงทุน' : 'Investment Guides';
-  const smartFinderLabel = locale === 'th' ? 'ตัวช่วยคัดตัวเลือก' : 'Smart Finder';
-  const compareLabel = locale === 'th' ? 'เทียบตัวเลือก' : 'Compare';
-  const marketplaceLabel = locale === 'th' ? 'ประกาศทั้งหมด' : 'Marketplace';
-  const rentLabel = locale === 'th' ? 'เช่า / ย้ายมาอยู่' : 'Rent / Relocate';
-  const sellLabel = locale === 'th' ? 'ขายกับ AMP' : 'Sell with AMP';
-  const homeAreaLabel = locale === 'th' ? 'พื้นที่' : 'Areas';
-
-  const defaultNavConfig: NavGroup[] = [
-    {
-      key: 'buy',
-      label: dict.nav.buy,
-      href: '/buy',
-      items: [
-        { href: '/buy', label: dict.nav.buy, desc: locale === 'th' ? 'เส้นทางซื้อสำหรับผู้ซื้อชาวต่างชาติและผู้ที่มองหาบ้านพักตากอากาศ' : 'Buyer route for foreign nationals and second-home clients' },
-        { href: '/projects', label: dict.nav.projects, desc: locale === 'th' ? 'ดูโครงการใหม่และโครงการที่ผ่านการคัดกรอง' : 'Review vetted projects and launches first' },
-        { href: '/marketplace', label: marketplaceLabel, desc: locale === 'th' ? 'ดูรายการที่ยังเปิดขายอยู่ในระบบ' : 'Open active inventory across the catalogue' },
-      ],
-    },
-    {
-      key: 'invest',
-      label: dict.nav.invest,
-      href: '/invest',
-      items: [
-        { href: '/invest', label: dict.nav.invest, desc: locale === 'th' ? 'เส้นทางลงทุนสำหรับผู้ซื้อระหว่างประเทศ' : 'Investment-first path for international buyers' },
-        { href: '/investment', label: investLabel, desc: locale === 'th' ? 'กรอบคิดเรื่องผลตอบแทน ดีมานด์ และความเสี่ยงของพัทยา' : 'Yield, demand, and risk framing for Pattaya' },
-        { href: '/smart-finder', label: smartFinderLabel, desc: locale === 'th' ? 'ช่วยคัดจากงบประมาณและโจทย์การลงทุนของคุณ' : 'Guided matching by budget and investment thesis' },
-        { href: '/compare', label: compareLabel, desc: locale === 'th' ? 'เทียบตัวเลือกแบบวางข้างกันอย่างชัดเจน' : 'Compare options side-by-side' },
-      ],
-    },
-    { key: 'rent', label: rentLabel, href: '/rent' },
-    { key: 'sell', label: sellLabel, href: '/sell' },
-    { key: 'projects', label: dict.nav.projects, href: '/projects' },
-    {
-      key: 'area-guide',
-      label: dict.nav.areaGuide,
-      href: '/area-guide',
-      items: [
-        { href: '/area-guide', label: dict.nav.areaGuide, desc: locale === 'th' ? 'ภาพรวมแต่ละโซนในพัทยา' : 'Understand Pattaya zone differences' },
-        { href: '/contact', label: dict.nav.contact, desc: locale === 'th' ? 'คุยกับที่ปรึกษาก่อนเลือกทำเล' : 'Talk to an advisor before selecting an area' },
-      ],
-    },
-  ];
-  const cmsNavConfig: NavGroup[] = (cms?.primaryLinks || []).map((item, index) => ({
-    key: `cms-${index}`,
-    label: item.label,
-    href: item.href,
-  }));
-  const fullNavConfig = cmsNavConfig.length > 0 ? cmsNavConfig : defaultNavConfig;
-  const homeNavConfig: NavGroup[] = [
-    { key: 'home-buy', label: dict.nav.buy, href: '/buy' },
-    { key: 'home-invest', label: dict.nav.invest, href: '/invest' },
-    { key: 'home-rent', label: locale === 'th' ? 'เช่า' : 'Rent', href: '/rent' },
-    { key: 'home-sell', label: locale === 'th' ? 'ขาย' : 'Sell', href: '/sell' },
-    { key: 'home-projects', label: dict.nav.projects, href: '/projects' },
-    { key: 'home-areas', label: homeAreaLabel, href: '/area-guide' },
-  ];
-  const homeMobileNavConfig: NavGroup[] = [
-    { key: 'home-mobile-projects', label: dict.nav.projects, href: '/projects' },
-    { key: 'home-mobile-areas', label: homeAreaLabel, href: '/area-guide' },
-  ];
-  const mobileQuickPaths: QuickPath[] = [
-    {
-      href: '/buy',
-      label: locale === 'th' ? 'ซื้อ' : 'Buy',
-      detail: locale === 'th' ? 'ซื้อในพัทยา' : 'Buy in Pattaya',
-    },
-    {
-      href: '/invest',
-      label: locale === 'th' ? 'ลงทุน' : 'Invest',
-      detail: locale === 'th' ? 'เส้นทางการลงทุน' : 'Investment route',
-    },
-    {
-      href: '/rent',
-      label: locale === 'th' ? 'เช่า' : 'Rent',
-      detail: locale === 'th' ? 'เช่าหรือย้ายมาอยู่' : 'Rent or relocate',
-    },
-    {
-      href: '/sell',
-      label: locale === 'th' ? 'ขาย' : 'Sell',
-      detail: locale === 'th' ? 'ขายหรือปล่อยเช่า' : 'Sell or rent out',
-    },
-  ];
-  const contactCtaHref = cms?.contactCta?.href || '/contact';
-  const contactCtaLabel = cms?.contactCta?.label || dict.cta.speakToAdvisor;
+  const fullNavConfig = getPublicNavItems(locale, dict, cms);
+  const homeNavConfig = getHomePublicNavItems(locale, dict);
+  const homeMobileNavConfig = getHomeMobileNavItems(locale, dict);
+  const mobileQuickPaths = getMobileQuickPaths(locale);
+  const ctaItems = getPublicCtaItems(locale, dict, cms);
+  const shortlistCta = ctaItems.find((item) => item.key === 'shortlist');
+  const conversionCtas = ctaItems.filter((item) => item.tone !== 'utility');
   const currentSurface = getPublicCtaSurface(currentPathname);
   const isHomeSurface = currentSurface === 'home';
   const showGlobalCtas = !routeOwnsPrimaryCta(currentPathname);
   const desktopNavConfig = isHomeSurface ? homeNavConfig : fullNavConfig;
   const mobileNavConfig = isHomeSurface ? homeMobileNavConfig : fullNavConfig;
-
-  const langLabel = locale === 'th' ? dict.common.thai : dict.common.english;
 
   /** Strip /<locale> prefix from pathname to compare with nav item hrefs */
   const pathWithoutLocale = pathname?.replace(new RegExp(`^/${locale}`), '') || '/';
@@ -401,19 +275,42 @@ export function Header({
           </nav>
 
           <div className="header-actions">
+            {shortlistCta ? (
+              <Link
+                href={resolveCtaHref(locale, shortlistCta)}
+                prefetch={false}
+                className={`header-cta header-cta--utility desktop-only ${isActive(shortlistCta.href) ? 'header-cta--active' : ''}`}
+                aria-current={isActive(shortlistCta.href) ? 'page' : undefined}
+              >
+                {shortlistCta.label}
+              </Link>
+            ) : null}
             {showGlobalCtas ? (
               <div className="header-cta-group desktop-only">
-                <Link href={CTA.whatsAppUrl} className="header-cta header-cta--secondary" target="_blank" rel="noreferrer">
-                  {dict.cta.whatsapp}
-                </Link>
-                <Link
-                  href={withLocale(locale, contactCtaHref)}
-                  prefetch={false}
-                  className={`header-cta header-cta--primary ${isActive(contactCtaHref) ? 'header-cta--active' : ''}`}
-                  aria-current={isActive(contactCtaHref) ? 'page' : undefined}
-                >
-                  {contactCtaLabel}
-                </Link>
+                {conversionCtas.map((item) => {
+                  const href = resolveCtaHref(locale, item);
+                  const className = `header-cta header-cta--${item.tone} ${!item.external && isActive(item.href) ? 'header-cta--active' : ''}`;
+
+                  if (item.external) {
+                    return (
+                      <a key={item.key} href={href} className={className} target="_blank" rel="noreferrer">
+                        {item.label}
+                      </a>
+                    );
+                  }
+
+                  return (
+                    <Link
+                      key={item.key}
+                      href={href}
+                      prefetch={false}
+                      className={className}
+                      aria-current={isActive(item.href) ? 'page' : undefined}
+                    >
+                      {item.label}
+                    </Link>
+                  );
+                })}
               </div>
             ) : null}
             {/* Currency Picker */}
@@ -572,70 +469,21 @@ export function Header({
         onClick={() => setMobileOpen(false)}
       />
 
-      <nav
-        ref={mobileMenuRef}
-        className={mobileOpen ? 'mobile-menu active' : 'mobile-menu'}
-        id="mobile-menu"
-        role="navigation"
-        aria-label={dict.common.mainNavigation}
-        aria-hidden={!mobileOpen}
-        data-locale={locale}
-      >
-        <div className="mobile-menu__inner">
-          <div className="mobile-menu__intro">
-            <p className="mobile-menu__eyebrow">
-              {locale === 'th' ? 'เส้นทางอสังหาริมทรัพย์พัทยา' : 'Pattaya real estate routes'}
-            </p>
-            <p className="mobile-menu__title">
-              {locale === 'th'
-                ? 'เลือกเส้นทางที่ใช่ก่อน'
-                : 'Choose the right route first.'}
-            </p>
-            <div className="mobile-menu__quick-grid">
-              {mobileQuickPaths.map((item) => (
-                <Link
-                  key={item.href}
-                  href={withLocale(locale, item.href)}
-                  prefetch={false}
-                  className="mobile-menu__quick-link"
-                  onClick={() => setMobileOpen(false)}
-                >
-                  <strong>{item.label}</strong>
-                  <span>{item.detail}</span>
-                </Link>
-              ))}
-            </div>
-            {isHomeSurface ? (
-              <Link
-                href={withLocale(locale, '/contact')}
-                prefetch={false}
-                className="mobile-menu__advisor-link"
-                onClick={() => setMobileOpen(false)}
-              >
-                <strong>{locale === 'th' ? 'คุยกับที่ปรึกษา' : 'Speak to an advisor'}</strong>
-                <span>
-                  {locale === 'th'
-                    ? 'ส่งโจทย์สั้น ๆ แล้วให้ทีมช่วยคัดทางต่อ'
-                    : 'Send a short brief and let the team narrow the next step.'}
-                </span>
-              </Link>
-            ) : null}
-          </div>
-          {mobileNavConfig.map((group) => (
-            <MobileSection key={group.key} group={group} locale={locale} onNavClick={() => setMobileOpen(false)} />
-          ))}
-          {showGlobalCtas ? (
-            <>
-              <Link href={CTA.whatsAppUrl} className="mobile-nav__item" onClick={() => setMobileOpen(false)} target="_blank" rel="noreferrer">
-                {dict.cta.whatsapp}
-              </Link>
-              <Link href={withLocale(locale, contactCtaHref)} prefetch={false} className="mobile-nav__cta" onClick={() => setMobileOpen(false)}>
-                {contactCtaLabel}
-              </Link>
-            </>
-          ) : null}
-        </div>
-      </nav>
+      <MobileMenu
+        ctaItems={ctaItems}
+        isHomeSurface={isHomeSurface}
+        locale={locale}
+        menuRef={mobileMenuRef}
+        navItems={mobileNavConfig}
+        onClose={() => setMobileOpen(false)}
+        open={mobileOpen}
+        quickPaths={mobileQuickPaths}
+        showGlobalCtas={showGlobalCtas}
+      />
     </>
   );
+}
+
+export function Header(props: HeaderProps) {
+  return <SiteHeader {...props} />;
 }

--- a/admin-app/components/layout/MobileMenu.tsx
+++ b/admin-app/components/layout/MobileMenu.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import Link from 'next/link';
+import type { RefObject } from 'react';
+import { useState } from 'react';
+
+import type { Locale } from '@/app/_lib/i18n/types';
+import { withLocale } from '@/app/_lib/i18n/routing';
+import type { PublicCtaItem, PublicNavItem, PublicQuickPath } from '@/app/_lib/public-navigation';
+
+function ChevronDown({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      aria-hidden="true"
+      style={{ transition: 'transform 0.2s', transform: open ? 'rotate(180deg)' : 'rotate(0deg)', flexShrink: 0 }}
+    >
+      <path d="M2 4l4 4 4-4" />
+    </svg>
+  );
+}
+
+function MobileSection({
+  group,
+  locale,
+  onNavClick,
+}: {
+  group: PublicNavItem;
+  locale: Locale;
+  onNavClick: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (!group.items?.length) {
+    return (
+      <Link href={withLocale(locale, group.href ?? '/')} prefetch={false} className="mobile-nav__item" onClick={onNavClick}>
+        {group.label}
+      </Link>
+    );
+  }
+
+  return (
+    <div className="mobile-nav__section">
+      <button
+        type="button"
+        className={`mobile-nav__trigger ${expanded ? 'mobile-nav__trigger--open' : ''}`}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <span>{group.label}</span>
+        <ChevronDown open={expanded} />
+      </button>
+      {expanded ? (
+        <div className="mobile-nav__sub">
+          {group.items.map((item) => (
+            <Link key={item.href} href={withLocale(locale, item.href)} prefetch={false} className="mobile-nav__sub-item" onClick={onNavClick}>
+              <span className="mobile-nav__sub-label">{item.label}</span>
+              {item.desc ? <span className="mobile-nav__sub-desc">{item.desc}</span> : null}
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ctaClassName(item: PublicCtaItem): string {
+  if (item.tone === 'primary') return 'mobile-nav__cta';
+  return 'mobile-nav__item';
+}
+
+function ctaHref(locale: Locale, item: PublicCtaItem): string {
+  if (item.external || !item.href.startsWith('/')) return item.href;
+  return withLocale(locale, item.href);
+}
+
+export function MobileMenu({
+  ctaItems,
+  isHomeSurface,
+  locale,
+  menuRef,
+  navItems,
+  onClose,
+  open,
+  quickPaths,
+  showGlobalCtas,
+}: {
+  ctaItems: PublicCtaItem[];
+  isHomeSurface: boolean;
+  locale: Locale;
+  menuRef?: RefObject<HTMLElement>;
+  navItems: PublicNavItem[];
+  onClose: () => void;
+  open: boolean;
+  quickPaths: PublicQuickPath[];
+  showGlobalCtas: boolean;
+}) {
+  const utilityCtas = ctaItems.filter((item) => item.tone === 'utility');
+  const conversionCtas = showGlobalCtas ? ctaItems.filter((item) => item.tone !== 'utility') : [];
+
+  return (
+    <nav
+      ref={menuRef}
+      className={open ? 'mobile-menu active' : 'mobile-menu'}
+      id="mobile-menu"
+      role="navigation"
+      aria-label={locale === 'th' ? 'เมนูหลัก' : 'Main navigation'}
+      aria-hidden={!open}
+      data-locale={locale}
+    >
+      <div className="mobile-menu__inner">
+        <div className="mobile-menu__intro">
+          <p className="mobile-menu__eyebrow">
+            {locale === 'th' ? 'เส้นทางอสังหาริมทรัพย์พัทยา' : 'Pattaya real estate routes'}
+          </p>
+          <p className="mobile-menu__title">
+            {locale === 'th'
+              ? 'เลือกเส้นทางที่ใช่ก่อน'
+              : 'Choose the right route first.'}
+          </p>
+          <div className="mobile-menu__quick-grid">
+            {quickPaths.map((item) => (
+              <Link
+                key={item.href}
+                href={withLocale(locale, item.href)}
+                prefetch={false}
+                className="mobile-menu__quick-link"
+                onClick={onClose}
+              >
+                <strong>{item.label}</strong>
+                <span>{item.detail}</span>
+              </Link>
+            ))}
+          </div>
+          {isHomeSurface ? (
+            <Link
+              href={withLocale(locale, '/contact')}
+              prefetch={false}
+              className="mobile-menu__advisor-link"
+              onClick={onClose}
+            >
+              <strong>{locale === 'th' ? 'คุยกับที่ปรึกษา' : 'Speak to an advisor'}</strong>
+              <span>
+                {locale === 'th'
+                  ? 'ส่งโจทย์สั้น ๆ แล้วให้ทีมช่วยคัดทางต่อ'
+                  : 'Send a short brief and let the team narrow the next step.'}
+              </span>
+            </Link>
+          ) : null}
+        </div>
+
+        {navItems.map((group) => (
+          <MobileSection key={group.key} group={group} locale={locale} onNavClick={onClose} />
+        ))}
+
+        {[...utilityCtas, ...conversionCtas].map((item) => {
+          const href = ctaHref(locale, item);
+          if (item.external) {
+            return (
+              <a key={item.key} href={href} className={ctaClassName(item)} onClick={onClose} target="_blank" rel="noreferrer">
+                {item.label}
+              </a>
+            );
+          }
+
+          return (
+            <Link key={item.key} href={href} prefetch={false} className={ctaClassName(item)} onClick={onClose}>
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/admin-app/styles/public-primitives.css
+++ b/admin-app/styles/public-primitives.css
@@ -4701,3 +4701,82 @@ html[lang='th'] .decision-page .public-hero__signal-title,
     padding: var(--public-panel-padding-compact);
   }
 }
+
+/* ======================== AMP PR 2 PUBLIC SHELL ======================== */
+
+.public-site-shell .site-header .header-cta--utility {
+  border: 1px solid var(--amp-public-border-soft);
+  background: var(--amp-public-color-paper);
+  color: var(--amp-public-color-ink);
+  box-shadow: var(--public-shadow-claude-sm);
+}
+
+.public-site-shell .site-header .header-cta--utility:hover,
+.public-site-shell .site-header .header-cta--utility.header-cta--active {
+  border-color: var(--public-border-strong);
+  background: var(--amp-public-color-paper-warm);
+  color: var(--amp-public-color-ink);
+}
+
+.public-site-shell .site-header .header-cta--secondary {
+  border-color: var(--amp-public-coral-border);
+  color: var(--amp-public-color-ink);
+}
+
+.public-site-shell .site-header .header-cta--primary {
+  background: var(--amp-public-color-coral);
+  color: var(--color-white);
+  box-shadow: var(--amp-public-coral-shadow);
+}
+
+.public-site-shell .site-header .header-cta--primary:hover,
+.public-site-shell .site-header .header-cta--primary.header-cta--active {
+  background: var(--amp-public-color-coral-hover);
+}
+
+.public-site-shell .site-footer .footer-cta-link {
+  min-height: 40px;
+  padding-inline: 16px;
+  text-decoration: none;
+}
+
+@media (min-width: 768px) and (max-width: 1179px) {
+  .public-site-shell .site-header .nav,
+  .public-site-shell .site-header .header-cta-group.desktop-only,
+  .public-site-shell .site-header .header-cta--utility.desktop-only {
+    display: none !important;
+  }
+
+  .public-site-shell .site-header .hamburger.mobile-only {
+    display: flex !important;
+  }
+}
+
+@media (min-width: 1180px) {
+  .public-site-shell .site-header .nav {
+    display: flex;
+    gap: clamp(6px, 0.9vw, 16px);
+  }
+
+  .public-site-shell .site-header .header-cta-group.desktop-only {
+    display: flex;
+  }
+
+  .public-site-shell .site-header .header-cta--utility.desktop-only {
+    display: inline-flex;
+  }
+
+  .public-site-shell .site-header .hamburger.mobile-only {
+    display: none !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .public-site-shell .mobile-menu {
+    width: min(92vw, 380px);
+  }
+
+  .public-site-shell .mobile-menu__quick-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/docs/AMP_PUBLIC_SHELL_PR2.md
+++ b/docs/AMP_PUBLIC_SHELL_PR2.md
@@ -1,0 +1,47 @@
+# AMP Public Shell - PR 2
+
+## Purpose
+
+PR 2 adds the reusable public website shell layer for the AMP Pattaya frontend migration. It builds on the PR 1 token and primitive foundation without migrating listing pages, detail pages, forms, tracking, backend, database, or admin UI.
+
+## Added
+
+- `SiteHeader` in `admin-app/components/layout/Header.tsx`
+- `MobileMenu` in `admin-app/components/layout/MobileMenu.tsx`
+- `SiteFooter` in `admin-app/components/layout/Footer.tsx`
+- Shared navigation configuration in `admin-app/app/_lib/public-navigation.ts`
+- Public shell CSS overrides scoped to `.public-site-shell`
+
+Existing `Header` and `Footer` exports remain as compatibility wrappers.
+
+## Shared Config
+
+Use these helpers instead of repeating links in components:
+
+```ts
+getPublicNavItems(locale, dict, cms?.header)
+getHomePublicNavItems(locale, dict)
+getHomeMobileNavItems(locale, dict)
+getMobileQuickPaths(locale)
+getPublicCtaItems(locale, dict, cms?.header)
+getFooterLinkGroups(locale, dict, cms?.footer)
+```
+
+## Shell Behavior
+
+- Desktop header includes Home, Buy, Rent, Projects, Sell, About, Contact, Shortlist, and conversion CTA items.
+- Tablet and mobile use the shared `MobileMenu`.
+- Mobile menu closes on route change, link click, overlay click, and Escape.
+- Footer uses shared link groups for quick links, property links, buyer resources, company links, and legal links.
+
+## Guardrails
+
+- Do not move listing/detail content into these components.
+- Do not connect shell links to new backend behavior.
+- Do not add form or tracking changes in shell PRs.
+- Do not copy `static-prototype/assets/css/style.css`.
+- Keep new shell styles scoped to `.public-site-shell` or component-owned classes.
+
+## Recommended PR 3
+
+Extract and migrate reusable `PropertyCard` and `ProjectCard` refinements using the PR 1 foundation and the PR 2 shell, without changing listing routes or detail routes yet.


### PR DESCRIPTION
## Summary

Adds the reusable AMP public shell foundation for PR2 without migrating listing/detail pages or touching backend behavior.

## Changes

- Adds shared public navigation config for header, mobile menu, CTAs, quick paths, and footer groups.
- Adds reusable `SiteHeader`, `MobileMenu`, and `SiteFooter` components.
- Keeps `Header` and `Footer` compatibility wrappers so existing imports continue to work.
- Wires the public localized site layout to `SiteHeader` / `SiteFooter` only.
- Adds scoped PR2 shell styles under `.public-site-shell` using the PR1 public UI foundation.
- Documents scope, guardrails, and validation in `docs/AMP_PUBLIC_SHELL_PR2.md`.

## Safety Audit

- No metadata, SEO, canonical, JSON-LD, tracking, provider, API, route, database, form, or admin behavior changes.
- No listing/detail page migration included.
- No duplicate public shell rendering found; localized layout renders one header and one footer.
- Admin routes and admin UI were not touched.

## Validation

- `npm run lint` passed; existing `<img>` warnings remain.
- `npm run test -- --reporter=dot` passed: 123 test files, 523 tests.
- `npm run build` passed: 104 static pages generated.
- `git diff --check` passed.
- Manual rendered smoke was performed earlier for desktop and mobile public shell behavior: header/footer render, mobile menu opens/closes, Escape closes, link click closes/navigates, no horizontal overflow observed.

## Not Included

- No public page rewrite.
- No property/project cards.
- No filters, galleries, detail page migration, forms, tracking, or admin shell migration.
