### PR TITLE
feat(amp-public): add public card data mappers

### DIFF
--- a/admin-app/__tests__/public_card_mappers.test.ts
+++ b/admin-app/__tests__/public_card_mappers.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  mapProjectToPublicCardData,
+  mapPropertyToPublicCardData,
+} from '@/app/_lib/public-card-mappers';
+
+describe('public card data mappers', () => {
+  it('maps full property data into the public property card contract', () => {
+    const card = mapPropertyToPublicCardData({
+      id: 'property-1',
+      source_id: 'source-1',
+      title: 'Riviera California - #RT04076 | Renthai',
+      type: 'resale',
+      property_type: 'sea_view_condo',
+      price: 8900000,
+      bedrooms: 2,
+      bathrooms: 2,
+      size_sqm: 65,
+      address: 'Wongamat',
+      city: 'Pattaya',
+      images: ['/images/property-interior.png'],
+      local_images: ['/images/property-exterior.png'],
+      cover_image: '/images/property-pool.png',
+      status: 'published',
+      slug: 'riviera-california-sea-view',
+      view: 'Sea view',
+      is_featured: true,
+    });
+
+    expect(card).toMatchObject({
+      id: 'property-1',
+      title: 'Riviera California',
+      href: '/en/property/riviera-california-sea-view',
+      imageSrc: '/images/property-pool.png',
+      imageAlt: 'Riviera California in Wongamat',
+      location: 'Wongamat',
+      priceLabel: 'THB 8,900,000',
+      listingType: 'sale',
+      propertyType: 'Sea View Condo',
+      bedrooms: 2,
+      bathrooms: 2,
+      sizeLabel: '65 sqm',
+      viewLabel: 'Sea view',
+      statusLabel: 'Published',
+      isFeatured: true,
+    });
+  });
+
+  it('maps missing optional property fields without broken text or crashes', () => {
+    const card = mapPropertyToPublicCardData({
+      id: 'property-minimal',
+      source_id: 'source-minimal',
+      title: '',
+      type: 'resale',
+      price: 0,
+      address: '',
+      city: '',
+      images: null,
+      local_images: null,
+      cover_image: null,
+      status: '',
+      slug: null,
+    });
+
+    expect(card.title).toBe('Pattaya property');
+    expect(card.href).toBe('/en/public/properties/property-minimal');
+    expect(card.imageSrc).toBe('/images/property-placeholder.svg');
+    expect(card.imageAlt).toBe('Pattaya property in Pattaya');
+    expect(card.location).toBe('Pattaya');
+    expect(card.priceLabel).toBe('Price on request');
+    expect(card.propertyType).toBeUndefined();
+    expect(card.bedrooms).toBeUndefined();
+    expect(card.bathrooms).toBeUndefined();
+    expect(card.sizeLabel).toBeUndefined();
+    expect(card.viewLabel).toBeUndefined();
+    expect(card.statusLabel).toBeUndefined();
+    expect(card.isFeatured).toBe(false);
+  });
+
+  it('maps sale and rent listing types correctly', () => {
+    const sale = mapPropertyToPublicCardData({
+      id: 'sale-1',
+      title: 'Sale property',
+      type: 'new',
+      price: 1,
+      address: 'Jomtien',
+      city: 'Pattaya',
+      images: null,
+      status: 'published',
+      slug: 'sale-property',
+    });
+    const rent = mapPropertyToPublicCardData({
+      id: 'rent-1',
+      title: 'Rent property',
+      type: 'rent',
+      price: 1,
+      address: 'Jomtien',
+      city: 'Pattaya',
+      images: null,
+      status: 'published',
+      slug: 'rent-property',
+    });
+
+    expect(sale.listingType).toBe('sale');
+    expect(rent.listingType).toBe('rent');
+    expect(rent.href).toBe('/en/property/rent-property');
+  });
+
+  it('maps full project data into the public project card contract', () => {
+    const card = mapProjectToPublicCardData({
+      id: 'project-1',
+      slug: 'once-wongamat',
+      name: 'Once Wongamat',
+      status: 'new_launch',
+      cover_image_url: '/images/project-overview.png',
+      hero_image_url: '/images/property-exterior.png',
+      images: ['/images/property-pool.png'],
+      starting_price: 4200000,
+      area: { id: 'area-1', slug: 'wongamat', name: 'Wongamat' },
+      highlights: ['Foreign quota available', 'Beach access'],
+      features: ['High-floor sea views'],
+      tags: ['Beach access'],
+      completion_year: 2028,
+      created_at: null,
+      updated_at: null,
+    });
+
+    expect(card).toMatchObject({
+      id: 'project-1',
+      name: 'Once Wongamat',
+      href: '/en/projects/once-wongamat',
+      imageSrc: '/images/project-overview.png',
+      imageAlt: 'Project image for Once Wongamat in Wongamat',
+      location: 'Wongamat',
+      startingPriceLabel: 'From THB 4,200,000',
+      completionLabel: 'Completion 2028',
+      statusLabel: 'New Launch',
+      highlights: ['Foreign quota available', 'Beach access', 'High-floor sea views'],
+    });
+  });
+
+  it('maps missing optional project fields without broken text or crashes', () => {
+    const card = mapProjectToPublicCardData({
+      id: 'project-minimal',
+      slug: '',
+      name: '',
+      status: '',
+      cover_image_url: null,
+      hero_image_url: null,
+      images: null,
+      starting_price: null,
+      created_at: null,
+      updated_at: null,
+    });
+
+    expect(card.name).toBe('Pattaya project');
+    expect(card.href).toBe('/en/projects');
+    expect(card.imageSrc).toBe('/images/project-overview.png');
+    expect(card.imageAlt).toBe('Project image for Pattaya project in Pattaya');
+    expect(card.location).toBe('Pattaya');
+    expect(card.startingPriceLabel).toBe('Price on request');
+    expect(card.completionLabel).toBeUndefined();
+    expect(card.statusLabel).toBeUndefined();
+    expect(card.highlights).toBeUndefined();
+  });
+
+  it('generates safe internal hrefs even when source values look external', () => {
+    const property = mapPropertyToPublicCardData({
+      id: 'property-external',
+      title: 'External-looking property',
+      type: 'resale',
+      price: 1000000,
+      address: 'Pattaya',
+      city: 'Pattaya',
+      images: null,
+      status: 'published',
+      slug: 'https://example.com/bad-path',
+      href: 'https://example.com/ignored',
+    });
+    const project = mapProjectToPublicCardData({
+      id: 'project-external',
+      slug: 'https://example.com/project',
+      name: 'External-looking project',
+      status: 'published',
+      starting_price: 1000000,
+      created_at: null,
+      updated_at: null,
+      href: 'https://example.com/ignored',
+    });
+
+    expect(property.href).toBe('/en/property/https%3A%2F%2Fexample.com%2Fbad-path');
+    expect(project.href).toBe('/en/projects/https%3A%2F%2Fexample.com%2Fproject');
+    expect(property.href.startsWith('/en/')).toBe(true);
+    expect(project.href.startsWith('/en/')).toBe(true);
+  });
+
+  it('uses explicit image alt when provided and falls back to descriptive alt text otherwise', () => {
+    const property = mapPropertyToPublicCardData({
+      id: 'property-alt',
+      title: 'Arom Wongamat',
+      type: 'resale',
+      price: 1000000,
+      address: 'Wongamat',
+      city: 'Pattaya',
+      images: null,
+      status: 'published',
+      slug: 'arom-wongamat',
+      imageAlt: 'Custom property image alt',
+    });
+    const project = mapProjectToPublicCardData({
+      id: 'project-alt',
+      slug: 'grand-solaire-noble',
+      name: 'Grand Solaire Noble',
+      status: 'published',
+      starting_price: 1000000,
+      area_name: 'Central Pattaya',
+      created_at: null,
+      updated_at: null,
+    });
+
+    expect(property.imageAlt).toBe('Custom property image alt');
+    expect(project.imageAlt).toBe('Project image for Grand Solaire Noble in Central Pattaya');
+  });
+
+  it('uses price fallback for missing property and project prices', () => {
+    const property = mapPropertyToPublicCardData({
+      id: 'property-price',
+      title: 'Price fallback property',
+      type: 'resale',
+      price: Number.NaN,
+      address: 'Pattaya',
+      city: 'Pattaya',
+      images: null,
+      status: 'published',
+      slug: 'price-fallback-property',
+    });
+    const project = mapProjectToPublicCardData({
+      id: 'project-price',
+      slug: 'price-fallback-project',
+      name: 'Price fallback project',
+      status: 'published',
+      starting_price: 0,
+      created_at: null,
+      updated_at: null,
+    });
+
+    expect(property.priceLabel).toBe('Price on request');
+    expect(project.startingPriceLabel).toBe('Price on request');
+  });
+});

--- a/admin-app/app/_lib/public-card-mappers.ts
+++ b/admin-app/app/_lib/public-card-mappers.ts
@@ -1,0 +1,279 @@
+import type { Locale } from '@/app/_lib/i18n/types';
+import { withLocale } from '@/app/_lib/i18n/routing';
+import { pickCoverImage, formatPriceTHB } from '@/app/_lib/public-api-shared';
+import { pickRenderableLocalMedia } from '@/app/_lib/local-media';
+import type { ProjectItem } from '@/app/_lib/public-api-server';
+import type { PropertyListItem } from '@/app/public/_shared/types';
+import type { PublicProjectCardData } from '@/components/public-system/components/ProjectCard';
+import type { PublicPropertyCardData } from '@/components/public-system/components/PropertyCard';
+
+const DEFAULT_LOCATION = 'Pattaya';
+const DEFAULT_PRICE_LABEL = 'Price on request';
+const DEFAULT_PROPERTY_TITLE = 'Pattaya property';
+const DEFAULT_PROJECT_NAME = 'Pattaya project';
+const DEFAULT_PROPERTY_IMAGE = '/images/property-placeholder.svg';
+const DEFAULT_PROJECT_IMAGE = '/images/project-overview.png';
+
+export type PublicCardMapperOptions = {
+  locale?: Locale;
+};
+
+export type PublicPropertyCardSource = Partial<PropertyListItem> & {
+  area_name?: string | null;
+  cover_image_url?: string | null;
+  featured?: boolean | null;
+  href?: string | null;
+  imageAlt?: string | null;
+  image_url?: string | null;
+  isFeatured?: boolean | null;
+  is_featured?: boolean | null;
+  location?: string | null;
+  status_label?: string | null;
+  title_i18n?: Record<string, string | null | undefined> | null;
+  view?: string | null;
+  view_label?: string | null;
+  viewLabel?: string | null;
+};
+
+export type PublicProjectCardSource = Partial<ProjectItem> & {
+  area_name?: string | null;
+  city?: string | null;
+  completion?: string | number | null;
+  completion_year?: string | number | null;
+  delivery_date?: string | null;
+  features?: Array<string | null | undefined> | null;
+  highlights?: Array<string | null | undefined> | null;
+  href?: string | null;
+  imageAlt?: string | null;
+  image_url?: string | null;
+  location?: string | null;
+  property_type?: string | null;
+  status_label?: string | null;
+  tags?: Array<string | null | undefined> | null;
+  title?: string | null;
+};
+
+function trimString(value: unknown): string | null {
+  const trimmed = typeof value === 'string' || typeof value === 'number'
+    ? String(value).trim()
+    : '';
+  return trimmed || null;
+}
+
+function firstText(...values: unknown[]): string | null {
+  for (const value of values) {
+    const trimmed = trimString(value);
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function cleanPropertyTitle(raw: string): string {
+  return raw
+    .replace(/\s*-\s*#[A-Z0-9]+\s*\|\s*\w+$/i, '')
+    .replace(/\s*\|\s*Renthai$/i, '')
+    .trim() || raw;
+}
+
+function localizedRecordText(
+  value: Record<string, string | null | undefined> | null | undefined,
+  locale: Locale,
+): string | null {
+  if (!value) return null;
+  return firstText(value[locale], value.en, value.th);
+}
+
+function humanizeToken(value: string | null | undefined): string | null {
+  const trimmed = trimString(value);
+  if (!trimmed) return null;
+  return trimmed
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function numericValue(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const numberValue = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(numberValue) ? numberValue : null;
+}
+
+function formatOptionalNumber(value: unknown): number | string | undefined {
+  const numberValue = numericValue(value);
+  if (numberValue !== null && numberValue >= 0) return numberValue;
+  const textValue = trimString(value);
+  return textValue ?? undefined;
+}
+
+function formatSizeLabel(property: PublicPropertyCardSource): string | undefined {
+  const explicit = firstText((property as { sizeLabel?: string | null }).sizeLabel);
+  if (explicit) return explicit;
+
+  const sizeValue = numericValue(property.size_sqm ?? property.size);
+  if (sizeValue === null || sizeValue <= 0) return undefined;
+  return `${Math.round(sizeValue).toLocaleString()} sqm`;
+}
+
+function formatPriceLabel(value: unknown, locale: Locale): string {
+  const price = numericValue(value);
+  if (price === null || price <= 0) return DEFAULT_PRICE_LABEL;
+  return formatPriceTHB(price, locale);
+}
+
+function prefixedProjectPrice(value: unknown, locale: Locale): string {
+  const price = numericValue(value);
+  if (price === null || price <= 0) return DEFAULT_PRICE_LABEL;
+  const prefix = locale === 'th' ? 'เริ่มต้น' : 'From';
+  return `${prefix} ${formatPriceTHB(price, locale)}`;
+}
+
+function safeLocalizedHref(locale: Locale, path: string): string {
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return withLocale(locale, normalized);
+}
+
+function propertyHref(property: PublicPropertyCardSource, locale: Locale): string {
+  const slug = trimString(property.slug);
+  if (slug) return safeLocalizedHref(locale, `/property/${encodeURIComponent(slug)}`);
+
+  const id = trimString(property.id);
+  if (id) return safeLocalizedHref(locale, `/public/properties/${encodeURIComponent(id)}`);
+
+  return safeLocalizedHref(locale, property.type === 'rent' ? '/rent' : '/buy');
+}
+
+function projectHref(project: PublicProjectCardSource, locale: Locale): string {
+  const slug = trimString(project.slug);
+  if (slug) return safeLocalizedHref(locale, `/projects/${encodeURIComponent(slug)}`);
+
+  return safeLocalizedHref(locale, '/projects');
+}
+
+function listingType(property: PublicPropertyCardSource): PublicPropertyCardData['listingType'] {
+  return String(property.type ?? '').trim().toLowerCase() === 'rent' ? 'rent' : 'sale';
+}
+
+function propertyTitle(property: PublicPropertyCardSource, locale: Locale): string {
+  const title = localizedRecordText(property.title_i18n, locale) ?? firstText(property.title);
+  return title ? cleanPropertyTitle(title) : DEFAULT_PROPERTY_TITLE;
+}
+
+function projectName(project: PublicProjectCardSource): string {
+  return firstText(project.name, project.title) ?? DEFAULT_PROJECT_NAME;
+}
+
+function propertyLocation(property: PublicPropertyCardSource): string {
+  return firstText(property.location, property.address, property.city, property.area_name) ?? DEFAULT_LOCATION;
+}
+
+function projectLocation(project: PublicProjectCardSource): string {
+  return firstText(project.location, project.area?.name, project.area_name, project.city) ?? DEFAULT_LOCATION;
+}
+
+function imageAltForProperty(title: string, location: string): string {
+  return `${title} in ${location}`;
+}
+
+function imageAltForProject(name: string, location: string): string {
+  return `Project image for ${name} in ${location}`;
+}
+
+function projectCompletionLabel(project: PublicProjectCardSource): string | undefined {
+  const raw = firstText(project.completion, project.completion_year, project.delivery_date);
+  if (!raw) return undefined;
+  return /^completion\b/i.test(raw) ? raw : `Completion ${raw}`;
+}
+
+function compactTextArray(values: Array<string | null | undefined>): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of values) {
+    const trimmed = trimString(value);
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(trimmed);
+  }
+
+  return result;
+}
+
+function projectHighlights(project: PublicProjectCardSource): string[] | undefined {
+  const values = compactTextArray([
+    ...(project.highlights ?? []),
+    ...(project.features ?? []),
+    ...(project.tags ?? []),
+  ]).slice(0, 4);
+
+  return values.length ? values : undefined;
+}
+
+export function mapPropertyToPublicCardData(
+  property: PublicPropertyCardSource,
+  options: PublicCardMapperOptions = {},
+): PublicPropertyCardData {
+  const locale = options.locale ?? 'en';
+  const title = propertyTitle(property, locale);
+  const location = propertyLocation(property);
+  const imageSrc = (
+    pickCoverImage({
+      cover_image: property.cover_image ?? property.cover_image_url ?? property.image_url ?? null,
+      local_images: property.local_images ?? null,
+      images: property.images ?? null,
+    }) ?? DEFAULT_PROPERTY_IMAGE
+  );
+  const statusLabel = firstText(property.status_label, humanizeToken(property.status));
+  const propertyType = humanizeToken(firstText(property.property_type));
+
+  return {
+    id: firstText(property.id, property.source_id) ?? 'property-card',
+    title,
+    href: propertyHref(property, locale),
+    imageSrc,
+    imageAlt: firstText((property as { imageAlt?: string | null }).imageAlt) ?? imageAltForProperty(title, location),
+    location,
+    priceLabel: formatPriceLabel(property.price, locale),
+    listingType: listingType(property),
+    propertyType: propertyType ?? undefined,
+    bedrooms: formatOptionalNumber(property.bedrooms),
+    bathrooms: formatOptionalNumber(property.bathrooms),
+    sizeLabel: formatSizeLabel(property),
+    viewLabel: firstText(property.viewLabel, property.view_label, property.view) ?? undefined,
+    statusLabel: statusLabel ?? undefined,
+    isFeatured: Boolean(property.isFeatured ?? property.is_featured ?? property.featured ?? false),
+  };
+}
+
+export function mapProjectToPublicCardData(
+  project: PublicProjectCardSource,
+  options: PublicCardMapperOptions = {},
+): PublicProjectCardData {
+  const locale = options.locale ?? 'en';
+  const name = projectName(project);
+  const location = projectLocation(project);
+  const imageSrc = (
+    pickRenderableLocalMedia({
+      cover_image: (project as { cover_image?: string | null }).cover_image ?? null,
+      cover_image_url: project.cover_image_url ?? project.image_url ?? null,
+      hero_image_url: project.hero_image_url ?? null,
+      images: project.images ?? null,
+    }) ?? DEFAULT_PROJECT_IMAGE
+  );
+  const statusLabel = firstText(project.status_label, humanizeToken(project.status));
+
+  return {
+    id: firstText(project.id) ?? 'project-card',
+    name,
+    href: projectHref(project, locale),
+    imageSrc,
+    imageAlt: firstText((project as { imageAlt?: string | null }).imageAlt) ?? imageAltForProject(name, location),
+    location,
+    startingPriceLabel: prefixedProjectPrice(project.starting_price, locale),
+    completionLabel: projectCompletionLabel(project),
+    statusLabel: statusLabel ?? undefined,
+    highlights: projectHighlights(project),
+  };
+}

--- a/docs/AMP_PUBLIC_CARD_MAPPERS_PR4.md
+++ b/docs/AMP_PUBLIC_CARD_MAPPERS_PR4.md
@@ -1,0 +1,81 @@
+# AMP Public Card Mappers PR4
+
+## Mapper Purpose
+
+PR4 adds isolated adapter functions that convert existing production property and project payloads into the PR3 public card contracts:
+
+- `mapPropertyToPublicCardData`
+- `mapProjectToPublicCardData`
+
+The mappers live in `admin-app/app/_lib/public-card-mappers.ts` and are intentionally not mounted in any production route yet.
+
+## Data Contract
+
+The mapper output matches the reusable card contracts:
+
+```ts
+type PublicPropertyCardData = {
+  id: string;
+  title: string;
+  href: string;
+  imageSrc: string;
+  imageAlt: string;
+  location: string;
+  priceLabel: string;
+  listingType: 'sale' | 'rent';
+  propertyType?: string;
+  bedrooms?: number | string;
+  bathrooms?: number | string;
+  sizeLabel?: string;
+  viewLabel?: string;
+  statusLabel?: string;
+  isFeatured?: boolean;
+};
+
+type PublicProjectCardData = {
+  id: string;
+  name: string;
+  href: string;
+  imageSrc: string;
+  imageAlt: string;
+  location: string;
+  startingPriceLabel?: string;
+  completionLabel?: string;
+  statusLabel?: string;
+  highlights?: string[];
+};
+```
+
+## Fallback Behavior
+
+- Missing property title becomes `Pattaya property`.
+- Missing project name becomes `Pattaya project`.
+- Missing location becomes `Pattaya`.
+- Missing or invalid property price becomes `Price on request`.
+- Missing or invalid project starting price becomes `Price on request`.
+- Missing property image becomes `/images/property-placeholder.svg`.
+- Missing project image becomes `/images/project-overview.png`.
+- Image alt text is generated from the title/name and location unless an explicit `imageAlt` is provided.
+- Property hrefs are generated from slug, then id, then route fallback.
+- Project hrefs are generated from slug, then `/projects` fallback.
+- Hrefs are always internal localized paths.
+- Optional facts remain `undefined` when source fields are absent so cards do not render broken placeholder text.
+
+## Intentionally Not Changed
+
+- No new `PropertyCard` or `ProjectCard` is mounted in production pages.
+- No home, buy, rent, projects, or detail route UI migration.
+- No route behavior changes.
+- No API, backend, database, query, form, tracking, SEO, canonical, or OpenGraph changes.
+- No admin UI changes.
+- No static prototype CSS copied.
+- No external dependencies added.
+
+## Recommended PR5 Scope
+
+PR5 should migrate one low-risk public card surface only:
+
+- Use these mappers to adapt existing route data.
+- Replace one card grid surface at a time.
+- Keep filters, sorting, pagination, lead forms, analytics events, SEO metadata, and backend calls unchanged.
+- Validate mobile, tablet, and desktop card grids before expanding to additional pages.


### PR DESCRIPTION
## Summary

Adds isolated PR4 mapper functions that adapt existing production property and project payloads into the PR3 public card contracts without mounting the new cards in production pages.

## Changes

- Adds `mapPropertyToPublicCardData` and `mapProjectToPublicCardData` in `admin-app/app/_lib/public-card-mappers.ts`.
- Adds mapper source types and safe fallback helpers for titles, names, locations, prices, hrefs, image sources, image alt text, facts, statuses, and highlights.
- Adds unit tests for full data, missing optional fields, sale/rent mapping, safe internal href generation, image alt fallback, and price fallback.
- Adds PR4 documentation in `docs/AMP_PUBLIC_CARD_MAPPERS_PR4.md`.

## Safety Audit

- No production page imports the new mappers yet; usage is limited to the mapper module and unit tests.
- No new `PropertyCard` or `ProjectCard` is mounted in production routes.
- No route, page UI, admin UI, backend, API, database, form, tracking, SEO, canonical, or OpenGraph changes.
- No external dependencies added.
- No static prototype CSS copied.

## Validation

- `npm run lint` passed; existing `<img>` warnings remain in unchanged files.
- `npm run test -- public_card_mappers.test.ts --reporter=dot` passed: 8 tests.
- `npm run test -- --reporter=dot` passed: 125 test files, 534 tests.
- `npm run build` passed: 104 static pages generated.
- `git diff --check` passed.

## Not Included

- No listing page UI migration.
- No home page rewrite.
- No card mounting in production pages.
- No backend/data query changes.
- No deployment.
