### PR TITLE
fix(public): resolve AMP homepage visual runtime blockers

### DIFF
--- a/admin-app/app/(site)/[locale]/page.tsx
+++ b/admin-app/app/(site)/[locale]/page.tsx
@@ -1159,21 +1159,30 @@ export default async function HomePage({
               </div>
             </div>
 
-            {/* Right Column - Sample Output Preview Card */}
+            {/* Right Column - Advisor Preview Card */}
             <div className="relative z-10 lg:col-span-5 w-full">
               <div className="bg-[var(--public-color-paper-warm)] rounded-2xl p-6 md:p-8 border border-[var(--public-color-line)] shadow-lg hover:shadow-xl transition-shadow duration-300 max-w-sm mx-auto lg:max-w-none">
                 <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--public-color-ink-4)] block mb-2 font-medium">
-                  {locale === 'th' ? 'ตัวอย่างผลลัพธ์' : 'Sample output'}
+                  {locale === 'th' ? 'บรีฟจากที่ปรึกษา' : 'Advisor preview'}
                 </span>
                 <h4 className="font-serif text-xl md:text-2xl tracking-tight leading-none text-[var(--public-color-ink)] mb-6 font-normal">
-                  {locale === 'th' ? 'รายการคัดสรรของท่าน' : 'Your AMP shortlist'}
+                  {locale === 'th' ? 'สิ่งที่ทีมจะตรวจให้ก่อนนัดชม' : 'What the team checks before a viewing'}
                 </h4>
 
                 <div className="space-y-3.5">
                   {[
-                    { name: 'Jomtien Bay Tower', match: locale === 'th' ? 'ตรงกัน 94%' : 'Match 94%', color: '#2c7a3c' },
-                    { name: 'Central Marina Suites', match: locale === 'th' ? 'ตรงกัน 88%' : 'Match 88%', color: '#2c7a3c' },
-                    { name: 'Na Jomtien Residence', match: locale === 'th' ? 'ตรงกัน 76%' : 'Match 76%', color: '#c08a1c' },
+                    {
+                      title: locale === 'th' ? 'ยืนยันเส้นทางกรรมสิทธิ์' : 'Confirm ownership route',
+                      note: locale === 'th' ? 'ตรวจโควตาต่างชาติและเอกสารก่อนเริ่มนัดชม' : 'Check foreign quota and paperwork before viewings.',
+                    },
+                    {
+                      title: locale === 'th' ? 'เทียบต้นทุนรวม' : 'Compare total cost',
+                      note: locale === 'th' ? 'แยกค่าธรรมเนียม โอน เฟอร์นิเจอร์ และงบหลังซื้อ' : 'Separate transfer, fit-out, and first-year ownership costs.',
+                    },
+                    {
+                      title: locale === 'th' ? 'ขอสถานะล่าสุด' : 'Request current availability',
+                      note: locale === 'th' ? 'ให้ทีมตรวจราคาและยูนิตว่างล่าสุดก่อนตัดสินใจ' : 'Ask the team to verify live price and unit availability.',
+                    },
                   ].map((item, i) => (
                     <div 
                       key={i} 
@@ -1182,14 +1191,13 @@ export default async function HomePage({
                       <div className="w-8 h-8 rounded-lg bg-[var(--public-color-sand-soft)] flex items-center justify-center font-mono text-xs font-semibold text-[var(--public-color-ink-2)] border border-[var(--public-color-line)]/40 shadow-sm">
                         {i + 1}
                       </div>
-                      <span className="text-xs md:text-sm font-medium text-[var(--public-color-ink)] flex-1">
-                        {item.name}
-                      </span>
-                      <span 
-                        className="text-[10px] md:text-xs font-mono font-semibold tracking-tight" 
-                        style={{ color: item.color }}
-                      >
-                        {item.match}
+                      <span className="flex-1 min-w-0">
+                        <span className="block text-xs md:text-sm font-semibold text-[var(--public-color-ink)]">
+                          {item.title}
+                        </span>
+                        <span className="block mt-1 text-[11px] md:text-xs leading-relaxed text-[var(--public-color-ink-muted)]">
+                          {item.note}
+                        </span>
                       </span>
                     </div>
                   ))}
@@ -1206,7 +1214,7 @@ export default async function HomePage({
                     <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
                       <path strokeLinecap="round" strokeLinejoin="round" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                     </svg>
-                    {locale === 'th' ? 'ดาวน์โหลดเป็น PDF' : 'Download as PDF'}
+                    {locale === 'th' ? 'ขอบรีฟรายการล่าสุด' : 'Request updated availability'}
                   </TrackedLink>
                 </div>
               </div>

--- a/admin-app/components/home/HomeSearchBar.tsx
+++ b/admin-app/components/home/HomeSearchBar.tsx
@@ -72,7 +72,7 @@ export function HomeSearchBar({ locale }: HomeSearchBarProps) {
     { value: 'gt_20m', label: locale === 'th' ? '20 ล้านบาทขึ้นไป' : 'Above ฿20M' },
   ];
 
-  const handleSearch = () => {
+  const buildSearchHref = (tab: SearchTab = activeTab) => {
     const params = new URLSearchParams();
     params.set('source', 'home_search_bar');
 
@@ -112,19 +112,22 @@ export function HomeSearchBar({ locale }: HomeSearchBarProps) {
     }
 
     let route = `/${locale}/buy`;
-    if (activeTab === 'rent') {
+    if (tab === 'rent') {
       route = `/${locale}/rent`;
-    } else if (activeTab === 'offplan') {
+    } else if (tab === 'offplan') {
       route = `/${locale}/projects`;
       params.set('status', 'off-plan');
-    } else if (activeTab === 'villas') {
+    } else if (tab === 'villas') {
       route = `/${locale}/buy`;
       params.set('type', 'villa');
     }
 
     const queryString = params.toString();
-    const targetUrl = queryString ? `${route}?${queryString}` : route;
-    router.push(targetUrl);
+    return queryString ? `${route}?${queryString}` : route;
+  };
+
+  const handleSearch = () => {
+    router.push(buildSearchHref());
   };
 
   const getActiveLabel = (value: string, options: Array<{ value: string; label: string }>) => {
@@ -134,43 +137,46 @@ export function HomeSearchBar({ locale }: HomeSearchBarProps) {
   return (
     <div
       ref={containerRef}
-      className="relative z-20 w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 -mt-8 sm:-mt-12 md:-mt-14 lg:-mt-16 xl:-mt-20 select-none pb-8"
+      className="home-search-shell relative z-20 w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 -mt-8 sm:-mt-12 md:-mt-14 lg:-mt-16 xl:-mt-20 select-none pb-8"
       data-testid="home-search-bar"
     >
-      <div className="bg-[#fcfaf2] border border-[#d8cdb4] shadow-2xl rounded-2xl md:rounded-3xl p-4 sm:p-5 lg:p-6 transition-all duration-300">
+      <div className="home-search-shell__panel bg-[#fcfaf2] border border-[#d8cdb4] shadow-2xl rounded-2xl md:rounded-3xl p-4 sm:p-5 lg:p-6 transition-all duration-300">
         {/* Search Tabs */}
-        <div className="flex items-center gap-1.5 sm:gap-2 mb-4 md:mb-5 pb-3 border-b border-[#efe6d2]">
+        <div className="home-search-shell__tabs flex items-center gap-1.5 sm:gap-2 mb-4 md:mb-5 pb-3 border-b border-[#efe6d2]">
           {[
             { id: 'buy', label: locale === 'th' ? 'ซื้อ (Buy)' : 'Buy' },
             { id: 'rent', label: locale === 'th' ? 'เช่า (Rent)' : 'Rent' },
             { id: 'offplan', label: locale === 'th' ? 'พรีเซลล์ / โครงการใหม่' : 'Off-plan' },
             { id: 'villas', label: locale === 'th' ? 'วิลล่า (Villas)' : 'Villas' },
           ].map((tab) => (
-            <button
+            <a
               key={tab.id}
-              onClick={() => {
+              href={buildSearchHref(tab.id as SearchTab)}
+              onClick={(event) => {
+                event.preventDefault();
                 setActiveTab(tab.id as SearchTab);
                 setActiveDropdown(null);
               }}
-              className={`px-3.5 sm:px-5 py-2.5 rounded-full text-xs sm:text-sm font-medium transition-all duration-300 ${
+              aria-current={activeTab === tab.id ? 'true' : undefined}
+              className={`home-search-shell__tab px-3.5 sm:px-5 py-2.5 rounded-full text-xs sm:text-sm font-medium transition-all duration-300 ${
                 activeTab === tab.id
                   ? 'bg-[#0e3a3a] text-[#f8f4ea] shadow-md'
                   : 'text-[#5b6764] hover:bg-[#efe6d2]/50 hover:text-[#0e3a3a]'
               }`}
             >
               {tab.label}
-            </button>
+            </a>
           ))}
         </div>
 
         {/* Search Inputs Row */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[1.2fr_1fr_1fr_1fr_auto] gap-2 lg:gap-0 lg:divide-x lg:divide-[#d8cdb4] items-center bg-white rounded-xl lg:rounded-2xl border border-[#efe6d2] overflow-visible p-2 lg:p-1.5">
+        <div className="home-search-shell__grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[1.2fr_1fr_1fr_1fr_auto] gap-2 lg:gap-0 lg:divide-x lg:divide-[#d8cdb4] items-center bg-white rounded-xl lg:rounded-2xl border border-[#efe6d2] overflow-visible p-2 lg:p-1.5">
           {/* Location Selector */}
-          <div className="relative w-full overflow-visible">
+          <div className="home-search-shell__field relative w-full overflow-visible">
             <button
               type="button"
               onClick={() => setActiveDropdown(activeDropdown === 'location' ? null : 'location')}
-              className={`w-full flex flex-col justify-start text-left px-4 py-3 sm:py-3.5 rounded-xl hover:bg-[#f8f4ea]/40 transition-colors ${
+              className={`home-search-shell__control w-full flex flex-col justify-start text-left px-4 py-3 sm:py-3.5 rounded-xl hover:bg-[#f8f4ea]/40 transition-colors ${
                 activeDropdown === 'location' ? 'bg-[#f8f4ea]/60' : ''
               }`}
             >
@@ -183,7 +189,7 @@ export function HomeSearchBar({ locale }: HomeSearchBarProps) {
               </span>
             </button>
             {activeDropdown === 'location' && (
-              <div className="absolute left-0 right-0 lg:w-72 mt-2 bg-white border border-[#efe6d2] shadow-xl rounded-xl p-2 z-50 animate-in fade-in slide-in-from-top-1 duration-200">
+              <div className="home-search-shell__dropdown absolute left-0 right-0 lg:w-72 mt-2 bg-white border border-[#efe6d2] shadow-xl rounded-xl p-2 z-50 animate-in fade-in slide-in-from-top-1 duration-200">
                 {locations.map((opt) => (
                   <button
                     key={opt.value}
@@ -205,12 +211,12 @@ export function HomeSearchBar({ locale }: HomeSearchBarProps) {
           </div>
 
           {/* Property Type Selector */}
-          <div className="relative w-full overflow-visible">
+          <div className="home-search-shell__field relative w-full overflow-visible">
             <button
               type="button"
               disabled={activeTab === 'villas'}
               onClick={() => setActiveDropdown(activeDropdown === 'type' ? null : 'type')}
-              className={`w-full flex flex-col justify-start text-left px-4 py-3 sm:py-3.5 rounded-xl hover:bg-[#f8f4ea]/40 transition-colors ${
+              className={`home-search-shell__control w-full flex flex-col justify-start text-left px-4 py-3 sm:py-3.5 rounded-xl hover:bg-[#f8f4ea]/40 transition-colors ${
                 activeTab === 'villas' ? 'opacity-50 cursor-not-allowed' : ''
               } ${activeDropdown === 'type' ? 'bg-[#f8f4ea]/60' : ''}`}
             >
@@ -226,7 +232,7 @@ export function HomeSearchBar({ locale }: HomeSearchBarProps) {
               </span>
             </button>
             {activeDropdown === 'type' && activeTab !== 'villas' && (
-              <div className="absolute left-0 right-0 lg:w-64 mt-2 bg-white border border-[#efe6d2] shadow-xl rounded-xl p-2 z-50 animate-in fade-in slide-in-from-top-1 duration-200">
+              <div className="home-search-shell__dropdown absolute left-0 right-0 lg:w-64 mt-2 bg-white border border-[#efe6d2] shadow-xl rounded-xl p-2 z-50 animate-in fade-in slide-in-from-top-1 duration-200">
                 {propTypes.map((opt) => (
                   <button
                     key={opt.value}
@@ -248,11 +254,11 @@ export function HomeSearchBar({ locale }: HomeSearchBarProps) {
           </div>
 
           {/* Bedrooms Selector */}
-          <div className="relative w-full overflow-visible">
+          <div className="home-search-shell__field relative w-full overflow-visible">
             <button
               type="button"
               onClick={() => setActiveDropdown(activeDropdown === 'bedrooms' ? null : 'bedrooms')}
-              className={`w-full flex flex-col justify-start text-left px-4 py-3 sm:py-3.5 rounded-xl hover:bg-[#f8f4ea]/40 transition-colors ${
+              className={`home-search-shell__control w-full flex flex-col justify-start text-left px-4 py-3 sm:py-3.5 rounded-xl hover:bg-[#f8f4ea]/40 transition-colors ${
                 activeDropdown === 'bedrooms' ? 'bg-[#f8f4ea]/60' : ''
               }`}
             >
@@ -264,7 +270,7 @@ export function HomeSearchBar({ locale }: HomeSearchBarProps) {
               </span>
             </button>
             {activeDropdown === 'bedrooms' && (
-              <div className="absolute left-0 right-0 lg:w-64 mt-2 bg-white border border-[#efe6d2] shadow-xl rounded-xl p-2 z-50 animate-in fade-in slide-in-from-top-1 duration-200">
+              <div className="home-search-shell__dropdown absolute left-0 right-0 lg:w-64 mt-2 bg-white border border-[#efe6d2] shadow-xl rounded-xl p-2 z-50 animate-in fade-in slide-in-from-top-1 duration-200">
                 {bedroomOptions.map((opt) => (
                   <button
                     key={opt.value}
@@ -286,11 +292,11 @@ export function HomeSearchBar({ locale }: HomeSearchBarProps) {
           </div>
 
           {/* Budget Selector */}
-          <div className="relative w-full overflow-visible">
+          <div className="home-search-shell__field relative w-full overflow-visible">
             <button
               type="button"
               onClick={() => setActiveDropdown(activeDropdown === 'budget' ? null : 'budget')}
-              className={`w-full flex flex-col justify-start text-left px-4 py-3 sm:py-3.5 rounded-xl hover:bg-[#f8f4ea]/40 transition-colors ${
+              className={`home-search-shell__control w-full flex flex-col justify-start text-left px-4 py-3 sm:py-3.5 rounded-xl hover:bg-[#f8f4ea]/40 transition-colors ${
                 activeDropdown === 'budget' ? 'bg-[#f8f4ea]/60' : ''
               }`}
             >
@@ -302,7 +308,7 @@ export function HomeSearchBar({ locale }: HomeSearchBarProps) {
               </span>
             </button>
             {activeDropdown === 'budget' && (
-              <div className="absolute left-0 right-0 lg:w-64 mt-2 bg-white border border-[#efe6d2] shadow-xl rounded-xl p-2 z-50 animate-in fade-in slide-in-from-top-1 duration-200">
+              <div className="home-search-shell__dropdown absolute left-0 right-0 lg:w-64 mt-2 bg-white border border-[#efe6d2] shadow-xl rounded-xl p-2 z-50 animate-in slide-in-from-top-1 duration-200">
                 {budgets.map((opt) => (
                   <button
                     key={opt.value}
@@ -324,16 +330,19 @@ export function HomeSearchBar({ locale }: HomeSearchBarProps) {
           </div>
 
           {/* Search CTA Button */}
-          <div className="w-full lg:w-auto p-2 lg:p-0 flex justify-end">
-            <button
-              type="button"
-              onClick={handleSearch}
-              className="w-full lg:w-auto h-12 sm:h-14 px-6 sm:px-8 bg-[#d96a4e] hover:bg-[#c4533a] active:scale-95 text-[#f8f4ea] font-medium text-sm rounded-xl flex items-center justify-center gap-2 transition-all duration-300 shadow-md hover:shadow-lg"
+          <div className="home-search-shell__submit-wrap w-full lg:w-auto p-2 lg:p-0 flex justify-end">
+            <a
+              href={buildSearchHref()}
+              onClick={(event) => {
+                event.preventDefault();
+                handleSearch();
+              }}
+              className="home-search-shell__submit w-full lg:w-auto h-12 sm:h-14 px-6 sm:px-8 bg-[#d96a4e] hover:bg-[#c4533a] active:scale-95 text-[#f8f4ea] font-medium text-sm rounded-xl flex items-center justify-center gap-2 transition-all duration-300 shadow-md hover:shadow-lg"
             >
               <IconSearch size="sm" />
               <span>{locale === 'th' ? 'ค้นหาทรัพย์' : 'Search Listings'}</span>
               <IconArrowRight size="sm" className="hidden lg:inline" />
-            </button>
+            </a>
           </div>
         </div>
       </div>

--- a/admin-app/styles/public-primitives.css
+++ b/admin-app/styles/public-primitives.css
@@ -4971,6 +4971,248 @@ html[lang='th'] .decision-page .public-hero__signal-title,
   background: var(--amp-public-color-coral-hover);
 }
 
+/* ======================== AMP PR 1B HOMEPAGE RUNTIME BLOCKERS ======================== */
+
+.public-site-shell .home-page {
+  max-width: 100%;
+  overflow-x: clip;
+}
+
+@supports not (overflow: clip) {
+  .public-site-shell .home-page {
+    overflow-x: hidden;
+  }
+}
+
+.public-site-shell .home-page > *,
+.public-site-shell .home-page section {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.public-site-shell .home-page .home-hero-slider,
+.public-site-shell .home-page .home-hero-slider__media-stack,
+.public-site-shell .home-page .home-market-section,
+.public-site-shell .home-page .home-bottom-cta {
+  overflow-x: clip;
+}
+
+.public-site-shell .home-page .home-hero-slider__media {
+  background:
+    linear-gradient(90deg, rgba(20, 32, 31, 0.72), rgba(20, 32, 31, 0.28)),
+    url('/images/hero-banner-20260318.webp') center 44% / cover no-repeat,
+    var(--public-color-ink);
+}
+
+.public-site-shell .home-page .home-hero-slider__media,
+.public-site-shell .home-page .home-hero-slider__image {
+  inset: 0;
+  max-width: 100%;
+}
+
+.public-site-shell .home-page .home-hero-slider__image[src*='project-overview'],
+.public-site-shell .home-page .home-hero-slider__image[src*='property-exterior'],
+.public-site-shell .home-page .home-hero-slider__image[src*='property-placeholder'] {
+  opacity: 0;
+}
+
+.public-site-shell .home-page .home-search-shell {
+  z-index: var(--amp-home-search-z);
+  box-sizing: border-box;
+  width: min(100%, calc(100vw - 24px));
+  max-width: min(72rem, calc(100vw - 24px));
+  margin-top: var(--amp-home-search-stack-offset) !important;
+  padding-right: 0 !important;
+  padding-left: 0 !important;
+  isolation: isolate;
+}
+
+.public-site-shell .home-page .home-search-shell__panel {
+  overflow: hidden;
+}
+
+.public-site-shell .home-page .home-search-shell__tabs {
+  min-width: 0;
+  gap: 8px !important;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.public-site-shell .home-page .home-search-shell__tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.public-site-shell .home-page .home-search-shell__tab,
+.public-site-shell .home-page .home-search-shell__submit {
+  min-height: var(--amp-public-touch-target);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.public-site-shell .home-page .home-search-shell__tab {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  padding-right: 16px;
+  padding-left: 16px;
+  border-radius: var(--amp-public-radius-pill);
+}
+
+.public-site-shell .home-page .home-search-shell__grid,
+.public-site-shell .home-page .home-search-shell__field,
+.public-site-shell .home-page .home-search-shell__control {
+  min-width: 0;
+}
+
+.public-site-shell .home-page .home-search-shell__dropdown {
+  max-width: min(100%, calc(100vw - 32px));
+}
+
+.public-site-shell .home-page .public-card-foundation__media {
+  background: var(--amp-public-media-fallback);
+}
+
+.public-site-shell .home-page .public-card-foundation__media::before {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  z-index: 0;
+  border-radius: inherit;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.42), transparent 42%),
+    repeating-linear-gradient(135deg, rgba(20, 32, 31, 0.035) 0 1px, transparent 1px 18px);
+  pointer-events: none;
+}
+
+.public-site-shell .home-page .public-card-foundation__media-link {
+  z-index: 1;
+}
+
+.public-site-shell .home-page .public-card-foundation__image {
+  background: var(--amp-public-media-fallback);
+}
+
+.public-site-shell .home-page .public-card-foundation__image[src*='project-overview'],
+.public-site-shell .home-page .public-card-foundation__image[src*='property-exterior'],
+.public-site-shell .home-page .public-card-foundation__image[src*='property-placeholder'] {
+  opacity: 0;
+}
+
+@media (max-width: 1179px) {
+  .public-site-shell .home-page .home-search-shell {
+    width: min(100%, calc(100vw - 16px));
+    max-width: calc(100vw - 16px);
+  }
+
+  .public-site-shell .home-page .home-search-shell__panel {
+    padding: clamp(12px, 2vw, 18px) !important;
+  }
+}
+
+@media (max-width: 767px) {
+  .public-site-shell .site-header .header-content {
+    gap: 8px;
+    padding-inline: clamp(10px, 3vw, 14px);
+  }
+
+  .public-site-shell .site-header .logo {
+    min-width: 0;
+    flex: 1 1 auto;
+    gap: 4px;
+  }
+
+  .public-site-shell .site-header .logo svg {
+    width: 22px;
+    height: 22px;
+  }
+
+  .public-site-shell .site-header .logo span {
+    overflow: hidden;
+    font-size: clamp(1.05rem, 5vw, 1.35rem) !important;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .public-site-shell .site-header .header-actions {
+    flex: 0 0 auto;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .public-site-shell .site-header .header-actions > .relative {
+    margin-right: 0 !important;
+  }
+
+  .public-site-shell .site-header .header-cta--utility.desktop-only {
+    display: none !important;
+  }
+
+  .public-site-shell .site-header .header-actions button {
+    min-height: 40px;
+    padding-right: 8px;
+    padding-left: 8px;
+  }
+
+  .public-site-shell .site-header .hamburger.mobile-only {
+    display: flex !important;
+    width: 40px;
+    height: 40px;
+    flex: 0 0 40px;
+  }
+
+  .public-site-shell .home-page .home-search-shell {
+    width: min(100%, calc(100vw - 4px));
+    max-width: calc(100vw - 4px);
+    margin-top: var(--amp-home-search-stack-offset-mobile) !important;
+    padding-bottom: 0 !important;
+  }
+
+  .public-site-shell .home-page .home-search-shell__panel {
+    border-radius: 18px;
+    padding: 10px !important;
+  }
+
+  .public-site-shell .home-page .home-search-shell__tabs {
+    margin-bottom: 10px !important;
+    padding-bottom: 10px !important;
+  }
+
+  .public-site-shell .home-page .home-search-shell__tab {
+    min-height: 38px;
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .public-site-shell .home-page .home-search-shell__grid {
+    gap: 0;
+    padding: 0 !important;
+    overflow: hidden;
+  }
+
+  .public-site-shell .home-page .home-search-shell__field + .home-search-shell__field,
+  .public-site-shell .home-page .home-search-shell__submit-wrap {
+    border-top: 1px solid var(--public-color-line-soft);
+  }
+
+  .public-site-shell .home-page .home-search-shell__control {
+    min-height: 68px;
+    border-radius: 0;
+  }
+
+  .public-site-shell .home-page .home-search-shell__submit-wrap {
+    padding: 0 !important;
+  }
+
+  .public-site-shell .home-page .home-search-shell__submit {
+    height: 46px;
+    min-height: 46px;
+    border-radius: 0 0 14px 14px;
+  }
+}
+
 .public-site-shell .site-footer .footer-cta-link {
   min-height: 40px;
   padding-inline: 16px;

--- a/admin-app/styles/public-tokens.css
+++ b/admin-app/styles/public-tokens.css
@@ -321,6 +321,12 @@
   --amp-public-mobile-card-title-size: 1.25rem;
   --amp-public-mobile-fact-value-size: 1.45rem;
   --amp-public-eyebrow-track: 0.14em;
+  --amp-home-search-stack-offset: clamp(8px, 1.4vw, 18px);
+  --amp-home-search-stack-offset-mobile: 8px;
+  --amp-home-search-z: 88;
+  --amp-public-media-fallback:
+    radial-gradient(circle at 18% 18%, rgba(201, 166, 119, 0.24), transparent 34%),
+    linear-gradient(135deg, rgba(248, 244, 234, 0.92) 0%, rgba(239, 230, 210, 0.82) 55%, rgba(217, 106, 78, 0.12) 100%);
 }
 
 html[lang='th'] {


### PR DESCRIPTION
## Summary

* Fixes homepage search surface click/stacking issue.
* Fixes mobile/tablet horizontal overflow.
* Removes mock-like `Sample output` / sample project names from public homepage.
* Improves media fallback styling for missing local `/media/library/*.webp` assets.
* Preserves production route/data/form/tracking/SEO behavior.

## Files changed

* `admin-app/styles/public-primitives.css`
* `admin-app/styles/public-tokens.css`
* `admin-app/components/home/HomeSearchBar.tsx`
* `admin-app/app/(site)/[locale]/page.tsx`

## Verification

* `curl -I http://localhost:3001/en`: `200 OK`
* 1440 overflow: `scrollWidth 1440 / clientWidth 1440`
* 768 overflow: `scrollWidth 768 / clientWidth 768`
* 390 overflow: `scrollWidth 390 / clientWidth 390`
* Tablet `Rent` click navigates to `/en/rent?source=home_search_bar`
* Mobile `Search Listings` click navigates to `/en/buy?source=home_search_bar`
* LeadForm remains visible and usable
* `Sample output`: removed
* sample hardcoded project names: removed

## Tests

* Focused Vitest: `9 files / 37 tests passed`
* `pnpm build`: passed

## Safety

* No deploy
* No merge
* No backend/API changes
* No database/schema changes
* No LeadForm submit contract changes
* No SEO/canonical/sitemap/robots changes
* No tracking/analytics changes
* No mock data added
* No `src/` prototype files changed

## Remaining risks

* Some local media URLs under `/media/library/*.webp` still return 404 in local dev. This PR improves fallback styling only and does not change media/data source.