### PR TITLE
feat(amp-public): migrate projects listing grid cards

### DIFF
--- a/admin-app/__tests__/projects_card_surface_pr5.test.tsx
+++ b/admin-app/__tests__/projects_card_surface_pr5.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ProjectsListingClient, type ProjectItem } from '@/components/project/ProjectsListingClient';
+
+vi.mock('next/image', () => ({
+  default: (props: Record<string, unknown>) => (
+    <div
+      role="img"
+      aria-label={String(props.alt ?? '')}
+      data-src={String(props.src ?? '')}
+      data-sizes={String(props.sizes ?? '')}
+    />
+  ),
+}));
+
+const copy = {
+  browseListingsLabel: 'Browse shortlist-ready listings',
+  card: {
+    areaFallback: 'Pattaya',
+    reviewAction: 'View project',
+  },
+};
+
+const projects: ProjectItem[] = [
+  {
+    id: 'project-once-wongamat',
+    slug: 'once-wongamat',
+    name: 'Once Wongamat',
+    starting_price: 4_200_000,
+    status: 'new_launch',
+    cover_image_url: '/images/project-overview.png',
+    area_name: 'Wongamat',
+    summary: {
+      en: 'Beach-focused new launch with foreign quota availability.',
+    },
+    property_type: 'condo',
+    delivery_date: '2028',
+    developer_name: 'Honor Group',
+    gross_yield: 0.065,
+    foreign_quota: 0.49,
+    beach_distance: 120,
+  },
+  {
+    id: 'project-minimal',
+    slug: 'minimal-project',
+    name: 'Minimal Pattaya Project',
+    status: null,
+    starting_price: null,
+    cover_image_url: null,
+    area_name: null,
+    summary: null,
+    description: null,
+  },
+];
+
+function renderProjectsListing(items: ProjectItem[] = projects) {
+  return render(
+    <ProjectsListingClient
+      initialProjects={items}
+      locale="en"
+      dict={{}}
+      copy={copy}
+    />,
+  );
+}
+
+describe('Projects listing PR5 card surface', () => {
+  it('renders the grid surface with public-system ProjectCard output and localized internal links', () => {
+    const { container } = renderProjectsListing();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grid' }));
+
+    const cards = container.querySelectorAll('article.public-project-card.public-card-foundation');
+    expect(cards).toHaveLength(2);
+
+    const onceCardElement = Array.from(cards).find((card) =>
+      card.getAttribute('aria-label')?.includes('Once Wongamat'),
+    );
+    expect(onceCardElement).toBeTruthy();
+    const onceCard = within(onceCardElement as HTMLElement);
+    expect(onceCard.getByRole('heading', { name: 'Once Wongamat' })).toBeInTheDocument();
+    expect(onceCard.getByText('Wongamat')).toBeInTheDocument();
+    expect(onceCard.getByText('New launch')).toBeInTheDocument();
+    expect(onceCard.getByText('From THB 4,200,000')).toBeInTheDocument();
+    expect(onceCard.getByText('Completion 2028')).toBeInTheDocument();
+    expect(onceCard.getByText('6.5% yield')).toBeInTheDocument();
+
+    expect(screen.getByRole('link', { name: 'Once Wongamat' })).toHaveAttribute(
+      'href',
+      '/en/projects/once-wongamat',
+    );
+    expect(onceCard.getByRole('link', { name: 'View project' })).toHaveAttribute(
+      'href',
+      '/en/projects/once-wongamat',
+    );
+  });
+
+  it('keeps missing optional project fields renderable without broken placeholder text', () => {
+    const { container } = renderProjectsListing([projects[1]]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grid' }));
+
+    const card = container.querySelector('article.public-project-card.public-card-foundation');
+    expect(card).not.toBeNull();
+    const minimalCard = within(card as HTMLElement);
+
+    expect(minimalCard.getByRole('heading', { name: 'Minimal Pattaya Project' })).toBeInTheDocument();
+    expect(minimalCard.getByText('Pattaya')).toBeInTheDocument();
+    expect(minimalCard.getByText('Price on request')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Minimal Pattaya Project' })).toHaveAttribute(
+      'href',
+      '/en/projects/minimal-project',
+    );
+    expect(container.textContent).not.toContain('undefined');
+    expect(container.textContent).not.toContain('null');
+  });
+
+  it('preserves the Projects listing route shell controls while swapping only the grid card renderer', () => {
+    renderProjectsListing();
+
+    expect(screen.getByRole('button', { name: 'Split' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Grid' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Map' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveValue('relevance');
+    expect(screen.getByRole('link', { name: /browse shortlist-ready listings/i })).toHaveAttribute('href', '/en/buy');
+  });
+});

--- a/admin-app/components/project/ProjectsListingClient.tsx
+++ b/admin-app/components/project/ProjectsListingClient.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import React, { useState, useMemo, useRef, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import { ProjectCard } from '@/components/project/ProjectCard';
+import { mapProjectToPublicCardData } from '@/app/_lib/public-card-mappers';
 import { withLocale } from '@/app/_lib/i18n/routing';
 import { withLocaleQuery } from '@/app/_lib/public-advisory';
+import { ProjectCard as PublicProjectCard } from '@/components/public-system/components/ProjectCard';
 
 // Basic Type matching ProjectItem in public-api-server
 export interface ProjectItem {
@@ -85,8 +85,6 @@ function getProjectCoords(project: ProjectItem, index: number): { x: number; y: 
 }
 
 export function ProjectsListingClient({ initialProjects, locale, dict, copy }: ProjectsListingClientProps) {
-  const pathname = usePathname() ?? '/';
-  
   // UI states
   const [view, setView] = useState<'split' | 'grid' | 'map'>('split');
   const [sort, setSort] = useState<string>('relevance');
@@ -557,7 +555,6 @@ export function ProjectsListingClient({ initialProjects, locale, dict, copy }: P
               >
                 {filteredAndSortedProjects.map((p, index) => {
                   const area = p.area_name || p.area?.name || p.district || p.city || copy.card.areaFallback;
-                  const hasEntryPrice = Boolean(p.starting_price && Number.isFinite(p.starting_price));
                   
                   // Extract status translation
                   let localizedStatus = locale === 'th' ? 'เปิดขาย' : 'Available';
@@ -569,11 +566,6 @@ export function ProjectsListingClient({ initialProjects, locale, dict, copy }: P
                   } else if (normStat.includes('complete') || normStat.includes('ready')) {
                     localizedStatus = locale === 'th' ? 'พร้อมอยู่' : 'Ready';
                   }
-
-                  const badges = [
-                    { key: 'status', label: localizedStatus },
-                    ...(hasEntryPrice ? [{ key: 'entry', label: copy.card.entryLabel }] : []),
-                  ];
 
                   const summary = p.summary?.[locale] || p.summary?.en || p.description?.[locale] || p.description?.en || '';
                   const shortSummary = summary.length > 80 ? `${summary.slice(0, 80).trim()}…` : summary;
@@ -593,6 +585,12 @@ export function ProjectsListingClient({ initialProjects, locale, dict, copy }: P
                   const developerName = p.developer?.name ?? p.developer_name ?? null;
                   const completion = p.completion_date ?? p.delivery_date ?? p.completion ?? null;
                   const coverImage = p.cover_image_url ?? '/images/project-overview.png';
+                  const publicCardHighlights = [
+                    shortSummary,
+                    yieldPctVal ? `${yieldPct} ${locale === 'th' ? 'ผลตอบแทน' : 'yield'}` : '',
+                    quotaVal ? (locale === 'th' ? `โควต้าต่างชาติ ${foreignQuota}` : `Foreign quota ${foreignQuota}`) : '',
+                    beachVal !== undefined && beachVal !== null ? beachDistance : '',
+                  ].filter((item): item is string => Boolean(item));
 
                   const isSavedToCompare = compareList.includes(p.id);
 
@@ -701,41 +699,39 @@ export function ProjectsListingClient({ initialProjects, locale, dict, copy }: P
                     );
                   }
 
-                  // Grid Layout using ProjectCard
+                  const publicProjectCard = mapProjectToPublicCardData(
+                    {
+                      id: p.id,
+                      slug: p.slug,
+                      name: p.name,
+                      starting_price: p.starting_price,
+                      status: p.status ?? undefined,
+                      cover_image_url: p.cover_image_url ?? undefined,
+                      hero_image_url: p.hero_image_url ?? undefined,
+                      images: p.images ?? undefined,
+                      location: String(area),
+                      status_label: p.status ? localizedStatus : undefined,
+                      completion,
+                      highlights: publicCardHighlights,
+                    },
+                    { locale },
+                  );
+
+                  // Grid Layout using the public-system ProjectCard. Split/map views keep their existing rendering.
                   return (
                     <div key={p.id} className="relative group">
-                      <ProjectCard
-                        href={withLocale(locale, `/projects/${encodeURIComponent(p.slug)}`)}
-                        name={p.name}
-                        locale={locale}
-                        media={{
-                          cover_image_url: coverImage,
-                          hero_image_url: coverImage,
-                          images: p.images ?? [],
-                        }}
-                        fallbackImage="/images/project-overview.png"
-                        area={area}
-                        price={formatCompactPrice(p.starting_price)}
-                        summary={shortSummary}
-                        badges={badges}
-                        facts={[
-                          p.property_type ? p.property_type : '',
-                          developerName ? `${locale === 'th' ? 'ผู้พัฒนา' : 'Developer'} ${developerName}` : '',
-                        ].filter(Boolean)}
+                      <PublicProjectCard
+                        project={publicProjectCard}
                         ctaLabel={copy.card.reviewAction}
-                        yieldPct={yieldPct}
-                        foreignQuota={foreignQuota}
-                        beachDistance={beachDistance}
-                        developerName={developerName}
-                        completion={completion}
-                        propertyId={p.id}
+                        fallbackImageSrc="/images/project-overview.png"
+                        imagePriority={index < 2}
                       />
                       
                       {/* Compare Overlay Button */}
                       <button
                         type="button"
                         onClick={() => toggleCompare(p.id)}
-                        className={`absolute bottom-5 right-5 z-20 px-3.5 py-1.5 rounded-full text-[11px] font-semibold border shadow-sm transition-all duration-300 ${
+                        className={`absolute right-4 top-4 z-20 px-3.5 py-1.5 rounded-full text-[11px] font-semibold border shadow-sm transition-all duration-300 ${
                           isSavedToCompare
                             ? 'bg-[var(--public-color-ink, #14201f)] text-[var(--public-color-bone, #f8f4ea)] border-[var(--public-color-ink, #14201f)]'
                             : 'bg-white text-[var(--public-color-ink, #14201f)] border-[var(--public-color-line-soft, #efe6d2)] hover:bg-[var(--public-color-sand-soft, #f3ead9)]'

--- a/docs/AMP_PROJECTS_CARD_SURFACE_PR5.md
+++ b/docs/AMP_PROJECTS_CARD_SURFACE_PR5.md
@@ -1,0 +1,57 @@
+# AMP Projects Card Surface PR5
+
+## Surface Migrated
+
+PR5 migrates only the interactive Projects listing grid card renderer in:
+
+- `admin-app/components/project/ProjectsListingClient.tsx`
+
+The default Projects page layout, hero, filters, sorting, split view, map view, data fetch, metadata, and route behavior are intentionally preserved.
+
+## Components And Mappers Used
+
+- `ProjectCard` from `admin-app/components/public-system/components/ProjectCard.tsx`
+- `mapProjectToPublicCardData` from `admin-app/app/_lib/public-card-mappers.ts`
+
+The grid branch adapts each existing project item into `PublicProjectCardData` before rendering the PR3 public card.
+
+## Existing Behavior Preserved
+
+- Existing `/[locale]/projects` route and localized href behavior remain unchanged.
+- Existing project data source remains `fetchProjects({ limit: 100 })`.
+- Existing filtering, sorting, view toggles, compare selection, and map behavior remain client-side and unchanged.
+- Existing SEO metadata, JSON-LD generation, canonical behavior, and OpenGraph behavior remain untouched.
+- Existing forms, tracking, backend/API queries, and admin UI remain untouched.
+
+## Intentionally Not Changed
+
+- No Home, Buy, Rent, Project Detail, Property Detail, or Admin page migration.
+- No full Projects page redesign.
+- No backend, database, API, route, form, tracking, SEO, canonical, or OpenGraph changes.
+- No static prototype CSS copied.
+- No external dependency added.
+- Split and map views keep their existing rendering for this PR.
+
+## Validation Results
+
+Local validation:
+
+- `npm run lint` - pass. Existing `<img>` warnings remain in the home page and the legacy Projects split view.
+- `npm run test -- projects_card_surface_pr5.test.tsx --reporter=dot` - pass, 3 tests.
+- `npm run test -- --reporter=dot` - pass, 126 files / 537 tests.
+- `npm run build` - pass.
+- `git diff --check` - pass.
+
+Rendered smoke target:
+
+- `/en/projects`
+- Desktop viewport: `1440x1000`
+- Mobile viewport: `390x844`
+- Local fixture API: `http://127.0.0.1:8000`
+- Local Next app: `http://127.0.0.1:3000/en/projects`
+- Browser plugin Node REPL runtime was unavailable in this session, so rendered smoke used Playwright MCP with `bypassCSP: true` for local dev only. The app CSP intentionally blocks Next dev `unsafe-eval`; production CSP was not changed.
+- Result: Grid toggle rendered 3 `public-project-card public-card-foundation` cards, project links remained internal/localized, card images had real rendered dimensions, no `undefined`/`null` text appeared, and no horizontal overflow was detected on desktop or mobile.
+
+## Recommended PR6 Scope
+
+PR6 should migrate the next single low-risk card surface only, preferably the Projects listing split/list card renderer or one isolated Home featured projects card grid. Keep filters, data fetching, forms, analytics, SEO metadata, and route behavior unchanged.


### PR DESCRIPTION
## Summary
- Migrates only the Projects listing grid card renderer to the PR3 public-system `ProjectCard`.
- Adapts existing project items through `mapProjectToPublicCardData` without changing fetches, filters, sorting, SEO, forms, tracking, backend, or admin UI.
- Adds focused PR5 tests and migration documentation.

## Scope Safety
- No Home/Buy/Rent/detail/admin page migration.
- No route, metadata, canonical, OpenGraph, API, database, form, or tracking changes.
- Split and map Projects views keep their existing rendering.
- Grid highlights/status are passed only when source data exists, avoiding broken `undefined`/`null` text.

## Validation
- `npm run lint` pass; existing `<img>` warnings remain in home and legacy Projects split view.
- `npm run test -- projects_card_surface_pr5.test.tsx --reporter=dot` pass, 3 tests.
- `npm run test -- --reporter=dot` pass, 126 files / 537 tests.
- `npm run build` pass.
- `git diff --check` pass.

## Rendered Smoke
- Local fixture API: `http://127.0.0.1:8000`
- Local app: `http://127.0.0.1:3000/en/projects`
- Viewports: `1440x1000`, `390x844`
- Browser plugin Node REPL runtime was unavailable, so Playwright MCP was used with `bypassCSP: true` for local dev only. Production CSP was not changed.
- Grid toggle rendered 3 public project cards; internal localized links and image rendering passed; no horizontal overflow detected.