### PR TITLE
feat(amp-public): add reusable public property and project cards

### DIFF
--- a/admin-app/__tests__/public_card_foundation.test.tsx
+++ b/admin-app/__tests__/public_card_foundation.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  PropertyCard,
+  type PublicPropertyCardData,
+} from '@/components/public-system/components/PropertyCard';
+import {
+  ProjectCard,
+  type PublicProjectCardData,
+} from '@/components/public-system/components/ProjectCard';
+
+vi.mock('next/image', () => ({
+  default: (props: Record<string, unknown>) => (
+    <div
+      role="img"
+      aria-label={String(props.alt ?? '')}
+      data-src={String(props.src ?? '')}
+      data-sizes={String(props.sizes ?? '')}
+    />
+  ),
+}));
+
+describe('public card foundation components', () => {
+  const property: PublicPropertyCardData = {
+    id: 'property-riviera-california',
+    title: 'Riviera California Sea View Residence',
+    href: '/en/property/riviera-california-sea-view',
+    imageSrc: '/images/property-exterior.png',
+    imageAlt: 'Riviera California Pattaya sea view condo',
+    location: 'Wongamat',
+    priceLabel: 'THB 8,900,000',
+    listingType: 'sale',
+    propertyType: 'Condo',
+    bedrooms: 2,
+    bathrooms: 2,
+    sizeLabel: '65 sqm',
+    viewLabel: 'Sea view',
+    statusLabel: 'Ready to move in',
+    isFeatured: true,
+  };
+
+  const project: PublicProjectCardData = {
+    id: 'project-once-wongamat',
+    name: 'Once Wongamat',
+    href: '/en/projects/once-wongamat',
+    imageSrc: '/images/project-overview.png',
+    imageAlt: 'Once Wongamat project exterior',
+    location: 'Wongamat',
+    startingPriceLabel: 'From THB 4.2M',
+    completionLabel: 'Completion 2028',
+    statusLabel: 'New launch',
+    highlights: ['Foreign quota available', 'Beach access', 'High-floor sea views'],
+  };
+
+  it('renders PropertyCard title, price, location, facts, image alt, badges, and links', () => {
+    const { container } = render(
+      <PropertyCard property={property} ctaLabel="View Details" showActionPlaceholders />,
+    );
+
+    expect(screen.getByRole('img', { name: property.imageAlt })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: property.title })).toBeInTheDocument();
+    expect(screen.getByText('Wongamat')).toBeInTheDocument();
+    expect(screen.getByText('THB 8,900,000')).toBeInTheDocument();
+    expect(screen.getByText('For sale')).toBeInTheDocument();
+    expect(screen.getByText('Featured')).toBeInTheDocument();
+    expect(screen.getByText('Ready to move in')).toBeInTheDocument();
+    expect(screen.getByText('Condo')).toBeInTheDocument();
+    expect(screen.getByText('Beds')).toBeInTheDocument();
+    expect(screen.getByText('Baths')).toBeInTheDocument();
+    expect(screen.getAllByText('2')).toHaveLength(2);
+    expect(screen.getByText('65 sqm')).toBeInTheDocument();
+    expect(screen.getByText('Sea view')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: property.title })).toHaveAttribute('href', property.href);
+    expect(screen.getByRole('link', { name: 'View Details' })).toHaveAttribute('href', property.href);
+    expect(screen.getByRole('button', { name: 'Shortlist' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Compare' })).toBeDisabled();
+    expect(container.querySelector('article.public-property-card.public-card-foundation')).not.toBeNull();
+    expect(container.querySelector('.public-card-foundation__facts')).not.toBeNull();
+  });
+
+  it('renders ProjectCard name, location, status, highlights, image alt, and links', () => {
+    const { container } = render(<ProjectCard project={project} ctaLabel="View Project" />);
+
+    expect(screen.getByRole('img', { name: project.imageAlt })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: project.name })).toBeInTheDocument();
+    expect(screen.getByText('Wongamat')).toBeInTheDocument();
+    expect(screen.getByText('From THB 4.2M')).toBeInTheDocument();
+    expect(screen.getByText('Completion 2028')).toBeInTheDocument();
+    expect(screen.getByText('New launch')).toBeInTheDocument();
+    expect(screen.getByText('Foreign quota available')).toBeInTheDocument();
+    expect(screen.getByText('Beach access')).toBeInTheDocument();
+    expect(screen.getByText('High-floor sea views')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: project.name })).toHaveAttribute('href', project.href);
+    expect(screen.getByRole('link', { name: 'View Project' })).toHaveAttribute('href', project.href);
+    expect(container.querySelector('article.public-project-card.public-card-foundation')).not.toBeNull();
+    expect(container.querySelectorAll('.public-card-foundation__highlight')).toHaveLength(3);
+  });
+
+  it('omits optional fields without rendering broken placeholder text', () => {
+    const minimalProperty: PublicPropertyCardData = {
+      id: 'property-minimal',
+      title: 'Compact Jomtien Studio',
+      href: '/en/property/compact-jomtien-studio',
+      imageSrc: '/images/property-placeholder.svg',
+      imageAlt: 'Compact Jomtien studio',
+      location: 'Jomtien',
+      priceLabel: 'THB 22,000 / month',
+      listingType: 'rent',
+    };
+
+    const minimalProject: PublicProjectCardData = {
+      id: 'project-minimal',
+      name: 'Skypark Lucean Jomtien',
+      href: '/en/projects/skypark-lucean-jomtien',
+      imageSrc: '/images/project-overview.png',
+      imageAlt: 'Skypark Lucean Jomtien project',
+      location: 'Jomtien',
+    };
+
+    const { container } = render(
+      <>
+        <PropertyCard property={minimalProperty} />
+        <ProjectCard project={minimalProject} />
+      </>,
+    );
+
+    expect(screen.getByText('For rent')).toBeInTheDocument();
+    expect(screen.getByText('Compact Jomtien Studio')).toBeInTheDocument();
+    expect(screen.getByText('Skypark Lucean Jomtien')).toBeInTheDocument();
+    expect(container.textContent).not.toContain('undefined');
+    expect(container.textContent).not.toContain('null');
+    expect(container.querySelector('.public-property-card .public-card-foundation__facts')).toBeNull();
+    expect(container.querySelector('.public-project-card .public-card-foundation__highlights')).toBeNull();
+  });
+});

--- a/admin-app/components/public-system/components/ProjectCard.tsx
+++ b/admin-app/components/public-system/components/ProjectCard.tsx
@@ -1,0 +1,107 @@
+import Link from 'next/link';
+
+import { SafeCoverImage } from '@/components/media/SafeCoverImage';
+import { cx } from '@/components/public/cx';
+import { Button } from '@/components/public-system/components/Button';
+import { Chip } from '@/components/public-system/components/Chip';
+import { CardBase } from '@/components/public-system/primitives/CardBase';
+
+export type PublicProjectCardData = {
+  id: string;
+  name: string;
+  href: string;
+  imageSrc: string;
+  imageAlt: string;
+  location: string;
+  startingPriceLabel?: string;
+  completionLabel?: string;
+  statusLabel?: string;
+  highlights?: string[];
+};
+
+export type ProjectCardProps = {
+  project: PublicProjectCardData;
+  className?: string;
+  ctaLabel?: string;
+  fallbackImageSrc?: string;
+  imagePriority?: boolean;
+  imageSizes?: string;
+};
+
+const DEFAULT_PROJECT_FALLBACK = '/images/project-overview.png';
+
+export function ProjectCard({
+  project,
+  className,
+  ctaLabel = 'View Project',
+  fallbackImageSrc = DEFAULT_PROJECT_FALLBACK,
+  imagePriority = false,
+  imageSizes = '(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw',
+}: ProjectCardProps) {
+  const highlights = project.highlights?.filter((item) => item.trim().length > 0) ?? [];
+  const cardLabel = `${project.name}, ${project.location}`;
+
+  return (
+    <CardBase
+      as="article"
+      interactive
+      className={cx('public-amp-card public-amp-card--interactive public-card-foundation public-project-card', className)}
+      aria-label={cardLabel}
+    >
+      <div className="public-card-foundation__media">
+        <Link href={project.href} className="public-card-foundation__media-link" aria-label={`${ctaLabel}: ${project.name}`}>
+          <SafeCoverImage
+            src={project.imageSrc}
+            alt={project.imageAlt}
+            fallbackSrc={fallbackImageSrc}
+            priority={imagePriority}
+            loading={imagePriority ? 'eager' : 'lazy'}
+            sizes={imageSizes}
+            className="public-card-foundation__image"
+            ssrStartWithPrimary
+          />
+        </Link>
+
+        {project.statusLabel ? (
+          <div className="public-card-foundation__badges" aria-label="Project badges">
+            <Chip size="sm" tone="accent" className="public-card-foundation__badge">
+              {project.statusLabel}
+            </Chip>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="public-card-foundation__body">
+        <div className="public-card-foundation__meta-row">
+          <span className="public-card-foundation__location">{project.location}</span>
+          {project.completionLabel ? <span className="public-card-foundation__type">{project.completionLabel}</span> : null}
+        </div>
+
+        <div className="public-card-foundation__headline">
+          <h3 className="public-amp-card-title public-card-foundation__title">
+            <Link href={project.href} className="public-card-foundation__title-link">
+              {project.name}
+            </Link>
+          </h3>
+          {project.startingPriceLabel ? <p className="public-card-foundation__price">{project.startingPriceLabel}</p> : null}
+        </div>
+
+        {highlights.length ? (
+          <ul className="public-card-foundation__highlights" aria-label="Project highlights">
+            {highlights.map((highlight, index) => (
+              <li key={`${highlight}-${index}`} className="public-card-foundation__highlight">
+                {highlight}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        <div className="public-card-foundation__footer">
+          <Button href={project.href} variant="primary" className="public-card-foundation__cta">
+            {ctaLabel}
+          </Button>
+        </div>
+      </div>
+    </CardBase>
+  );
+}

--- a/admin-app/components/public-system/components/PropertyCard.tsx
+++ b/admin-app/components/public-system/components/PropertyCard.tsx
@@ -1,0 +1,169 @@
+import Link from 'next/link';
+
+import { SafeCoverImage } from '@/components/media/SafeCoverImage';
+import { cx } from '@/components/public/cx';
+import { Button } from '@/components/public-system/components/Button';
+import { Chip } from '@/components/public-system/components/Chip';
+import { CardBase } from '@/components/public-system/primitives/CardBase';
+
+export type PublicPropertyCardData = {
+  id: string;
+  title: string;
+  href: string;
+  imageSrc: string;
+  imageAlt: string;
+  location: string;
+  priceLabel: string;
+  listingType: 'sale' | 'rent';
+  propertyType?: string;
+  bedrooms?: number | string;
+  bathrooms?: number | string;
+  sizeLabel?: string;
+  viewLabel?: string;
+  statusLabel?: string;
+  isFeatured?: boolean;
+};
+
+export type PropertyCardProps = {
+  property: PublicPropertyCardData;
+  className?: string;
+  ctaLabel?: string;
+  fallbackImageSrc?: string;
+  imagePriority?: boolean;
+  imageSizes?: string;
+  showActionPlaceholders?: boolean;
+};
+
+type FactItem = {
+  key: string;
+  label: string;
+  value: string;
+};
+
+const DEFAULT_PROPERTY_FALLBACK = '/images/property-placeholder.svg';
+
+function hasDisplayValue(value: string | number | undefined): value is string | number {
+  return value !== undefined && value !== null && String(value).trim().length > 0;
+}
+
+function buildPropertyFacts(property: PublicPropertyCardData): FactItem[] {
+  const facts: FactItem[] = [];
+
+  if (hasDisplayValue(property.bedrooms)) {
+    facts.push({ key: 'bedrooms', label: 'Beds', value: String(property.bedrooms) });
+  }
+
+  if (hasDisplayValue(property.bathrooms)) {
+    facts.push({ key: 'bathrooms', label: 'Baths', value: String(property.bathrooms) });
+  }
+
+  if (property.sizeLabel) {
+    facts.push({ key: 'size', label: 'Size', value: property.sizeLabel });
+  }
+
+  if (property.viewLabel) {
+    facts.push({ key: 'view', label: 'View', value: property.viewLabel });
+  }
+
+  return facts;
+}
+
+function listingTypeLabel(type: PublicPropertyCardData['listingType']): string {
+  return type === 'rent' ? 'For rent' : 'For sale';
+}
+
+export function PropertyCard({
+  property,
+  className,
+  ctaLabel = 'View Details',
+  fallbackImageSrc = DEFAULT_PROPERTY_FALLBACK,
+  imagePriority = false,
+  imageSizes = '(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw',
+  showActionPlaceholders = false,
+}: PropertyCardProps) {
+  const facts = buildPropertyFacts(property);
+  const cardLabel = `${property.title}, ${property.location}`;
+
+  return (
+    <CardBase
+      as="article"
+      interactive
+      className={cx('public-amp-card public-amp-card--interactive public-card-foundation public-property-card', className)}
+      aria-label={cardLabel}
+    >
+      <div className="public-card-foundation__media">
+        <Link href={property.href} className="public-card-foundation__media-link" aria-label={`${ctaLabel}: ${property.title}`}>
+          <SafeCoverImage
+            src={property.imageSrc}
+            alt={property.imageAlt}
+            fallbackSrc={fallbackImageSrc}
+            priority={imagePriority}
+            loading={imagePriority ? 'eager' : 'lazy'}
+            sizes={imageSizes}
+            className="public-card-foundation__image"
+            ssrStartWithPrimary
+          />
+        </Link>
+
+        <div className="public-card-foundation__badges" aria-label="Property badges">
+          {property.isFeatured ? (
+            <Chip size="sm" tone="accent" className="public-card-foundation__badge">
+              Featured
+            </Chip>
+          ) : null}
+          {property.statusLabel ? (
+            <Chip size="sm" tone="deep" className="public-card-foundation__badge">
+              {property.statusLabel}
+            </Chip>
+          ) : null}
+          <Chip size="sm" className="public-card-foundation__badge">
+            {listingTypeLabel(property.listingType)}
+          </Chip>
+        </div>
+      </div>
+
+      <div className="public-card-foundation__body">
+        <div className="public-card-foundation__meta-row">
+          <span className="public-card-foundation__location">{property.location}</span>
+          {property.propertyType ? <span className="public-card-foundation__type">{property.propertyType}</span> : null}
+        </div>
+
+        <div className="public-card-foundation__headline">
+          <h3 className="public-amp-card-title public-card-foundation__title">
+            <Link href={property.href} className="public-card-foundation__title-link">
+              {property.title}
+            </Link>
+          </h3>
+          <p className="public-card-foundation__price">{property.priceLabel}</p>
+        </div>
+
+        {facts.length ? (
+          <dl className="public-card-foundation__facts" aria-label="Property quick facts">
+            {facts.map((fact) => (
+              <div key={fact.key} className="public-card-foundation__fact">
+                <dt className="public-card-foundation__fact-label">{fact.label}</dt>
+                <dd className="public-card-foundation__fact-value">{fact.value}</dd>
+              </div>
+            ))}
+          </dl>
+        ) : null}
+
+        <div className="public-card-foundation__footer">
+          {showActionPlaceholders ? (
+            <div className="public-card-foundation__placeholder-actions" aria-label="Future card actions">
+              <button type="button" className="public-card-foundation__placeholder-action" disabled>
+                Shortlist
+              </button>
+              <button type="button" className="public-card-foundation__placeholder-action" disabled>
+                Compare
+              </button>
+            </div>
+          ) : null}
+          <Button href={property.href} variant="primary" className="public-card-foundation__cta">
+            {ctaLabel}
+          </Button>
+        </div>
+      </div>
+    </CardBase>
+  );
+}

--- a/admin-app/components/public-system/index.ts
+++ b/admin-app/components/public-system/index.ts
@@ -13,6 +13,8 @@ export * from '@/components/public-system/components/CTAGroup';
 export * from '@/components/public-system/components/SectionHeader';
 export * from '@/components/public-system/components/Button';
 export * from '@/components/public-system/components/Card';
+export * from '@/components/public-system/components/PropertyCard';
+export * from '@/components/public-system/components/ProjectCard';
 export * from '@/components/public-system/components/InputBase';
 export * from '@/components/public-system/components/SelectBase';
 export * from '@/components/public-system/components/TextAreaBase';

--- a/admin-app/styles/public-primitives.css
+++ b/admin-app/styles/public-primitives.css
@@ -4702,6 +4702,226 @@ html[lang='th'] .decision-page .public-hero__signal-title,
   }
 }
 
+/* ======================== AMP PR 3 PUBLIC CARD FOUNDATION ======================== */
+
+.public-card-foundation {
+  display: flex;
+  min-width: 0;
+  height: 100%;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.public-card-foundation__media {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--amp-public-color-paper-warm);
+}
+
+.public-card-foundation__media-link {
+  position: absolute;
+  inset: 0;
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.public-card-foundation__image {
+  object-fit: cover;
+  transition: transform var(--public-motion-base) var(--public-ease-standard);
+}
+
+.public-card-foundation:hover .public-card-foundation__image,
+.public-card-foundation:focus-within .public-card-foundation__image {
+  transform: scale(1.035);
+}
+
+.public-card-foundation__badges {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  right: 12px;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.public-card-foundation__badge {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  box-shadow: var(--public-shadow-claude-sm);
+}
+
+.public-card-foundation__body {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 16px;
+  padding: clamp(18px, 2.4vw, 24px);
+}
+
+.public-card-foundation__meta-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.public-card-foundation__location,
+.public-card-foundation__type,
+.public-card-foundation__fact-label {
+  color: var(--amp-public-color-muted);
+  font-family: var(--public-type-mono-family);
+  font-size: 0.72rem;
+  font-weight: var(--public-font-weight-bold);
+  letter-spacing: 0.1em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.public-card-foundation__location,
+.public-card-foundation__type {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.public-card-foundation__type {
+  color: var(--amp-public-color-champagne-deep);
+}
+
+.public-card-foundation__headline {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.public-card-foundation__title-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.public-card-foundation__title-link:hover,
+.public-card-foundation__title-link:focus-visible {
+  color: var(--amp-public-color-coral-hover);
+}
+
+.public-card-foundation__price {
+  margin: 0;
+  color: var(--amp-public-color-ink);
+  font-family: var(--amp-public-display-family);
+  font-size: clamp(1.22rem, 1.8vw, 1.55rem);
+  line-height: 1;
+  letter-spacing: -0.015em;
+}
+
+.public-card-foundation__facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.public-card-foundation__fact {
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--amp-public-border-soft);
+  border-radius: var(--public-radius-md);
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.public-card-foundation__fact-label,
+.public-card-foundation__fact-value {
+  margin: 0;
+}
+
+.public-card-foundation__fact-value {
+  margin-top: 4px;
+  color: var(--amp-public-color-ink);
+  font-weight: var(--public-font-weight-semibold);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.public-card-foundation__highlights {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.public-card-foundation__highlight {
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--amp-public-border-soft);
+  border-radius: var(--amp-public-radius-pill);
+  background: rgba(var(--amp-public-color-ink-rgb), 0.04);
+  color: var(--amp-public-color-ink);
+  font-size: var(--public-type-caption-size);
+  line-height: var(--public-type-caption-line);
+}
+
+.public-card-foundation__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: auto;
+}
+
+.public-card-foundation__placeholder-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.public-card-foundation__placeholder-action {
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px dashed var(--amp-public-border-soft);
+  border-radius: var(--amp-public-radius-pill);
+  background: var(--amp-public-color-paper);
+  color: var(--amp-public-color-muted);
+  font-size: var(--public-type-caption-size);
+}
+
+.public-card-foundation__cta {
+  min-height: var(--amp-public-touch-target);
+}
+
+@media (max-width: 767px) {
+  .public-card-foundation__media {
+    aspect-ratio: 16 / 11;
+  }
+
+  .public-card-foundation__body {
+    padding: var(--public-panel-padding-compact);
+  }
+
+  .public-card-foundation__footer,
+  .public-card-foundation__placeholder-actions {
+    width: 100%;
+  }
+
+  .public-card-foundation__cta,
+  .public-card-foundation__placeholder-action {
+    flex: 1 1 100%;
+    justify-content: center;
+  }
+}
+
 /* ======================== AMP PR 2 PUBLIC SHELL ======================== */
 
 .public-site-shell .site-header .header-cta--utility {

--- a/docs/AMP_PUBLIC_CARDS_PR3.md
+++ b/docs/AMP_PUBLIC_CARDS_PR3.md
@@ -1,0 +1,119 @@
+# AMP Public Cards PR3
+
+## Components Added
+
+- `PropertyCard` in `admin-app/components/public-system/components/PropertyCard.tsx`
+- `ProjectCard` in `admin-app/components/public-system/components/ProjectCard.tsx`
+
+These are isolated public card foundation components. They are not wired into the home, buy, rent, projects, or detail routes in PR3.
+
+## Data Contract
+
+```ts
+export type PublicPropertyCardData = {
+  id: string;
+  title: string;
+  href: string;
+  imageSrc: string;
+  imageAlt: string;
+  location: string;
+  priceLabel: string;
+  listingType: 'sale' | 'rent';
+  propertyType?: string;
+  bedrooms?: number | string;
+  bathrooms?: number | string;
+  sizeLabel?: string;
+  viewLabel?: string;
+  statusLabel?: string;
+  isFeatured?: boolean;
+};
+
+export type PublicProjectCardData = {
+  id: string;
+  name: string;
+  href: string;
+  imageSrc: string;
+  imageAlt: string;
+  location: string;
+  startingPriceLabel?: string;
+  completionLabel?: string;
+  statusLabel?: string;
+  highlights?: string[];
+};
+```
+
+## Example Usage
+
+```tsx
+import { PropertyCard } from '@/components/public-system/components/PropertyCard';
+import { ProjectCard } from '@/components/public-system/components/ProjectCard';
+
+<PropertyCard
+  property={{
+    id: 'property-riviera-california',
+    title: 'Riviera California Sea View Residence',
+    href: '/en/property/riviera-california-sea-view',
+    imageSrc: '/images/property-exterior.png',
+    imageAlt: 'Riviera California Pattaya sea view condo',
+    location: 'Wongamat',
+    priceLabel: 'THB 8,900,000',
+    listingType: 'sale',
+    propertyType: 'Condo',
+    bedrooms: 2,
+    bathrooms: 2,
+    sizeLabel: '65 sqm',
+    viewLabel: 'Sea view',
+    statusLabel: 'Ready to move in',
+    isFeatured: true,
+  }}
+  ctaLabel="View Details"
+/>
+
+<ProjectCard
+  project={{
+    id: 'project-once-wongamat',
+    name: 'Once Wongamat',
+    href: '/en/projects/once-wongamat',
+    imageSrc: '/images/project-overview.png',
+    imageAlt: 'Once Wongamat project exterior',
+    location: 'Wongamat',
+    startingPriceLabel: 'From THB 4.2M',
+    completionLabel: 'Completion 2028',
+    statusLabel: 'New launch',
+    highlights: ['Foreign quota available', 'Beach access', 'High-floor sea views'],
+  }}
+  ctaLabel="View Project"
+/>
+```
+
+## Styling
+
+Card styles are scoped to `public-card-foundation*` classes and reuse PR1/PR2 tokens:
+
+- `public-amp-card`
+- `public-amp-card-title`
+- `--amp-public-*`
+- `--public-*`
+- public button and chip primitives
+
+No full static prototype stylesheet was copied.
+
+## Intentionally Not Implemented
+
+- No production page migration.
+- No home, buy, rent, projects, or detail layout rewrite.
+- No real shortlist or compare state.
+- No API calls or data fetching.
+- No backend, database, form, tracking, SEO, canonical, or OpenGraph changes.
+- No admin UI changes.
+
+`PropertyCard` can render disabled `Shortlist` and `Compare` placeholder controls with `showActionPlaceholders`. They are visual placeholders only.
+
+## Recommended PR4 Usage
+
+PR4 should migrate one low-risk listing surface first, preferably behind existing data mapping:
+
+- Add mapper functions from existing listing/project API payloads into `PublicPropertyCardData` and `PublicProjectCardData`.
+- Replace one card grid surface at a time.
+- Keep route behavior, filters, sorting, lead forms, tracking, and SEO unchanged.
+- Validate desktop/tablet/mobile card grids and no horizontal overflow before moving to additional pages.


### PR DESCRIPTION
## Summary

Adds isolated reusable public card foundation components for future AMP public listing and project migrations without mounting them in production routes.

## Changes

- Adds `PropertyCard` and `ProjectCard` under `admin-app/components/public-system/components`.
- Adds explicit `PublicPropertyCardData` and `PublicProjectCardData` contracts.
- Exports the new components through the public-system barrel for future adoption.
- Adds scoped `public-card-foundation*` CSS using the PR1 public UI tokens and primitives.
- Adds isolated component tests for rendering, optional fields, links, image alt text, badges, facts, and highlights.
- Documents PR3 usage, boundaries, and recommended PR4 migration path.

## Safety Audit

- New cards are not mounted in any production route yet.
- Existing production card components remain untouched:
  - `admin-app/components/cards/PropertyCard.tsx`
  - `admin-app/components/project/ProjectCard.tsx`
- No route, page, admin UI, backend, API, database, form, tracking, SEO, canonical, or OpenGraph files changed.
- No root barrel import collision was found for `@/components/public-system`; current production code uses direct subpath imports.
- CSS is scoped to the `public-card-foundation*` namespace and only applies when the new card class is rendered.

## Validation

- `npm ci` passed in `admin-app`; npm reported existing dependency audit/deprecation warnings.
- `npm run lint` passed; existing `<img>` warnings remain in unchanged files.
- `npm run test -- --reporter=dot` passed after clean install: 124 test files, 526 tests.
- `npm run build` passed after clean install: 104 static pages generated.
- `git diff --check` passed.

## Not Included

- No listing page migration.
- No home section migration.
- No detail page migration.
- No real shortlist or compare state.
- No backend/data fetching changes.
- No deployment.
