### PR TITLE
feat(amp-public): migrate home featured property cards

### DIFF
--- a/admin-app/__tests__/home_featured_properties_pr7.test.tsx
+++ b/admin-app/__tests__/home_featured_properties_pr7.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PropertyListItem } from '@/app/public/_shared/types';
+import { HomeFeaturedPropertyCard } from '@/components/home/HomeFeaturedPropertyCard';
+
+vi.mock('next/image', () => ({
+  default: (props: Record<string, unknown>) => (
+    <div
+      role="img"
+      aria-label={String(props.alt ?? '')}
+      data-src={String(props.src ?? '')}
+      data-sizes={String(props.sizes ?? '')}
+    />
+  ),
+}));
+
+vi.mock('@/components/shortlist/ShortlistSaveButton', () => ({
+  ShortlistSaveButton: ({
+    className,
+    locale,
+    propertyId,
+    sourceSurface,
+  }: {
+    className?: string;
+    locale: 'en' | 'th';
+    propertyId: string;
+    sourceSurface: string;
+  }) => (
+    <button
+      type="button"
+      className={className}
+      data-locale={locale}
+      data-property-id={propertyId}
+      data-source-surface={sourceSurface}
+    >
+      Save to shortlist
+    </button>
+  ),
+}));
+
+const saleProperty: PropertyListItem = {
+  id: 'property-riviera-california',
+  source_id: 'source-1',
+  title: 'Riviera California Sea View Residence',
+  type: 'resale',
+  property_type: 'condo',
+  price: 8_900_000,
+  bedrooms: 2,
+  bathrooms: 2,
+  size_sqm: 65,
+  address: 'Wongamat',
+  city: 'Pattaya',
+  images: ['/images/property-exterior.png'],
+  local_images: null,
+  cover_image: '/images/property-exterior.png',
+  status: 'published',
+  slug: 'riviera-california-sea-view',
+};
+
+describe('Home featured properties PR7 card surface', () => {
+  it('renders a home sale property with public-system PropertyCard output and localized internal links', () => {
+    const { container } = render(<HomeFeaturedPropertyCard property={saleProperty} locale="en" />);
+
+    expect(container.querySelector('article.public-property-card.public-card-foundation')).not.toBeNull();
+    expect(screen.getByRole('heading', { name: 'Riviera California Sea View Residence' })).toBeInTheDocument();
+    expect(screen.getByText('Wongamat')).toBeInTheDocument();
+    expect(screen.getByText('THB 8,900,000')).toBeInTheDocument();
+    expect(screen.getByText('For sale')).toBeInTheDocument();
+    expect(screen.getByText('Featured')).toBeInTheDocument();
+    expect(screen.getAllByText('2')).toHaveLength(2);
+    expect(screen.getByText('65 sqm')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Riviera California Sea View Residence' })).toHaveAttribute(
+      'href',
+      '/en/property/riviera-california-sea-view',
+    );
+    expect(screen.getByRole('link', { name: 'Check buy fit' })).toHaveAttribute(
+      'href',
+      '/en/property/riviera-california-sea-view',
+    );
+    expect(screen.getByRole('button', { name: 'Save to shortlist' })).toHaveAttribute(
+      'data-source-surface',
+      'buy_listing_card',
+    );
+    expect(container.querySelector('.property-card')).toBeNull();
+  });
+
+  it('keeps sparse rental property data renderable without broken placeholder text', () => {
+    const sparseRental: PropertyListItem = {
+      id: 'property-minimal-rental',
+      source_id: 'source-2',
+      title: 'Compact Jomtien Rental',
+      type: 'rent',
+      property_type: null,
+      price: 0,
+      bedrooms: null,
+      bathrooms: null,
+      size_sqm: null,
+      size: null,
+      address: '',
+      city: '',
+      images: null,
+      local_images: null,
+      cover_image: null,
+      status: 'published',
+      slug: 'compact-jomtien-rental',
+    };
+
+    const { container } = render(<HomeFeaturedPropertyCard property={sparseRental} locale="en" />);
+
+    expect(container.querySelector('article.public-property-card.public-card-foundation')).not.toBeNull();
+    expect(screen.getByRole('heading', { name: 'Compact Jomtien Rental' })).toBeInTheDocument();
+    expect(screen.getByText('Pattaya')).toBeInTheDocument();
+    expect(screen.getByText('Price on request')).toBeInTheDocument();
+    expect(screen.getByText('For rent')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Check rental fit' })).toHaveAttribute(
+      'href',
+      '/en/property/compact-jomtien-rental',
+    );
+    expect(screen.getByRole('button', { name: 'Save to shortlist' })).toHaveAttribute(
+      'data-source-surface',
+      'rent_listing_card',
+    );
+    expect(container.textContent).not.toContain('undefined');
+    expect(container.textContent).not.toContain('null');
+    expect(container.querySelector('.public-property-card .public-card-foundation__facts')).toBeNull();
+  });
+
+  it('keeps the home page source scoped to the public property card wrapper', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const homePage = fs.readFileSync(path.join(process.cwd(), 'app/(site)/[locale]/page.tsx'), 'utf8');
+
+    expect(homePage).toContain("import('@/components/home/HomeFeaturedPropertyCard')");
+    expect(homePage).toContain('<HomeFeaturedPropertyCard key={property.id} property={property} locale={locale} />');
+    expect(homePage).not.toContain("import('@/components/cards/PropertyCard')");
+  });
+});

--- a/admin-app/__tests__/public_design_system_contract.test.ts
+++ b/admin-app/__tests__/public_design_system_contract.test.ts
@@ -500,7 +500,9 @@ describe('public design system contract', () => {
     expect(homePage).toContain('home-segmentation-note');
     expect(homePage).toContain('home-unit-group');
     expect(homePage).toContain('home_curated_unit_group');
-    expect(homePage).toContain('<PropertyCard key={property.id} item={property} dict={dict} locale={locale} />');
+    expect(homePage).toContain('<HomeFeaturedPropertyCard key={property.id} property={property} locale={locale} />');
+    expect(homePage).toContain("import('@/components/home/HomeFeaturedPropertyCard')");
+    expect(homePage).not.toContain("import('@/components/cards/PropertyCard')");
     expect(renderBody).not.toContain('id="home-proof-process"');
   });
 
@@ -509,6 +511,7 @@ describe('public design system contract', () => {
 
     expect(primitives).toContain('Phase 3C: homepage IA stabilization');
     expect(primitives).toContain('.public-site-shell .home-page .home-unit-group__grid');
+    expect(primitives).toContain('.public-site-shell .home-page .home-featured-property-card');
     expect(primitives).toContain('.public-site-shell .home-page .home-owner-section');
     expect(primitives).toContain('.public-site-shell .home-page .home-bottom-cta');
     expect(primitives).toContain('padding-bottom: clamp(12px, 2vw, 20px);');

--- a/admin-app/app/(site)/[locale]/page.tsx
+++ b/admin-app/app/(site)/[locale]/page.tsx
@@ -116,7 +116,7 @@ export default async function HomePage({
     { HomeHero },
     { HomeSearchBar },
     { FeaturedProjects },
-    { PropertyCard },
+    { HomeFeaturedPropertyCard },
     { HomeBottomCta },
     { HomePerfProbe },
     { LeadForm },
@@ -133,7 +133,7 @@ export default async function HomePage({
     import('@/components/home/HomeHero'),
     import('@/components/home/HomeSearchBar'),
     import('@/components/home/FeaturedProjects'),
-    import('@/components/cards/PropertyCard'),
+    import('@/components/home/HomeFeaturedPropertyCard'),
     import('@/components/home/HomeBottomCta'),
     (enableHomePerfProbe
       ? import('@/components/home/HomePerfProbe')
@@ -636,7 +636,7 @@ export default async function HomePage({
                           </div>
                           <div className="home-unit-group__grid">
                             {group.items.map((property) => (
-                              <PropertyCard key={property.id} item={property} dict={dict} locale={locale} />
+                              <HomeFeaturedPropertyCard key={property.id} property={property} locale={locale} />
                             ))}
                           </div>
                           <TrackedLink

--- a/admin-app/components/home/HomeFeaturedPropertyCard.tsx
+++ b/admin-app/components/home/HomeFeaturedPropertyCard.tsx
@@ -1,0 +1,52 @@
+import type { PropertyListItem } from '@/app/public/_shared/types';
+import { mapPropertyToPublicCardData } from '@/app/_lib/public-card-mappers';
+import { PropertyCard as PublicPropertyCard } from '@/components/public-system/components/PropertyCard';
+import { getPublicButtonClassName } from '@/components/public-system/tokens/publicUiTokens';
+import { ShortlistSaveButton } from '@/components/shortlist/ShortlistSaveButton';
+
+function propertyCtaLabel(property: PropertyListItem, locale: 'en' | 'th'): string {
+  if (property.type === 'rent') {
+    return locale === 'th' ? 'เช็กโจทย์การเช่า' : 'Check rental fit';
+  }
+  return locale === 'th' ? 'เช็กโจทย์การซื้อ' : 'Check buy fit';
+}
+
+function propertySourceSurface(property: PropertyListItem): string {
+  return property.type === 'rent' ? 'rent_listing_card' : 'buy_listing_card';
+}
+
+export function HomeFeaturedPropertyCard({
+  property,
+  locale,
+}: {
+  property: PropertyListItem;
+  locale: 'en' | 'th';
+}) {
+  const publicPropertyCard = mapPropertyToPublicCardData(
+    {
+      ...property,
+      isFeatured: true,
+    },
+    { locale },
+  );
+
+  return (
+    <div className="home-featured-property-card">
+      <PublicPropertyCard
+        property={publicPropertyCard}
+        ctaLabel={propertyCtaLabel(property, locale)}
+        imageSizes="(max-width: 767px) 92vw, (max-width: 1279px) 48vw, 31vw"
+      />
+      <ShortlistSaveButton
+        className={getPublicButtonClassName({
+          variant: 'secondary',
+          fullWidth: true,
+          className: 'home-featured-property-card__shortlist',
+        })}
+        locale={locale}
+        propertyId={property.id}
+        sourceSurface={propertySourceSurface(property)}
+      />
+    </div>
+  );
+}

--- a/admin-app/styles/public-primitives.css
+++ b/admin-app/styles/public-primitives.css
@@ -168,6 +168,23 @@
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
 }
 
+.public-site-shell .home-page .home-featured-property-card {
+  display: flex;
+  min-width: 0;
+  height: 100%;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.public-site-shell .home-page .home-featured-property-card .public-property-card {
+  flex: 1 1 auto;
+}
+
+.public-site-shell .home-page .home-featured-property-card__shortlist {
+  min-height: var(--amp-public-touch-target);
+  justify-content: center;
+}
+
 .public-site-shell .home-page .home-unit-group__route-link {
   justify-self: start;
 }

--- a/docs/AMP_HOME_FEATURED_PROPERTIES_PR7.md
+++ b/docs/AMP_HOME_FEATURED_PROPERTIES_PR7.md
@@ -1,0 +1,61 @@
+# AMP Home Featured Properties PR7
+
+## Surface Migrated
+
+PR7 migrates only the Home page Featured Properties / curated unit card renderer in:
+
+- `admin-app/app/(site)/[locale]/page.tsx`
+- `admin-app/components/home/HomeFeaturedPropertyCard.tsx`
+
+The Home page layout, hero, search/intent sections, featured projects, route behavior, data source ownership, forms, tracking hooks, metadata, canonical handling, and OpenGraph behavior are intentionally preserved.
+
+## Components And Mappers Used
+
+- `PropertyCard` from `admin-app/components/public-system/components/PropertyCard.tsx`
+- `mapPropertyToPublicCardData` from `admin-app/app/_lib/public-card-mappers.ts`
+- Existing `ShortlistSaveButton` remains mounted below each Home property card so the existing shortlist entry behavior is not removed while the card visual surface migrates.
+
+The Home curated unit grid adapts each existing property item into `PublicPropertyCardData` before rendering the PR3 public card component.
+
+## Existing Behavior Preserved
+
+- Existing Home route and localized property href behavior remain internal and localized.
+- Existing Home curated opportunities section, unit group wrappers, group CTAs, and section ordering remain in place.
+- Existing Home property data source remains unchanged.
+- Existing shortlist save entry point remains available through the existing `ShortlistSaveButton`.
+- Existing SEO metadata, canonical behavior, OpenGraph behavior, lead forms, backend/API queries, and admin UI remain untouched.
+- Existing public-system `Button` default keeps property CTA links opted out of automatic prefetch.
+
+## Intentionally Not Changed
+
+- No full Home page redesign.
+- No Home hero, search, lead form, CTA tracking, or metadata changes.
+- No Buy, Rent, Projects, Project Detail, Property Detail, or Admin migration.
+- No backend, database, API, route, form, tracking, SEO, canonical, or OpenGraph changes.
+- No static prototype CSS copied.
+- No external dependency added.
+- No listing/detail card migration.
+
+## Validation Results
+
+Local validation:
+
+- `npm run test -- home_featured_properties_pr7.test.tsx public_design_system_contract.test.ts --reporter=dot` - pass, 20 tests.
+- `npm run lint` - pass. Existing `<img>` warnings remain in the Home page and the legacy Projects split view.
+- `npm run test -- --reporter=dot` - pass, 127 files / 541 tests.
+- `npm run build` - pass. Existing `<img>` warnings remain in the Home page and the legacy Projects split view.
+- `git diff --check` - pass.
+
+Rendered smoke:
+
+- Target route: `/en`
+- Desktop viewport: `1440x1000`
+- Mobile viewport: `390x844`
+- Local fixture API: `http://127.0.0.1:8000`
+- Local Next app: `http://127.0.0.1:3000/en`
+- Browser plugin JavaScript runtime was unavailable in this session, so rendered smoke used repo Playwright with `bypassCSP: true` for local dev only. The app CSP intentionally blocks Next dev `unsafe-eval`; production CSP was not changed.
+- Result: Home rendered 4 `public-property-card public-card-foundation` cards, property links remained internal/localized, shortlist buttons remained present for each card, card images had real rendered dimensions, no `undefined`/`null` text appeared, no framework error dialog appeared, no console errors were logged, and no horizontal overflow was detected on desktop or mobile.
+
+## Recommended PR8 Scope
+
+PR8 should migrate one additional low-risk public card surface only, preferably the Projects listing split/list renderer or one isolated Buy listing card surface. Keep data fetching, filters, forms, analytics events, SEO metadata, route behavior, and backend calls unchanged.


### PR DESCRIPTION
## Summary
- migrate only the Home featured properties / curated unit card surface to the PR3 public `PropertyCard`
- adapt existing Home property data through `mapPropertyToPublicCardData`
- preserve existing Home layout, data source, localized route behavior, shortlist entry point, forms, tracking, SEO, and backend behavior
- add focused PR7 tests and documentation

## Validation
- npm run test -- home_featured_properties_pr7.test.tsx public_design_system_contract.test.ts --reporter=dot
- npm run lint
- npm run test -- --reporter=dot
- npm run build
- git diff --check
- rendered smoke on /en at 1440x1000 and 390x844 with local fixture API and Next dev app

## Scope guardrails
- no full Home page rewrite
- no Buy/Rent/Projects/Detail/Admin migration
- no backend, database, API, form, tracking, SEO, canonical, or OpenGraph changes
- no external dependencies or static prototype CSS copy