### PR TITLE
feat(public): refresh AMP public shell header and footer

### DIFF
--- a/admin-app/components/layout/Footer.tsx
+++ b/admin-app/components/layout/Footer.tsx
@@ -38,8 +38,8 @@ export function SiteFooter({
   const facebookLabel = cms?.contact.facebookLabel || dict.common.facebookLabel || 'Facebook';
 
   const brandDesc = locale === 'th'
-    ? 'ที่ปรึกษาอสังหาริมทรัพย์ระดับผู้เชี่ยวชาญของพัทยา ได้รับใบอนุญาตจัดตั้งปี 2018 สมาชิกสมาคมอสังหาริมทรัพย์ไทย'
-    : "Pattaya's investor-grade property advisory. Licensed brokerage est. 2018. Member, Thai Real Estate Association.";
+    ? 'ที่ปรึกษาอสังหาริมทรัพย์พัทยาสำหรับผู้ซื้อ นักลงทุน และเจ้าของทรัพย์ที่ต้องการทางเลือกชัดเจนก่อนตัดสินใจ'
+    : 'Pattaya property advisory for buyers, investors, and owners who need clear next steps before a decision.';
 
   const officeAddress = locale === 'th' ? (
     <>
@@ -66,8 +66,11 @@ export function SiteFooter({
     >
       <Container variant="wide">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-12 gap-10 lg:gap-8 pb-12">
-          <div className="lg:col-span-4 flex flex-col items-start">
-            <Link href={withLocale(locale, '/')} prefetch={false} className="flex items-center text-white mb-4 hover:opacity-90 transition-opacity">
+          <div className="site-footer__brand lg:col-span-4 flex flex-col items-start">
+            <span className="site-footer__eyebrow">
+              {locale === 'th' ? 'AMP Pattaya Advisory' : 'AMP Pattaya Advisory'}
+            </span>
+            <Link href={withLocale(locale, '/')} prefetch={false} className="site-footer__logo flex items-center text-white mb-4 hover:opacity-90 transition-opacity">
               <svg width="24" height="24" viewBox="0 0 32 32" className="shrink-0 mr-1 text-white" style={{ fill: 'none' }} aria-hidden="true">
                 <rect x="0.5" y="0.5" width="31" height="31" rx="6" fill="none" stroke="currentColor" strokeWidth="1.2" />
                 <path d="M9 23 L16 9 L23 23 M12 18 L20 18" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
@@ -81,15 +84,15 @@ export function SiteFooter({
               {brandDesc}
             </p>
 
-            <div className="footer-contact-block mb-6 text-sm leading-relaxed text-[var(--public-color-bone, #f8f4ea)]/80">
+            <div className="footer-contact-block site-footer__contact-card mb-6 text-sm leading-relaxed text-[var(--public-color-bone, #f8f4ea)]/80">
               <span className="block font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--public-color-bone, #f8f4ea)]/50 mb-3 font-semibold">
                 {locale === 'th' ? 'ติดต่อ AMP Pattaya' : 'Contact AMP Pattaya'}
               </span>
               <p className="mb-3">{officeAddress}</p>
-              <a href={CTA.phoneTel} className="block text-white hover:text-[var(--public-color-champagne)] transition-colors duration-200 font-medium">
+              <a href={CTA.phoneTel} className="site-footer__contact-link block text-white hover:text-[var(--public-color-champagne)] transition-colors duration-200 font-medium">
                 {CTA.phoneTel.replace('tel:', '')}
               </a>
-              <a href={`mailto:${contactEmail}`} className="block text-[var(--public-color-bone, #f8f4ea)]/80 hover:text-white transition-colors duration-200">
+              <a href={`mailto:${contactEmail}`} className="site-footer__contact-link block text-[var(--public-color-bone, #f8f4ea)]/80 hover:text-white transition-colors duration-200">
                 {contactEmail}
               </a>
             </div>
@@ -103,7 +106,7 @@ export function SiteFooter({
                 className: 'footer-cta-link mb-5',
               })}
             >
-              {locale === 'th' ? 'คุยกับที่ปรึกษา' : 'Speak to an advisor'}
+              {locale === 'th' ? 'คุยกับที่ปรึกษาอสังหาฯ พัทยา' : 'Speak with a Pattaya Property Advisor'}
             </Link>
 
             <div className="footer-signal-list flex items-center gap-2">
@@ -142,7 +145,7 @@ export function SiteFooter({
           </div>
 
           {visibleLinkGroups.map((group) => (
-            <div key={group.key} className="lg:col-span-2">
+            <div key={group.key} className="site-footer__link-group lg:col-span-2">
               <span className="block font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--public-color-bone, #f8f4ea)]/50 mb-4 font-semibold">
                 {group.title}
               </span>
@@ -165,7 +168,7 @@ export function SiteFooter({
 
         <div className="mt-12 pt-6 border-t border-[rgba(248,244,234,0.1)] flex flex-col md:flex-row items-center justify-between gap-4 text-xs text-[var(--public-color-bone, #f8f4ea)]/50">
           <div>
-            <span>© {new Date().getFullYear()} AMP Pattaya Property Co., Ltd · License #BR-2018-0992</span>
+            <span>© {new Date().getFullYear()} AMP Pattaya Property Co., Ltd · Pattaya property advisory</span>
             {facebookUrl && !/flowbiz/i.test(facebookUrl) ? (
               <span className="ml-3">
                 ·{' '}

--- a/admin-app/components/layout/Header.tsx
+++ b/admin-app/components/layout/Header.tsx
@@ -152,6 +152,11 @@ function resolveCtaHref(locale: Locale, item: PublicCtaItem): string {
   return withLocale(locale, item.href);
 }
 
+function getShellCtaLabel(locale: Locale, item: PublicCtaItem): string {
+  if (item.key !== 'contact') return item.label;
+  return locale === 'th' ? 'คุยกับที่ปรึกษาอสังหาฯ พัทยา' : 'Speak with a Pattaya Property Advisor';
+}
+
 export function SiteHeader({
   locale,
   dict: dictProp,
@@ -189,7 +194,10 @@ export function SiteHeader({
   const homeNavConfig = getHomePublicNavItems(locale, dict);
   const homeMobileNavConfig = getHomeMobileNavItems(locale, dict);
   const mobileQuickPaths = getMobileQuickPaths(locale);
-  const ctaItems = getPublicCtaItems(locale, dict, cms);
+  const ctaItems = getPublicCtaItems(locale, dict, cms).map((item) => ({
+    ...item,
+    label: getShellCtaLabel(locale, item),
+  }));
   const shortlistCta = ctaItems.find((item) => item.key === 'shortlist');
   const conversionCtas = ctaItems.filter((item) => item.tone !== 'utility');
   const currentSurface = getPublicCtaSurface(currentPathname);
@@ -258,13 +266,18 @@ export function SiteHeader({
         data-locale={locale}
       >
         <div className={`site-header__content header-content${isHomeSurface ? ' header-content--home' : ''}`}>
-          <Link href={withLocale(locale, '/')} prefetch={false} className="logo animate-fade-in" aria-label={dict.brand.name}>
-            <svg width="26" height="26" viewBox="0 0 32 32" className="shrink-0 mr-1 text-inherit" style={{ fill: 'none' }}>
+          <Link href={withLocale(locale, '/')} prefetch={false} className="logo site-header__brand animate-fade-in" aria-label={dict.brand.name}>
+            <svg width="26" height="26" viewBox="0 0 32 32" className="site-header__brand-mark shrink-0 mr-1 text-inherit" style={{ fill: 'none' }}>
               <rect x="0.5" y="0.5" width="31" height="31" rx="6" fill="none" stroke="currentColor" strokeWidth="1.2"/>
               <path d="M9 23 L16 9 L23 23 M12 18 L20 18" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
-            <span className="font-serif font-normal tracking-[0.04em] text-2xl flex items-center leading-none" style={{ color: 'inherit' }}>
-              AMP <span className="italic ml-1 font-normal text-inherit">Pattaya</span>
+            <span className="site-header__brand-copy">
+              <span className="site-header__brand-name font-serif font-normal tracking-[0.04em] text-2xl flex items-center leading-none" style={{ color: 'inherit' }}>
+                AMP <span className="italic ml-1 font-normal text-inherit">Pattaya</span>
+              </span>
+              <span className="site-header__brand-line">
+                {locale === 'th' ? 'ที่ปรึกษาอสังหาฯ พัทยา' : 'Pattaya Property Advisory'}
+              </span>
             </span>
           </Link>
 
@@ -314,16 +327,17 @@ export function SiteHeader({
               </div>
             ) : null}
             {/* Currency Picker */}
-            <div ref={currencyRef} className="relative inline-block text-left mr-1.5 md:mr-2">
+            <div ref={currencyRef} className="header-picker header-picker--currency relative inline-block text-left mr-1.5 md:mr-2">
               <button
                 type="button"
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold uppercase tracking-wider transition-all duration-300 hover:bg-black/5 dark:hover:bg-white/10"
+                className="header-picker__button inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold uppercase tracking-wider transition-all duration-300 hover:bg-black/5 dark:hover:bg-white/10"
                 style={{
                   color: isHomeSurface && !homeHeaderScrolled ? 'rgba(255, 255, 255, 0.94)' : 'var(--color-ink)',
                 }}
                 onClick={() => setCurrencyOpen((o) => !o)}
                 aria-expanded={currencyOpen}
                 aria-haspopup="true"
+                aria-label={locale === 'th' ? 'เลือกสกุลเงิน' : 'Select currency'}
               >
                 <span>{currency}</span>
                 <svg
@@ -341,7 +355,7 @@ export function SiteHeader({
               </button>
               {currencyOpen && (
                 <div
-                  className="absolute right-0 mt-1.5 w-36 rounded-xl border border-[var(--public-color-line-soft, #efe6d2)] shadow-xl p-1 z-[110] text-[var(--public-color-ink, #14201f)]"
+                  className="header-picker__menu absolute right-0 mt-1.5 w-36 rounded-xl border border-[var(--public-color-line-soft, #efe6d2)] shadow-xl p-1 z-[110] text-[var(--public-color-ink, #14201f)]"
                   style={{
                     background: 'var(--public-color-paper-warm, #fdfaf2)',
                   }}
@@ -371,16 +385,17 @@ export function SiteHeader({
             </div>
 
             {/* Locale Picker */}
-            <div ref={localeRef} className="relative inline-block text-left mr-1.5 md:mr-2">
+            <div ref={localeRef} className="header-picker header-picker--locale relative inline-block text-left mr-1.5 md:mr-2">
               <button
                 type="button"
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold transition-all duration-300 hover:bg-black/5 dark:hover:bg-white/10"
+                className="header-picker__button inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold transition-all duration-300 hover:bg-black/5 dark:hover:bg-white/10"
                 style={{
                   color: isHomeSurface && !homeHeaderScrolled ? 'rgba(255, 255, 255, 0.94)' : 'var(--color-ink)',
                 }}
                 onClick={() => setLocaleOpen((o) => !o)}
                 aria-expanded={localeOpen}
                 aria-haspopup="true"
+                aria-label={locale === 'th' ? 'เลือกภาษา' : 'Select language'}
               >
                 <span>{locale === 'th' ? '🇹🇭 TH' : '🇬🇧 EN'}</span>
                 <svg
@@ -398,7 +413,7 @@ export function SiteHeader({
               </button>
               {localeOpen && (
                 <div
-                  className="absolute right-0 mt-1.5 w-44 rounded-xl border border-[var(--public-color-line-soft, #efe6d2)] shadow-xl p-1 z-[110] text-[var(--public-color-ink, #14201f)]"
+                  className="header-picker__menu absolute right-0 mt-1.5 w-44 rounded-xl border border-[var(--public-color-line-soft, #efe6d2)] shadow-xl p-1 z-[110] text-[var(--public-color-ink, #14201f)]"
                   style={{
                     background: 'var(--public-color-paper-warm, #fdfaf2)',
                   }}

--- a/admin-app/components/layout/MobileMenu.tsx
+++ b/admin-app/components/layout/MobileMenu.tsx
@@ -115,6 +115,19 @@ export function MobileMenu({
       data-locale={locale}
     >
       <div className="mobile-menu__inner">
+        <div className="mobile-menu__top">
+          <span className="mobile-menu__brand">AMP Pattaya</span>
+          <button
+            type="button"
+            className="mobile-menu__close"
+            onClick={onClose}
+            aria-label={locale === 'th' ? 'ปิดเมนู' : 'Close menu'}
+          >
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+              <path d="M4 4l10 10M14 4L4 14" />
+            </svg>
+          </button>
+        </div>
         <div className="mobile-menu__intro">
           <p className="mobile-menu__eyebrow">
             {locale === 'th' ? 'เส้นทางอสังหาริมทรัพย์พัทยา' : 'Pattaya real estate routes'}
@@ -145,7 +158,7 @@ export function MobileMenu({
               className="mobile-menu__advisor-link"
               onClick={onClose}
             >
-              <strong>{locale === 'th' ? 'คุยกับที่ปรึกษา' : 'Speak to an advisor'}</strong>
+              <strong>{locale === 'th' ? 'คุยกับที่ปรึกษาอสังหาฯ พัทยา' : 'Speak with a Pattaya Property Advisor'}</strong>
               <span>
                 {locale === 'th'
                   ? 'ส่งโจทย์สั้น ๆ แล้วให้ทีมช่วยคัดทางต่อ'

--- a/admin-app/styles/public-primitives.css
+++ b/admin-app/styles/public-primitives.css
@@ -5259,3 +5259,548 @@ html[lang='th'] .decision-page .public-hero__signal-title,
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+/* ======================== AMP PR 540 PUBLIC SHELL PREMIUM REFRESH ======================== */
+
+.public-site-shell {
+  --amp-shell-header-bg: rgba(253, 250, 242, 0.9);
+  --amp-shell-header-border: rgba(216, 205, 180, 0.72);
+  --amp-shell-header-shadow: 0 18px 48px rgba(20, 32, 31, 0.1);
+  --amp-shell-control-bg: rgba(255, 255, 255, 0.7);
+  --amp-shell-control-border: rgba(216, 205, 180, 0.78);
+  --amp-shell-control-hover: rgba(253, 250, 242, 0.96);
+  --amp-shell-night: #08111f;
+  --amp-shell-night-2: #0f2629;
+}
+
+.public-site-shell .site-header.header {
+  position: sticky;
+  top: 0;
+  z-index: 140;
+  background:
+    linear-gradient(180deg, rgba(253, 250, 242, 0.94), var(--amp-shell-header-bg));
+  border-bottom-color: var(--amp-shell-header-border);
+  box-shadow: var(--amp-shell-header-shadow);
+  -webkit-backdrop-filter: blur(22px) saturate(126%);
+  backdrop-filter: blur(22px) saturate(126%);
+}
+
+.public-site-shell .site-header.header::after {
+  background: linear-gradient(90deg, transparent, rgba(201, 166, 119, 0.42), transparent);
+  opacity: 0.52;
+  pointer-events: none;
+}
+
+.public-site-shell .site-header .header-content {
+  position: relative;
+  z-index: 1;
+  max-width: min(1680px, calc(100vw - clamp(24px, 4vw, 72px)));
+  gap: clamp(12px, 1.6vw, 24px);
+  padding-block: 12px;
+  padding-inline: clamp(14px, 2vw, 26px);
+}
+
+.public-site-shell .site-header .header-content--home {
+  margin-top: 10px;
+  border-color: rgba(255, 255, 255, 0.12);
+  background:
+    linear-gradient(180deg, rgba(8, 17, 31, 0.48), rgba(8, 17, 31, 0.2));
+  box-shadow:
+    0 18px 42px rgba(3, 8, 18, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.public-site-shell .site-header.header.header--home {
+  background:
+    linear-gradient(180deg, rgba(4, 11, 23, 0.68) 0%, rgba(4, 11, 23, 0.28) 68%, rgba(4, 11, 23, 0.02) 100%);
+  border-bottom-color: rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+.public-site-shell .site-header.header.header--home.header--home-scrolled {
+  background: rgba(253, 250, 242, 0.9);
+  border-bottom-color: var(--amp-shell-header-border);
+  box-shadow: var(--amp-shell-header-shadow);
+}
+
+.public-site-shell .site-header.header.header--home.header--home-scrolled .header-content--home {
+  background: rgba(255, 255, 255, 0.78);
+  border-color: rgba(216, 205, 180, 0.58);
+  box-shadow: 0 14px 34px rgba(20, 32, 31, 0.08);
+}
+
+.public-site-shell .site-header__brand {
+  min-width: 0;
+  gap: 10px;
+  text-decoration: none;
+}
+
+.public-site-shell .site-header__brand-mark {
+  width: 28px;
+  height: 28px;
+  padding: 2px;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.public-site-shell .site-header__brand-copy {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.public-site-shell .site-header__brand-name {
+  font-size: clamp(1.18rem, 1.55vw, 1.55rem) !important;
+  letter-spacing: 0 !important;
+  white-space: nowrap;
+}
+
+.public-site-shell .site-header__brand-line {
+  max-width: 18rem;
+  overflow: hidden;
+  color: var(--public-color-ink-3);
+  font-size: 0.68rem;
+  font-weight: var(--public-font-weight-semibold);
+  letter-spacing: 0;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.public-site-shell .header--home:not(.header--home-scrolled) .site-header__brand-line {
+  color: rgba(255, 255, 255, 0.66);
+}
+
+.public-site-shell .site-header .nav {
+  align-items: center;
+  padding: 4px;
+  border: 1px solid rgba(216, 205, 180, 0.58);
+  border-radius: var(--public-radius-pill);
+  background: rgba(255, 255, 255, 0.5);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.64);
+}
+
+.public-site-shell .header--home:not(.header--home-scrolled) .nav {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.public-site-shell .site-header .nav-link,
+.public-site-shell .site-header .nav-group__trigger {
+  min-height: 38px;
+  padding-inline: 12px;
+  color: var(--public-color-ink-2);
+  font-size: 0.86rem;
+  letter-spacing: 0;
+}
+
+.public-site-shell .header--home:not(.header--home-scrolled) .nav-link,
+.public-site-shell .header--home:not(.header--home-scrolled) .nav-group__trigger {
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.public-site-shell .site-header .nav-link:hover,
+.public-site-shell .site-header .nav-group__trigger:hover,
+.public-site-shell .site-header .nav-link[aria-current='page'],
+.public-site-shell .site-header .nav-link--active,
+.public-site-shell .site-header .nav-group__trigger.nav-link--active {
+  background: rgba(20, 32, 31, 0.07);
+  color: var(--public-color-ink);
+}
+
+.public-site-shell .header--home:not(.header--home-scrolled) .nav-link:hover,
+.public-site-shell .header--home:not(.header--home-scrolled) .nav-group__trigger:hover,
+.public-site-shell .header--home:not(.header--home-scrolled) .nav-link[aria-current='page'],
+.public-site-shell .header--home:not(.header--home-scrolled) .nav-link--active,
+.public-site-shell .header--home:not(.header--home-scrolled) .nav-group__trigger.nav-link--active {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff !important;
+}
+
+.public-site-shell .site-header .nav-link::after,
+.public-site-shell .site-header .nav-link[aria-current='page']::after,
+.public-site-shell .site-header .nav-link--active::after {
+  display: none;
+}
+
+.public-site-shell .site-header .dropdown-panel {
+  min-width: 260px;
+  padding: 10px;
+  border-color: rgba(216, 205, 180, 0.72);
+  border-radius: 20px;
+  background:
+    radial-gradient(circle at top right, rgba(201, 166, 119, 0.12), transparent 30%),
+    rgba(253, 250, 242, 0.98);
+  box-shadow: 0 24px 60px rgba(20, 32, 31, 0.16);
+}
+
+.public-site-shell .site-header .dropdown-item {
+  border-radius: 14px;
+}
+
+.public-site-shell .site-header .dropdown-item:hover {
+  background: rgba(239, 230, 210, 0.72);
+  color: var(--public-color-ink);
+}
+
+.public-site-shell .site-header .dropdown-item__desc {
+  color: var(--public-color-ink-3);
+}
+
+.public-site-shell .site-header .header-actions {
+  gap: clamp(6px, 0.8vw, 12px);
+}
+
+.public-site-shell .site-header .header-cta {
+  min-height: 40px;
+  padding-inline: 15px;
+  font-size: 0.84rem;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.public-site-shell .site-header .header-cta--utility {
+  border-color: rgba(216, 205, 180, 0.78);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.public-site-shell .site-header .header-cta--secondary {
+  border-color: rgba(217, 106, 78, 0.28);
+  background: rgba(255, 255, 255, 0.62);
+  color: var(--public-color-ink);
+}
+
+.public-site-shell .site-header .header-cta--primary {
+  background: linear-gradient(135deg, var(--public-color-coral), var(--public-color-coral-2));
+  color: var(--public-color-paper) !important;
+  box-shadow: 0 18px 34px rgba(217, 106, 78, 0.22);
+}
+
+.public-site-shell .site-header .header-cta--primary:hover,
+.public-site-shell .site-header .header-cta--primary.header-cta--active {
+  background: linear-gradient(135deg, var(--public-color-coral-2), #b94b32);
+}
+
+.public-site-shell .site-header .header-picker {
+  margin-right: 0 !important;
+}
+
+.public-site-shell .site-header .header-picker__button,
+.public-site-shell .site-header .hamburger {
+  min-height: 40px;
+  border: 1px solid var(--amp-shell-control-border);
+  background: var(--amp-shell-control-bg);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.56);
+  letter-spacing: 0 !important;
+}
+
+.public-site-shell .site-header .header-picker__button:hover,
+.public-site-shell .site-header .hamburger:hover {
+  background: var(--amp-shell-control-hover);
+  border-color: var(--public-color-line);
+}
+
+.public-site-shell .header--home:not(.header--home-scrolled) .header-picker__button,
+.public-site-shell .header--home:not(.header--home-scrolled) .hamburger {
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.public-site-shell .site-header .header-picker__menu {
+  border-radius: 18px;
+  border-color: rgba(216, 205, 180, 0.82);
+  box-shadow: 0 22px 54px rgba(20, 32, 31, 0.16);
+}
+
+.public-site-shell .mobile-overlay.active {
+  background: rgba(5, 12, 23, 0.54);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+}
+
+.public-site-shell .mobile-menu {
+  width: min(94vw, 420px);
+  border-left: 1px solid rgba(216, 205, 180, 0.72);
+  background:
+    radial-gradient(circle at 88% 8%, rgba(201, 166, 119, 0.18), transparent 24%),
+    linear-gradient(180deg, var(--public-color-paper-warm), var(--public-color-paper));
+  box-shadow: -28px 0 70px rgba(5, 12, 23, 0.24);
+}
+
+.public-site-shell .mobile-menu__inner {
+  padding: 0 0 32px;
+}
+
+.public-site-shell .mobile-menu__top {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 64px;
+  padding: 12px 18px 10px 22px;
+  border-bottom: 1px solid rgba(216, 205, 180, 0.7);
+  background: rgba(253, 250, 242, 0.92);
+  -webkit-backdrop-filter: blur(18px);
+  backdrop-filter: blur(18px);
+}
+
+.public-site-shell .mobile-menu__brand {
+  color: var(--public-color-ink);
+  font-family: var(--public-type-title-family);
+  font-size: 1.05rem;
+  font-weight: var(--public-font-weight-semibold);
+  letter-spacing: 0;
+}
+
+.public-site-shell .mobile-menu__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid rgba(216, 205, 180, 0.86);
+  border-radius: var(--public-radius-pill);
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--public-color-ink);
+}
+
+.public-site-shell .mobile-menu__intro {
+  margin-bottom: 2px;
+  padding: 20px 22px 22px;
+  border-bottom-color: rgba(216, 205, 180, 0.72);
+  background:
+    radial-gradient(circle at 92% 8%, rgba(201, 166, 119, 0.18), transparent 28%),
+    linear-gradient(180deg, rgba(243, 234, 217, 0.72), rgba(253, 250, 242, 0.96));
+}
+
+.public-site-shell .mobile-menu__eyebrow {
+  background: rgba(20, 32, 31, 0.07);
+  color: var(--public-color-ink-2);
+  letter-spacing: 0;
+}
+
+.public-site-shell .mobile-menu__title {
+  color: var(--public-color-ink);
+  font-family: var(--public-type-title-family);
+  font-size: clamp(1.15rem, 4.4vw, 1.45rem);
+  line-height: 1.24;
+  letter-spacing: 0;
+}
+
+.public-site-shell .mobile-menu__quick-link,
+.public-site-shell .mobile-menu__advisor-link {
+  border-radius: 18px;
+}
+
+.public-site-shell .mobile-menu__quick-link {
+  min-height: 78px;
+  border-color: rgba(216, 205, 180, 0.74);
+  box-shadow: 0 12px 28px rgba(20, 32, 31, 0.06);
+}
+
+.public-site-shell .mobile-menu__advisor-link {
+  background:
+    radial-gradient(circle at 84% 14%, rgba(201, 166, 119, 0.2), transparent 30%),
+    linear-gradient(145deg, var(--amp-shell-night), var(--amp-shell-night-2));
+}
+
+.public-site-shell .mobile-nav__item,
+.public-site-shell .mobile-nav__trigger {
+  min-height: 52px;
+  padding: 15px 22px;
+  border-bottom-color: rgba(216, 205, 180, 0.58);
+  color: var(--public-color-ink);
+  font-size: 0.96rem;
+  letter-spacing: 0;
+}
+
+.public-site-shell .mobile-nav__trigger:hover,
+.public-site-shell .mobile-nav__trigger--open,
+.public-site-shell .mobile-nav__item:hover {
+  background: rgba(243, 234, 217, 0.68);
+  color: var(--public-color-ink);
+}
+
+.public-site-shell .mobile-nav__sub {
+  background: rgba(248, 244, 234, 0.78);
+}
+
+.public-site-shell .mobile-nav__sub-item {
+  padding: 11px 22px 11px 34px;
+}
+
+.public-site-shell .mobile-nav__cta {
+  margin: 18px 22px 0;
+  border-radius: var(--public-radius-pill);
+  background: linear-gradient(135deg, var(--public-color-coral), var(--public-color-coral-2));
+}
+
+.public-site-shell .site-footer.footer {
+  padding-top: clamp(56px, 6vw, 86px);
+  background:
+    radial-gradient(circle at 8% 10%, rgba(201, 166, 119, 0.14), transparent 26%),
+    radial-gradient(circle at 92% 22%, rgba(217, 106, 78, 0.1), transparent 24%),
+    linear-gradient(180deg, #07111e 0%, #081724 48%, #050b14 100%);
+}
+
+.public-site-shell .site-footer.footer::before {
+  background: linear-gradient(90deg, transparent, rgba(201, 166, 119, 0.68), transparent);
+}
+
+.public-site-shell .site-footer__eyebrow,
+.public-site-shell .site-footer__link-group > span,
+.public-site-shell .footer-contact-block > span {
+  letter-spacing: 0 !important;
+}
+
+.public-site-shell .site-footer__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  margin-bottom: 16px;
+  padding: 0 11px;
+  border: 1px solid rgba(201, 166, 119, 0.28);
+  border-radius: var(--public-radius-pill);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(248, 244, 234, 0.72);
+  font-size: 0.72rem;
+  font-weight: var(--public-font-weight-semibold);
+}
+
+.public-site-shell .site-footer__logo {
+  gap: 8px;
+  text-decoration: none;
+}
+
+.public-site-shell .site-footer__brand .footer-brand__promise {
+  max-width: 34rem;
+  color: rgba(248, 244, 234, 0.78);
+}
+
+.public-site-shell .site-footer__contact-card {
+  width: min(100%, 360px);
+  padding: 18px;
+  border: 1px solid rgba(248, 244, 234, 0.12);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.045);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.public-site-shell .site-footer__contact-link {
+  width: fit-content;
+  text-underline-offset: 4px;
+}
+
+.public-site-shell .site-footer .footer-cta-link {
+  min-height: 42px;
+  padding-inline: 18px;
+  border-radius: var(--public-radius-pill);
+  box-shadow: 0 16px 34px rgba(217, 106, 78, 0.2);
+}
+
+.public-site-shell .site-footer .footer-signal-list a {
+  border-color: rgba(248, 244, 234, 0.16);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.public-site-shell .site-footer__link-group {
+  min-width: 0;
+}
+
+.public-site-shell .site-footer__link-group > span {
+  color: rgba(201, 166, 119, 0.82) !important;
+  font-size: 0.74rem;
+}
+
+.public-site-shell .site-footer__link-group a {
+  text-underline-offset: 4px;
+}
+
+.public-site-shell .site-footer__link-group a:hover {
+  text-decoration: underline;
+}
+
+@media (min-width: 1180px) {
+  .public-site-shell .site-header .header-content {
+    display: grid;
+    grid-template-columns: minmax(190px, 0.74fr) auto minmax(250px, 0.82fr);
+  }
+
+  .public-site-shell .site-header .header-actions {
+    justify-content: flex-end;
+  }
+}
+
+@media (min-width: 1180px) and (max-width: 1320px) {
+  .public-site-shell .site-header__brand-line {
+    display: none;
+  }
+
+  .public-site-shell .site-header .nav {
+    gap: 4px;
+  }
+
+  .public-site-shell .site-header .nav-link,
+  .public-site-shell .site-header .nav-group__trigger {
+    padding-inline: 10px;
+  }
+}
+
+@media (max-width: 1179px) {
+  .public-site-shell .site-header .header-content {
+    max-width: min(100%, calc(100vw - 20px));
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1179px) {
+  .public-site-shell .mobile-overlay.active {
+    display: block !important;
+  }
+
+  .public-site-shell .mobile-menu {
+    width: min(420px, 88vw);
+  }
+
+  .public-site-shell .mobile-menu.active {
+    display: block !important;
+  }
+}
+
+@media (max-width: 767px) {
+  .public-site-shell .site-header .header-content {
+    padding-block: 10px;
+  }
+
+  .public-site-shell .site-header__brand-line {
+    display: none;
+  }
+
+  .public-site-shell .site-header__brand-mark {
+    width: 24px;
+    height: 24px;
+  }
+
+  .public-site-shell .site-header .header-picker__button {
+    min-height: 38px;
+    padding-right: 7px;
+    padding-left: 7px;
+    font-size: 0.68rem;
+  }
+
+  .public-site-shell .site-header .hamburger.mobile-only {
+    width: 38px;
+    height: 38px;
+    flex-basis: 38px;
+  }
+
+  .public-site-shell .mobile-menu {
+    width: min(100vw, 420px);
+  }
+
+  .public-site-shell .site-footer__contact-card {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- Refreshes AMP public header, mobile menu, footer, and shared public shell styling.
- Improves premium real estate visual presentation.
- Keeps navigation and mobile drawer behavior working.
- Preserves routes, data, tracking, SEO, LeadForm, backend/API behavior.

## Files changed
- admin-app/components/layout/Footer.tsx
- admin-app/components/layout/Header.tsx
- admin-app/components/layout/MobileMenu.tsx
- admin-app/styles/public-primitives.css

## Verification
- Focused Vitest: 8 files / 48 tests passed
- FLOWBIZ_FORCE_FULL_BUILD=1 pnpm build passed
- http://localhost:3001/en = 200
- 1440 overflow: scrollWidth 1440 / clientWidth 1440
- 768 overflow: scrollWidth 768 / clientWidth 768
- 390 overflow: scrollWidth 390 / clientWidth 390
- Desktop nav click works: /en/projects
- Tablet drawer works: Rent -> /en/rent
- Mobile drawer works: Buy -> /en/buy
- Footer visible, links valid, no empty href
- Sample output: 0
- sample project names: 0

## Safety
- No deploy
- No merge
- No backend/API changes
- No database/schema changes
- No env/deployment changes
- No LeadForm submit contract changes
- No SEO/canonical/sitemap/robots changes
- No tracking/analytics changes
- No mock data added
- No src/ prototype files changed

## Remaining risks
- Existing <img> warnings remain from pre-existing files.
- Existing hero image preload warning observed once in Playwright, with no page error or horizontal overflow.
