### PR TITLE
feat(public): add AMP public v2 preview foundation

### DIFF
--- a/admin-app/__tests__/header_cta_visibility.test.tsx
+++ b/admin-app/__tests__/header_cta_visibility.test.tsx
@@ -77,4 +77,12 @@ describe('Header CTA visibility', () => {
     expect(sharedRender.container.querySelector('.header-cta-group')).toBeNull();
     expect(sharedRender.container.querySelector('.mobile-nav__cta')).toBeNull();
   });
+
+  it('suppresses the desktop shortlist CTA on the English preview route with trailing slash', () => {
+    mockedPathname = '/en/v2-preview/';
+
+    const { container } = render(<Header locale="en" dict={en} />);
+
+    expect(container.querySelector('.header-cta--utility')).toBeNull();
+  });
 });

--- a/admin-app/__tests__/middleware_locale_routing.test.ts
+++ b/admin-app/__tests__/middleware_locale_routing.test.ts
@@ -62,6 +62,17 @@ describe('middleware locale routing', () => {
     expect(response.cookies.get(LOCALE_COOKIE_NAME)?.value).toBe('th');
   });
 
+  it('returns a real 404 for the Thai-only AMP public v2 preview path', () => {
+    const request = new NextRequest('https://amppattaya.com/th/v2-preview');
+
+    const response = middleware(request);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('x-next-pathname')).toBe('/th/v2-preview');
+    expect(response.cookies.get(LOCALE_COOKIE_NAME)?.value).toBe('th');
+  });
+
   it('bypasses locale redirects for media proxy routes', () => {
     const request = new NextRequest('https://amppattaya.com/media/project-covers/hero.webp');
 

--- a/admin-app/__tests__/middleware_locale_routing.test.ts
+++ b/admin-app/__tests__/middleware_locale_routing.test.ts
@@ -73,6 +73,17 @@ describe('middleware locale routing', () => {
     expect(response.cookies.get(LOCALE_COOKIE_NAME)?.value).toBe('th');
   });
 
+  it('returns a real 404 for the Thai-only AMP public v2 preview path with trailing slash', () => {
+    const request = new NextRequest('https://amppattaya.com/th/v2-preview/');
+
+    const response = middleware(request);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('x-next-pathname')).toBe('/th/v2-preview/');
+    expect(response.cookies.get(LOCALE_COOKIE_NAME)?.value).toBe('th');
+  });
+
   it('bypasses locale redirects for media proxy routes', () => {
     const request = new NextRequest('https://amppattaya.com/media/project-covers/hero.webp');
 

--- a/admin-app/__tests__/public_client_enhancements_locale_semantics.test.tsx
+++ b/admin-app/__tests__/public_client_enhancements_locale_semantics.test.tsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { PublicClientEnhancements } from '@/components/layout/PublicClientEnhancements';
 
@@ -10,11 +10,21 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('next/dynamic', () => ({
-  default: () => {
-    const Stub = () => null;
+  default: (loader: () => Promise<unknown>) => {
+    const source = String(loader);
+    const testId = source.includes('StickyMobileCTA')
+      ? 'sticky-mobile-cta'
+      : source.includes('AIChatWidget')
+        ? 'ai-chat-widget'
+        : 'dynamic-component';
+    const Stub = () => <div data-testid={testId} />;
     return Stub;
   },
 }));
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('PublicClientEnhancements locale semantics', () => {
   it('syncs html lang with the current locale pathname', () => {
@@ -27,5 +37,28 @@ describe('PublicClientEnhancements locale semantics', () => {
     rerender(<PublicClientEnhancements />);
 
     expect(document.documentElement.getAttribute('lang')).toBe('th');
+  });
+
+  it('suppresses sticky mobile CTA and AI chat on the English preview route with trailing slash', async () => {
+    vi.useFakeTimers();
+    mockedPathname = '/en/v2-preview/';
+
+    render(<PublicClientEnhancements />);
+
+    expect(screen.queryByTestId('sticky-mobile-cta')).toBeNull();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByTestId('ai-chat-widget')).toBeNull();
+  });
+
+  it('does not treat normal public routes as the preview surface', () => {
+    mockedPathname = '/en/projects';
+
+    render(<PublicClientEnhancements />);
+
+    expect(screen.getByTestId('sticky-mobile-cta')).toBeInTheDocument();
   });
 });

--- a/admin-app/__tests__/v2_preview_route.test.tsx
+++ b/admin-app/__tests__/v2_preview_route.test.tsx
@@ -164,6 +164,19 @@ describe('AMP Public v2 preview route', () => {
     expect(document.body.textContent).not.toContain('Figma Make');
   });
 
+  it('renders fallback cards when API returns null or non-array payloads', async () => {
+    publicApiMock.fetchProjects.mockResolvedValue(null);
+    publicApiMock.fetchAreas.mockResolvedValue(null);
+    publicApiMock.fetchProperties.mockResolvedValue({ data: null, meta: { page: 1, limit: 0, total: 0 } });
+
+    render(await AmpPublicV2PreviewPage({ params: Promise.resolve({ locale: 'en' }) }));
+
+    expect(screen.getByRole('heading', { name: 'The Riviera Palm Beach' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Pattaya coastal condominium' })).toBeInTheDocument();
+    expect(screen.getAllByText('Price on request').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Availability to be confirmed').length).toBeGreaterThan(0);
+  });
+
   it('keeps preview implementation isolated from Figma mock sources and production route files', () => {
     const previewSource = [
       read('app/(site)/[locale]/v2-preview/page.tsx'),
@@ -181,9 +194,9 @@ describe('AMP Public v2 preview route', () => {
     expect(previewSource).not.toContain('@/components/public-system/components/PropertyCard');
     expect(previewSource).toContain('function V2Header');
     expect(previewSource).toContain('function V2Footer');
-    expect(enhancementsSource).toContain("pathWithoutLocale === '/v2-preview'");
+    expect(enhancementsSource).toContain('isV2PreviewPath');
     expect(enhancementsSource).toContain('{isPreviewSurface ? null : <StickyMobileCTA />}');
-    expect(headerSource).toContain("pathWithoutLocale === '/v2-preview'");
+    expect(headerSource).toContain('isV2PreviewPath');
     expect(headerSource).toContain('shortlistCta && !isV2PreviewSurface');
     expect(read('app/(site)/[locale]/page.tsx')).not.toContain('v2-preview');
     expect(read('app/(site)/[locale]/projects/page.tsx')).not.toContain('v2-preview');

--- a/admin-app/__tests__/v2_preview_route.test.tsx
+++ b/admin-app/__tests__/v2_preview_route.test.tsx
@@ -1,0 +1,199 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import sitemap from '@/app/sitemap';
+import AmpPublicV2PreviewPage, { generateMetadata } from '@/app/(site)/[locale]/v2-preview/page';
+
+const navigationMock = vi.hoisted(() => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+}));
+
+const publicApiMock = vi.hoisted(() => ({
+  fetchAreas: vi.fn(),
+  fetchProjects: vi.fn(),
+  fetchProperties: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: navigationMock.notFound,
+}));
+
+vi.mock('next/image', () => ({
+  default: (props: Record<string, unknown>) => (
+    <div
+      role="img"
+      aria-label={String(props.alt ?? '')}
+      data-src={String(props.src ?? '')}
+      data-sizes={String(props.sizes ?? '')}
+    />
+  ),
+}));
+
+vi.mock('@/components/forms/LeadForm', () => ({
+  LeadForm: (props: {
+    heading?: string;
+    formId?: string;
+    submitLabel?: string;
+    defaultMessage?: string;
+  }) => (
+    <form aria-label={props.heading ?? 'Lead form'} data-form-id={props.formId}>
+      <p>{props.defaultMessage}</p>
+      <button type="submit">{props.submitLabel ?? 'Submit'}</button>
+    </form>
+  ),
+}));
+
+vi.mock('@/app/_lib/public-api-server', () => ({
+  fetchAreas: publicApiMock.fetchAreas,
+  fetchProjects: publicApiMock.fetchProjects,
+  fetchProperties: publicApiMock.fetchProperties,
+}));
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+}
+
+function seedApiData() {
+  publicApiMock.fetchProjects.mockResolvedValue([
+    {
+      id: 'project-alpha',
+      slug: 'alpha-residence',
+      name: 'Alpha Residence',
+      status: null,
+      cover_image_url: '/images/project-overview.png',
+      starting_price: null,
+      area: { id: 'area-jomtien', slug: 'jomtien', name: 'Jomtien' },
+      created_at: null,
+      updated_at: null,
+    },
+  ]);
+  publicApiMock.fetchProperties.mockImplementation(async (params: { type?: string }) => ({
+    data: [
+      {
+        id: `property-${params.type ?? 'sale'}`,
+        slug: `${params.type ?? 'sale'}-property`,
+        title: params.type === 'rent' ? 'Rental Residence' : 'Buyer Residence',
+        type: params.type === 'rent' ? 'rent' : 'resale',
+        price: null,
+        city: 'Pattaya',
+        cover_image: null,
+        images: null,
+        local_images: null,
+      },
+    ],
+    meta: { page: 1, limit: 1, total: 1 },
+  }));
+  publicApiMock.fetchAreas.mockResolvedValue([
+    {
+      id: 'area-jomtien',
+      slug: 'jomtien',
+      name: 'Jomtien',
+      city: 'Pattaya',
+      hero_image_url: null,
+      created_at: '',
+    },
+  ]);
+}
+
+describe('AMP Public v2 preview route', () => {
+  beforeEach(() => {
+    navigationMock.notFound.mockClear();
+    publicApiMock.fetchAreas.mockReset();
+    publicApiMock.fetchProjects.mockReset();
+    publicApiMock.fetchProperties.mockReset();
+    seedApiData();
+  });
+
+  it('renders the isolated English preview with advisor CTA and safe data labels', async () => {
+    render(await AmpPublicV2PreviewPage({ params: Promise.resolve({ locale: 'en' }) }));
+
+    expect(screen.getByRole('heading', {
+      name: /find the pattaya property that fits the way you want to live/i,
+    })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /browse verified projects/i })).toHaveAttribute(
+      'href',
+      '/en/projects?source=v2_preview_hero',
+    );
+    expect(screen.getByRole('heading', { name: 'Alpha Residence' })).toBeInTheDocument();
+    expect(screen.getAllByText('Price on request').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Availability to be confirmed').length).toBeGreaterThan(0);
+    expect(screen.getByRole('form', { name: /speak with a pattaya property advisor/i })).toHaveAttribute(
+      'data-form-id',
+      'v2-preview-advisor',
+    );
+    expect(publicApiMock.fetchProjects).toHaveBeenCalledWith({ limit: 12 });
+  });
+
+  it('returns notFound for the Thai preview route before fetching public data', async () => {
+    await expect(
+      AmpPublicV2PreviewPage({ params: Promise.resolve({ locale: 'th' }) }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+
+    expect(navigationMock.notFound).toHaveBeenCalledTimes(1);
+    expect(publicApiMock.fetchProjects).not.toHaveBeenCalled();
+    expect(publicApiMock.fetchProperties).not.toHaveBeenCalled();
+    expect(publicApiMock.fetchAreas).not.toHaveBeenCalled();
+  });
+
+  it('marks the preview metadata noindex and nofollow', async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ locale: 'en' }) });
+    const robots = metadata.robots as {
+      index?: boolean;
+      follow?: boolean;
+      googleBot?: { index?: boolean; follow?: boolean };
+    };
+
+    expect(metadata.alternates?.canonical).toBe('/en/v2-preview');
+    expect(robots.index).toBe(false);
+    expect(robots.follow).toBe(false);
+    expect(robots.googleBot?.index).toBe(false);
+    expect(robots.googleBot?.follow).toBe(false);
+  });
+
+  it('keeps the preview route out of the sitemap', () => {
+    const urls = sitemap().map((entry) => entry.url);
+    expect(urls.some((url) => url.includes('/v2-preview'))).toBe(false);
+  });
+
+  it('renders fallback-safe cards without Figma mock data when the API is empty', async () => {
+    publicApiMock.fetchProjects.mockResolvedValue([]);
+    publicApiMock.fetchProperties.mockResolvedValue({ data: [], meta: { page: 1, limit: 0, total: 0 } });
+    publicApiMock.fetchAreas.mockResolvedValue([]);
+
+    render(await AmpPublicV2PreviewPage({ params: Promise.resolve({ locale: 'en' }) }));
+
+    expect(screen.getByRole('heading', { name: 'The Riviera Palm Beach' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Pattaya coastal condominium' })).toBeInTheDocument();
+    expect(screen.getAllByText('Request updated price list').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Availability to be confirmed').length).toBeGreaterThan(0);
+    expect(document.body.textContent).not.toContain('mockData');
+    expect(document.body.textContent).not.toContain('Figma Make');
+  });
+
+  it('keeps preview implementation isolated from Figma mock sources and production route files', () => {
+    const previewSource = [
+      read('app/(site)/[locale]/v2-preview/page.tsx'),
+      read('app/(site)/[locale]/v2-preview/_lib/v2-preview-data.ts'),
+      read('app/(site)/[locale]/v2-preview/_components/V2PreviewPage.tsx'),
+    ].join('\n');
+    const enhancementsSource = read('components/layout/PublicClientEnhancements.tsx');
+    const headerSource = read('components/layout/Header.tsx');
+
+    expect(previewSource).not.toContain('src/app/data/mockData');
+    expect(previewSource).not.toContain('figma/make');
+    expect(previewSource).not.toContain('RXcIsp7lQNDW95nPm20Zwu');
+    expect(enhancementsSource).toContain("pathWithoutLocale === '/v2-preview'");
+    expect(enhancementsSource).toContain('{isPreviewSurface ? null : <StickyMobileCTA />}');
+    expect(headerSource).toContain("pathWithoutLocale === '/v2-preview'");
+    expect(headerSource).toContain('shortlistCta && !isV2PreviewSurface');
+    expect(read('app/(site)/[locale]/page.tsx')).not.toContain('v2-preview');
+    expect(read('app/(site)/[locale]/projects/page.tsx')).not.toContain('v2-preview');
+    expect(read('app/(site)/[locale]/buy/page.tsx')).not.toContain('v2-preview');
+    expect(read('app/(site)/[locale]/rent/page.tsx')).not.toContain('v2-preview');
+  });
+});

--- a/admin-app/__tests__/v2_preview_route.test.tsx
+++ b/admin-app/__tests__/v2_preview_route.test.tsx
@@ -34,20 +34,6 @@ vi.mock('next/image', () => ({
   ),
 }));
 
-vi.mock('@/components/forms/LeadForm', () => ({
-  LeadForm: (props: {
-    heading?: string;
-    formId?: string;
-    submitLabel?: string;
-    defaultMessage?: string;
-  }) => (
-    <form aria-label={props.heading ?? 'Lead form'} data-form-id={props.formId}>
-      <p>{props.defaultMessage}</p>
-      <button type="submit">{props.submitLabel ?? 'Submit'}</button>
-    </form>
-  ),
-}));
-
 vi.mock('@/app/_lib/public-api-server', () => ({
   fetchAreas: publicApiMock.fetchAreas,
   fetchProjects: publicApiMock.fetchProjects,
@@ -113,18 +99,21 @@ describe('AMP Public v2 preview route', () => {
     render(await AmpPublicV2PreviewPage({ params: Promise.resolve({ locale: 'en' }) }));
 
     expect(screen.getByRole('heading', {
-      name: /find the pattaya property that fits the way you want to live/i,
+      name: /pattaya, priced for investors who measure in years, not weekends/i,
     })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /browse verified projects/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /90-second smart finder/i })).toHaveAttribute(
       'href',
-      '/en/projects?source=v2_preview_hero',
+      '/en/smart-finder?source=v2_preview_hero',
     );
     expect(screen.getByRole('heading', { name: 'Alpha Residence' })).toBeInTheDocument();
     expect(screen.getAllByText('Price on request').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Availability to be confirmed').length).toBeGreaterThan(0);
-    expect(screen.getByRole('form', { name: /speak with a pattaya property advisor/i })).toHaveAttribute(
-      'data-form-id',
-      'v2-preview-advisor',
+    expect(screen.getByRole('navigation', { name: /amp public v2 preview navigation/i })).toHaveTextContent(
+      'New Projects',
+    );
+    expect(screen.getByRole('link', { name: /request private recommendation/i })).toHaveAttribute(
+      'href',
+      '/en/contact?source=v2_preview_advisor_cta',
     );
     expect(publicApiMock.fetchProjects).toHaveBeenCalledWith({ limit: 12 });
   });
@@ -187,6 +176,11 @@ describe('AMP Public v2 preview route', () => {
     expect(previewSource).not.toContain('src/app/data/mockData');
     expect(previewSource).not.toContain('figma/make');
     expect(previewSource).not.toContain('RXcIsp7lQNDW95nPm20Zwu');
+    expect(previewSource).not.toContain('@/components/forms/LeadForm');
+    expect(previewSource).not.toContain('@/components/public-system/components/ProjectCard');
+    expect(previewSource).not.toContain('@/components/public-system/components/PropertyCard');
+    expect(previewSource).toContain('function V2Header');
+    expect(previewSource).toContain('function V2Footer');
     expect(enhancementsSource).toContain("pathWithoutLocale === '/v2-preview'");
     expect(enhancementsSource).toContain('{isPreviewSurface ? null : <StickyMobileCTA />}');
     expect(headerSource).toContain("pathWithoutLocale === '/v2-preview'");

--- a/admin-app/app/(site)/[locale]/v2-preview/_components/V2PreviewPage.tsx
+++ b/admin-app/app/(site)/[locale]/v2-preview/_components/V2PreviewPage.tsx
@@ -1,0 +1,281 @@
+import Link from 'next/link';
+
+import { LeadForm } from '@/components/forms/LeadForm';
+import { SafeCoverImage } from '@/components/media/SafeCoverImage';
+import { cx } from '@/components/public/cx';
+import { Button } from '@/components/public-system/components/Button';
+import { ProjectCard } from '@/components/public-system/components/ProjectCard';
+import { PropertyCard } from '@/components/public-system/components/PropertyCard';
+
+import type { V2PreviewAreaCard, V2PreviewData } from '../_lib/v2-preview-data';
+import styles from '../v2-preview.module.css';
+
+const BUYER_FIT_CARDS = [
+  {
+    title: 'Buy to live',
+    body: 'Shortlist by daily rhythm first: beach access, commute, facilities, and how each building feels after a full week.',
+    href: '/en/buy?source=v2_preview_fit_live',
+  },
+  {
+    title: 'Buy to invest',
+    body: 'Compare projects with advisor context before asking for price lists, quotas, rental assumptions, and handover details.',
+    href: '/en/invest?source=v2_preview_fit_invest',
+  },
+  {
+    title: 'Rent before deciding',
+    body: 'Use rental options to test an area, building, or lifestyle fit before committing to a purchase route.',
+    href: '/en/rent?source=v2_preview_fit_rent',
+  },
+];
+
+const TRUST_STEPS = [
+  {
+    title: 'Start with the brief',
+    body: 'Budget, nationality, lifestyle, timeline, and risk tolerance shape the first shortlist.',
+  },
+  {
+    title: 'Check the moving parts',
+    body: 'The advisor follow-up can confirm current price lists, foreign quota, availability, and transfer timing.',
+  },
+  {
+    title: 'Choose a next step',
+    body: 'Move from a broad search into project comparison, private viewing, or a tighter area-led shortlist.',
+  },
+];
+
+type SectionHeadingProps = {
+  label: string;
+  title: string;
+  body: string;
+  align?: 'left' | 'center';
+};
+
+function SectionHeading({ label, title, body, align = 'left' }: SectionHeadingProps) {
+  return (
+    <div className={cx(styles.sectionHeading, align === 'center' && styles.sectionHeadingCenter)}>
+      <p className={styles.sectionLabel}>{label}</p>
+      <h2>{title}</h2>
+      <p>{body}</p>
+    </div>
+  );
+}
+
+function AreaCard({ area }: { area: V2PreviewAreaCard }) {
+  return (
+    <Link href={area.href} className={styles.areaCard}>
+      <span className={styles.areaImage}>
+        <SafeCoverImage
+          src={area.imageSrc}
+          alt={area.imageAlt}
+          fallbackSrc="/images/area-guide-pattaya.png"
+          sizes="(min-width: 1024px) 25vw, (min-width: 768px) 50vw, 100vw"
+          className={styles.coverImage}
+          ssrStartWithPrimary
+        />
+      </span>
+      <span className={styles.areaBody}>
+        <span className={styles.areaName}>{area.name}</span>
+        <span className={styles.areaDescription}>{area.description}</span>
+        <span className={styles.textLink}>Open area guide</span>
+      </span>
+    </Link>
+  );
+}
+
+export function V2PreviewPage({ data }: { data: V2PreviewData }) {
+  const heroProjectNames = data.projectCards.slice(0, 3).map((project) => project.name);
+
+  return (
+    <main className={styles.page} data-testid="amp-public-v2-preview">
+      <section className={styles.hero} aria-labelledby="v2-preview-hero-title">
+        <div className={styles.heroGrid}>
+          <div className={styles.heroCopy}>
+            <p className={styles.brandLine}>AMP Pattaya</p>
+            <h1 id="v2-preview-hero-title">Find the Pattaya property that fits the way you want to live</h1>
+            <p className={styles.heroLead}>
+              A calmer public search experience for buyers who need context before comparing projects, areas,
+              price lists, and private viewing options.
+            </p>
+            <div className={styles.heroActions}>
+              <Button href="#v2-preview-contact" variant="primary" className={styles.heroPrimaryCta}>
+                Speak with a Pattaya property advisor
+              </Button>
+              <Button
+                href="/en/projects?source=v2_preview_hero"
+                variant="secondary"
+                className={cx(styles.heroSecondaryCta, 'v2-preview-hero-secondary')}
+              >
+                Browse verified projects
+              </Button>
+            </div>
+            <dl className={styles.heroProofGrid} aria-label="Preview search assurances">
+              <div>
+                <dt>Search style</dt>
+                <dd>Advisor-led</dd>
+              </div>
+              <div>
+                <dt>Route</dt>
+                <dd>English public</dd>
+              </div>
+              <div>
+                <dt>Next step</dt>
+                <dd>Updated shortlist</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div className={styles.heroMediaPanel} aria-label="Featured Pattaya property media">
+            <div className={styles.heroImageFrame}>
+              <SafeCoverImage
+                src={data.heroImageSrc}
+                alt={data.heroImageAlt}
+                fallbackSrc="/images/hero-banner-20260318.webp"
+                priority
+                loading="eager"
+                fetchPriority="high"
+                sizes="(min-width: 1024px) 48vw, 100vw"
+                className={styles.coverImage}
+                ssrStartWithPrimary
+              />
+            </div>
+            <div className={styles.heroAdvisorPanel}>
+              <p>Shortlist starting points</p>
+              <ul>
+                {heroProjectNames.map((name) => (
+                  <li key={name}>{name}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.fitSection} aria-labelledby="v2-preview-fit-title">
+        <SectionHeading
+          label="Buyer fit"
+          title="Start from intent, not a generic property grid"
+          body="The preview keeps the first decision simple: choose the route that matches how the buyer wants to use the property."
+        />
+        <div className={styles.fitGrid}>
+          {BUYER_FIT_CARDS.map((card) => (
+            <article key={card.title} className={styles.fitCard}>
+              <h3>{card.title}</h3>
+              <p>{card.body}</p>
+              <Link href={card.href} className={styles.textLink}>
+                Continue this route
+              </Link>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.projectSection} aria-labelledby="v2-preview-projects-title">
+        <SectionHeading
+          label="Projects"
+          title="Project cards with safe public data"
+          body="Cards use live project data when available, and fall back to existing AMP media with neutral availability labels."
+        />
+        <div className={styles.cardRail}>
+          {data.projectCards.slice(0, 3).map((project, index) => (
+            <ProjectCard
+              key={project.id}
+              project={project}
+              ctaLabel="Request updated price list"
+              imagePriority={index === 0}
+              className={cx(styles.previewCard, 'v2-preview-card')}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.propertySection} aria-labelledby="v2-preview-properties-title">
+        <SectionHeading
+          label="Residences"
+          title="A tighter way to scan buy and rent options"
+          body="The preview separates buyer intent from listing detail, while still sending visitors to the existing safe routes."
+        />
+        <div className={styles.cardRail}>
+          {data.propertyCards.slice(0, 3).map((property) => (
+            <PropertyCard
+              key={property.id}
+              property={property}
+              ctaLabel={property.listingType === 'rent' ? 'View rental route' : 'View buying route'}
+              className={cx(styles.previewCard, 'v2-preview-card')}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.areaSection} aria-labelledby="v2-preview-areas-title">
+        <SectionHeading
+          label="Areas"
+          title="Choose by beach, commute, and daily rhythm"
+          body="Area cards keep the lifestyle question close to the property search without making unverified performance claims."
+          align="center"
+        />
+        <div className={styles.areaGrid}>
+          {data.areaCards.map((area) => (
+            <AreaCard key={area.id} area={area} />
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.trustSection} aria-labelledby="v2-preview-trust-title">
+        <div className={styles.trustIntro}>
+          <SectionHeading
+            label="Advisor workflow"
+            title="The shortlist is only useful when the next question is clear"
+            body="The v2 foundation is designed around a human follow-up path, so buyers know what needs confirmation before a viewing or reservation conversation."
+          />
+        </div>
+        <ol className={styles.trustList}>
+          {TRUST_STEPS.map((step, index) => (
+            <li key={step.title} className={styles.trustItem}>
+              <span className={styles.trustIndex}>{String(index + 1).padStart(2, '0')}</span>
+              <div>
+                <h3>{step.title}</h3>
+                <p>{step.body}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section id="v2-preview-contact" className={styles.contactSection} aria-labelledby="v2-preview-contact-title">
+        <div className={styles.contactCopy}>
+          <p className={styles.sectionLabel}>Lead handoff</p>
+          <h2 id="v2-preview-contact-title">Speak with a Pattaya property advisor</h2>
+          <p>
+            Share the brief once. The existing inquiry workflow can carry the route, budget, area, and timeline
+            context into advisor follow-up.
+          </p>
+          <ul className={styles.contactChecks}>
+            <li>Request updated price list</li>
+            <li>Confirm availability before viewing</li>
+            <li>Compare areas before committing</li>
+          </ul>
+        </div>
+        <div className={styles.formPanel}>
+          <LeadForm
+            locale="en"
+            formId="v2-preview-advisor"
+            heading="Speak with a Pattaya property advisor"
+            description="Tell us what you are comparing and the sales team will respond with the clearest next step."
+            submitLabel="Send brief to advisor"
+            defaultMessage="I am reviewing the AMP Public v2 preview and would like help comparing Pattaya projects, areas, and current availability."
+            defaultTimeframe="flexible"
+            inquiryIntent="project_consultation"
+            inquirySource="v2_preview"
+            inquiryTags={['v2_preview', 'english_public', 'advisor_led']}
+            contextSummary={[
+              'Source route: /en/v2-preview',
+              'Intent: advisor-led Pattaya property shortlist',
+              'Fallback labels are used when price or availability is not confirmed',
+            ]}
+            hideSupport
+          />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/admin-app/app/(site)/[locale]/v2-preview/_components/V2PreviewPage.tsx
+++ b/admin-app/app/(site)/[locale]/v2-preview/_components/V2PreviewPage.tsx
@@ -1,45 +1,93 @@
 import Link from 'next/link';
 
-import { LeadForm } from '@/components/forms/LeadForm';
 import { SafeCoverImage } from '@/components/media/SafeCoverImage';
 import { cx } from '@/components/public/cx';
-import { Button } from '@/components/public-system/components/Button';
-import { ProjectCard } from '@/components/public-system/components/ProjectCard';
-import { PropertyCard } from '@/components/public-system/components/PropertyCard';
 
 import type { V2PreviewAreaCard, V2PreviewData } from '../_lib/v2-preview-data';
 import styles from '../v2-preview.module.css';
 
+type ProjectCardData = V2PreviewData['projectCards'][number];
+type PropertyCardData = V2PreviewData['propertyCards'][number];
+
+const NAV_ITEMS = [
+  { label: 'Home', href: '/en?source=v2_preview_nav' },
+  { label: 'Buy', href: '/en/buy?source=v2_preview_nav' },
+  { label: 'New Projects', href: '/en/projects?source=v2_preview_nav' },
+  { label: 'Areas', href: '/en/area-guide?source=v2_preview_nav' },
+  { label: 'Invest', href: '/en/invest?source=v2_preview_nav' },
+  { label: 'Contact', href: '/en/contact?source=v2_preview_nav' },
+];
+
+const HERO_STATS = [
+  { value: 'Curated', label: 'Pattaya projects' },
+  { value: 'Freehold', label: 'Foreign buyer context' },
+  { value: 'Verified', label: 'Advisor fact check' },
+  { value: 'Private', label: 'Shortlist handoff' },
+];
+
+const SEARCH_TABS = [
+  { label: 'Buy', href: '/en/buy?source=v2_preview_search_tab' },
+  { label: 'Rent', href: '/en/rent?source=v2_preview_search_tab' },
+  { label: 'Off-plan', href: '/en/projects?source=v2_preview_search_tab' },
+  { label: 'Villas', href: '/en/buy?property_type=villa&source=v2_preview_search_tab' },
+];
+
+const SEARCH_FIELDS = [
+  { label: 'Location', value: 'Pattaya / Jomtien' },
+  { label: 'Type', value: 'Condo or villa' },
+  { label: 'Bedrooms', value: 'Buyer-fit brief' },
+  { label: 'Budget', value: 'Price on request' },
+];
+
 const BUYER_FIT_CARDS = [
   {
-    title: 'Buy to live',
-    body: 'Shortlist by daily rhythm first: beach access, commute, facilities, and how each building feels after a full week.',
-    href: '/en/buy?source=v2_preview_fit_live',
+    title: 'Foreign buyer route',
+    body: 'Clarify ownership structure, transfer cost questions, and advisor checks before shortlisting projects.',
+    href: '/en/buy?source=v2_preview_fit_foreign',
   },
   {
-    title: 'Buy to invest',
-    body: 'Compare projects with advisor context before asking for price lists, quotas, rental assumptions, and handover details.',
+    title: 'Investor comparison',
+    body: 'Compare location, building profile, holding plan, and rental assumptions without treating estimates as facts.',
     href: '/en/invest?source=v2_preview_fit_invest',
   },
   {
-    title: 'Rent before deciding',
-    body: 'Use rental options to test an area, building, or lifestyle fit before committing to a purchase route.',
-    href: '/en/rent?source=v2_preview_fit_rent',
+    title: 'Lifestyle first',
+    body: 'Choose by daily rhythm: beach access, commute, building feel, facilities, and viewing practicality.',
+    href: '/en/area-guide?source=v2_preview_fit_lifestyle',
   },
 ];
 
 const TRUST_STEPS = [
   {
-    title: 'Start with the brief',
+    title: 'Brief',
     body: 'Budget, nationality, lifestyle, timeline, and risk tolerance shape the first shortlist.',
   },
   {
-    title: 'Check the moving parts',
-    body: 'The advisor follow-up can confirm current price lists, foreign quota, availability, and transfer timing.',
+    title: 'Verify',
+    body: 'Ask the advisor to confirm price list, foreign quota, availability, transfer timing, and viewing access.',
   },
   {
-    title: 'Choose a next step',
-    body: 'Move from a broad search into project comparison, private viewing, or a tighter area-led shortlist.',
+    title: 'Visit',
+    body: 'Move into private viewing or a tighter project comparison only when the next question is clear.',
+  },
+];
+
+const FOOTER_GROUPS = [
+  {
+    title: 'Explore',
+    links: [
+      { label: 'Buy property', href: '/en/buy?source=v2_preview_footer' },
+      { label: 'Rent property', href: '/en/rent?source=v2_preview_footer' },
+      { label: 'New projects', href: '/en/projects?source=v2_preview_footer' },
+    ],
+  },
+  {
+    title: 'Advisor routes',
+    links: [
+      { label: 'Smart Finder', href: '/en/smart-finder?source=v2_preview_footer' },
+      { label: 'Area guide', href: '/en/area-guide?source=v2_preview_footer' },
+      { label: 'Contact', href: '/en/contact?source=v2_preview_footer' },
+    ],
   },
 ];
 
@@ -50,13 +98,174 @@ type SectionHeadingProps = {
   align?: 'left' | 'center';
 };
 
+function V2Logo() {
+  return (
+    <span className={styles.logo} aria-label="AMP Pattaya">
+      <span className={styles.logoMark}>A</span>
+      <span className={styles.logoCopy}>
+        <span>
+          AMP <em>Pattaya</em>
+        </span>
+        <small>Pattaya Property Advisory</small>
+      </span>
+    </span>
+  );
+}
+
+function V2Header() {
+  return (
+    <header className={styles.v2Header}>
+      <Link href="/en?source=v2_preview_logo" className={styles.logoLink}>
+        <V2Logo />
+      </Link>
+
+      <nav className={styles.v2Nav} aria-label="AMP public v2 preview navigation">
+        {NAV_ITEMS.map((item) => (
+          <Link key={item.label} href={item.href}>
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+
+      <div className={styles.headerActions}>
+        <span className={styles.headerPill}>THB</span>
+        <span className={styles.headerPill}>EN</span>
+        <Link href="/en/contact?source=v2_preview_header_cta" className={styles.headerCta}>
+          Book a viewing
+        </Link>
+      </div>
+
+      <details className={styles.mobileMenu}>
+        <summary aria-label="Open preview navigation">
+          <span />
+          <span />
+          <span />
+        </summary>
+        <div className={styles.mobileMenuPanel}>
+          {NAV_ITEMS.map((item) => (
+            <Link key={item.label} href={item.href}>
+              {item.label}
+            </Link>
+          ))}
+          <Link href="/en/contact?source=v2_preview_mobile_cta" className={styles.mobileMenuCta}>
+            Book a viewing
+          </Link>
+        </div>
+      </details>
+    </header>
+  );
+}
+
 function SectionHeading({ label, title, body, align = 'left' }: SectionHeadingProps) {
   return (
     <div className={cx(styles.sectionHeading, align === 'center' && styles.sectionHeadingCenter)}>
-      <p className={styles.sectionLabel}>{label}</p>
+      <p>{label}</p>
       <h2>{title}</h2>
-      <p>{body}</p>
+      <span>{body}</span>
     </div>
+  );
+}
+
+function HeroLeadCard() {
+  return (
+    <aside className={styles.heroLeadCard} aria-label="Advisor lead handoff preview">
+      <div className={styles.heroLeadCardHeader}>
+        <p>Get price & floor plan</p>
+        <span>Advisor reply</span>
+      </div>
+      <h2>Speak to an advisor</h2>
+      <div className={styles.heroVisualForm} aria-hidden="true">
+        <span>Your name *</span>
+        <span>Phone (with code)</span>
+        <span>Email</span>
+        <span>5-10M</span>
+        <span>1-2 BR</span>
+        <span className={styles.visualInputWide}>Within 3 months</span>
+      </div>
+      <p className={styles.heroConsentLine}>Contact me on WhatsApp if preferred</p>
+      <Link href="/en/contact?source=v2_preview_hero_form" className={styles.heroFormButton}>
+        Send brief to advisor <span aria-hidden="true">&rarr;</span>
+      </Link>
+      <p className={styles.heroFinePrint}>Advisor follow-up only.</p>
+    </aside>
+  );
+}
+
+function HeroSearchPanel() {
+  return (
+    <nav className={styles.heroSearchPanel} aria-label="Preview property search shortcuts">
+      <div className={styles.searchTabs}>
+        {SEARCH_TABS.map((tab, index) => (
+          <Link key={tab.label} href={tab.href} className={cx(index === 0 && styles.searchTabActive)}>
+            {tab.label}
+          </Link>
+        ))}
+      </div>
+      <div className={styles.searchFields}>
+        {SEARCH_FIELDS.map((field) => (
+          <Link key={field.label} href="/en/smart-finder?source=v2_preview_search_field">
+            <span>{field.label}</span>
+            <strong>{field.value}</strong>
+          </Link>
+        ))}
+        <Link href="/en/smart-finder?source=v2_preview_search" className={styles.searchButton}>
+          Find buyer-fit projects
+        </Link>
+      </div>
+    </nav>
+  );
+}
+
+function V2ProjectCard({ project, priority = false }: { project: ProjectCardData; priority?: boolean }) {
+  return (
+    <Link href={project.href} className={styles.projectCard}>
+      <span className={styles.cardImage}>
+        <SafeCoverImage
+          src={project.imageSrc}
+          alt={project.imageAlt}
+          fallbackSrc="/images/project-overview.png"
+          sizes="(min-width: 1024px) 31vw, 100vw"
+          priority={priority}
+          loading="eager"
+          fetchPriority={priority ? 'high' : undefined}
+          className={styles.coverImage}
+          ssrStartWithPrimary
+        />
+      </span>
+      <span className={styles.cardBody}>
+        <span className={styles.cardKicker}>{project.location || 'Pattaya'}</span>
+        <h3>{project.name}</h3>
+        <span>{project.startingPriceLabel || 'Price on request'}</span>
+      </span>
+      <span className={styles.cardFooter}>
+        <span>{project.statusLabel || 'Availability to be confirmed'}</span>
+        <span>Request updated price list</span>
+      </span>
+    </Link>
+  );
+}
+
+function V2PropertyCard({ property }: { property: PropertyCardData }) {
+  return (
+    <Link href={property.href} className={styles.propertyCard}>
+      <span className={styles.propertyImage}>
+        <SafeCoverImage
+          src={property.imageSrc}
+          alt={property.imageAlt}
+          fallbackSrc="/images/property-exterior.png"
+          sizes="(min-width: 1024px) 24vw, 100vw"
+          loading="eager"
+          className={styles.coverImage}
+          ssrStartWithPrimary
+        />
+      </span>
+      <span className={styles.propertyCopy}>
+        <span>{property.listingType === 'rent' ? 'Rental route' : 'Buyer route'}</span>
+        <h3>{property.title}</h3>
+        <span>{property.location || 'Pattaya'} · {property.propertyType || 'Residence'}</span>
+        <em>{property.priceLabel || 'Price on request'}</em>
+      </span>
+    </Link>
   );
 }
 
@@ -69,139 +278,161 @@ function AreaCard({ area }: { area: V2PreviewAreaCard }) {
           alt={area.imageAlt}
           fallbackSrc="/images/area-guide-pattaya.png"
           sizes="(min-width: 1024px) 25vw, (min-width: 768px) 50vw, 100vw"
+          loading="eager"
           className={styles.coverImage}
           ssrStartWithPrimary
         />
       </span>
       <span className={styles.areaBody}>
-        <span className={styles.areaName}>{area.name}</span>
-        <span className={styles.areaDescription}>{area.description}</span>
-        <span className={styles.textLink}>Open area guide</span>
+        <span>{area.name}</span>
+        <small>{area.description}</small>
       </span>
     </Link>
   );
 }
 
-export function V2PreviewPage({ data }: { data: V2PreviewData }) {
-  const heroProjectNames = data.projectCards.slice(0, 3).map((project) => project.name);
+function AdvisorCta() {
+  return (
+    <section id="v2-preview-contact" className={styles.advisorSection} aria-labelledby="v2-preview-contact-title">
+      <div>
+        <p>Private recommendation</p>
+        <h2 id="v2-preview-contact-title">Request a buyer-fit Pattaya shortlist</h2>
+        <span>
+          Share the brief once. The advisor follow-up can confirm price lists, availability, quota, and viewing
+          options before you commit to a project route.
+        </span>
+      </div>
+      <div className={styles.advisorPanel}>
+        <span>Recommended next step</span>
+        <strong>Speak with a Pattaya property advisor</strong>
+        <Link href="/en/contact?source=v2_preview_advisor_cta">
+          Request private recommendation <span aria-hidden="true">&rarr;</span>
+        </Link>
+      </div>
+    </section>
+  );
+}
 
+function V2Footer() {
+  return (
+    <footer className={styles.v2Footer}>
+      <div className={styles.footerBrand}>
+        <V2Logo />
+        <p>
+          AMP Pattaya helps buyers compare homes and projects with advisor verification before price lists, quota
+          checks, and viewing plans.
+        </p>
+      </div>
+      <div className={styles.footerLinks}>
+        {FOOTER_GROUPS.map((group) => (
+          <div key={group.title}>
+            <span>{group.title}</span>
+            {group.links.map((link) => (
+              <Link key={link.label} href={link.href}>
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        ))}
+      </div>
+    </footer>
+  );
+}
+
+export function V2PreviewPage({ data }: { data: V2PreviewData }) {
   return (
     <main className={styles.page} data-testid="amp-public-v2-preview">
+      <V2Header />
+
       <section className={styles.hero} aria-labelledby="v2-preview-hero-title">
+        <SafeCoverImage
+          src={data.heroImageSrc}
+          alt={data.heroImageAlt}
+          fallbackSrc="/images/hero-banner-20260318.webp"
+          priority
+          loading="eager"
+          fetchPriority="high"
+          sizes="100vw"
+          className={cx(styles.coverImage, styles.heroBackgroundImage)}
+          ssrStartWithPrimary
+        />
+        <div className={styles.heroShade} aria-hidden="true" />
         <div className={styles.heroGrid}>
           <div className={styles.heroCopy}>
-            <p className={styles.brandLine}>AMP Pattaya</p>
-            <h1 id="v2-preview-hero-title">Find the Pattaya property that fits the way you want to live</h1>
+            <p className={styles.heroStatusPill}>
+              <span aria-hidden="true" />
+              Advisor-led search
+            </p>
+            <h1 id="v2-preview-hero-title">
+              Pattaya, priced for <em>investors who measure</em> in years, not weekends.
+            </h1>
             <p className={styles.heroLead}>
-              A calmer public search experience for buyers who need context before comparing projects, areas,
-              price lists, and private viewing options.
+              A Pattaya property advisory helping foreign buyers compare projects, resale homes, and villa options
+              before requesting current price lists, quota checks, and viewing options.
             </p>
             <div className={styles.heroActions}>
-              <Button href="#v2-preview-contact" variant="primary" className={styles.heroPrimaryCta}>
-                Speak with a Pattaya property advisor
-              </Button>
-              <Button
-                href="/en/projects?source=v2_preview_hero"
-                variant="secondary"
-                className={cx(styles.heroSecondaryCta, 'v2-preview-hero-secondary')}
-              >
-                Browse verified projects
-              </Button>
+              <Link href="/en/projects?source=v2_preview_hero" className={styles.primaryButton}>
+                Explore property routes <span aria-hidden="true">&rarr;</span>
+              </Link>
+              <Link href="/en/smart-finder?source=v2_preview_hero" className={styles.secondaryButton}>
+                90-second Smart Finder
+              </Link>
             </div>
             <dl className={styles.heroProofGrid} aria-label="Preview search assurances">
-              <div>
-                <dt>Search style</dt>
-                <dd>Advisor-led</dd>
-              </div>
-              <div>
-                <dt>Route</dt>
-                <dd>English public</dd>
-              </div>
-              <div>
-                <dt>Next step</dt>
-                <dd>Updated shortlist</dd>
-              </div>
+              {HERO_STATS.map((stat) => (
+                <div key={stat.value}>
+                  <dt>{stat.value}</dt>
+                  <dd>{stat.label}</dd>
+                </div>
+              ))}
             </dl>
           </div>
 
-          <div className={styles.heroMediaPanel} aria-label="Featured Pattaya property media">
-            <div className={styles.heroImageFrame}>
-              <SafeCoverImage
-                src={data.heroImageSrc}
-                alt={data.heroImageAlt}
-                fallbackSrc="/images/hero-banner-20260318.webp"
-                priority
-                loading="eager"
-                fetchPriority="high"
-                sizes="(min-width: 1024px) 48vw, 100vw"
-                className={styles.coverImage}
-                ssrStartWithPrimary
-              />
-            </div>
-            <div className={styles.heroAdvisorPanel}>
-              <p>Shortlist starting points</p>
-              <ul>
-                {heroProjectNames.map((name) => (
-                  <li key={name}>{name}</li>
-                ))}
-              </ul>
-            </div>
-          </div>
+          <HeroLeadCard />
         </div>
+        <HeroSearchPanel />
       </section>
 
       <section className={styles.fitSection} aria-labelledby="v2-preview-fit-title">
         <SectionHeading
           label="Buyer fit"
-          title="Start from intent, not a generic property grid"
-          body="The preview keeps the first decision simple: choose the route that matches how the buyer wants to use the property."
+          title="Start with the buyer route, then verify the facts"
+          body="Shortlist by ownership context, location fit, and advisor checks without treating price, quota, yield, or availability as confirmed until verified."
         />
         <div className={styles.fitGrid}>
           {BUYER_FIT_CARDS.map((card) => (
-            <article key={card.title} className={styles.fitCard}>
-              <h3>{card.title}</h3>
+            <Link key={card.title} href={card.href} className={styles.fitCard}>
+              <span>{card.title}</span>
               <p>{card.body}</p>
-              <Link href={card.href} className={styles.textLink}>
-                Continue this route
-              </Link>
-            </article>
+            </Link>
           ))}
         </div>
       </section>
 
       <section className={styles.projectSection} aria-labelledby="v2-preview-projects-title">
         <SectionHeading
-          label="Projects"
-          title="Project cards with safe public data"
-          body="Cards use live project data when available, and fall back to existing AMP media with neutral availability labels."
+          label="Featured projects"
+          title="Project cards with advisor-safe labels"
+          body="Real project names and media are used when available. Missing price or availability stays neutral."
         />
-        <div className={styles.cardRail}>
+        <div className={styles.projectGrid}>
           {data.projectCards.slice(0, 3).map((project, index) => (
-            <ProjectCard
-              key={project.id}
-              project={project}
-              ctaLabel="Request updated price list"
-              imagePriority={index === 0}
-              className={cx(styles.previewCard, 'v2-preview-card')}
-            />
+            <V2ProjectCard key={project.id} project={project} priority={index === 0} />
           ))}
         </div>
       </section>
 
       <section className={styles.propertySection} aria-labelledby="v2-preview-properties-title">
-        <SectionHeading
-          label="Residences"
-          title="A tighter way to scan buy and rent options"
-          body="The preview separates buyer intent from listing detail, while still sending visitors to the existing safe routes."
-        />
-        <div className={styles.cardRail}>
-          {data.propertyCards.slice(0, 3).map((property) => (
-            <PropertyCard
-              key={property.id}
-              property={property}
-              ctaLabel={property.listingType === 'rent' ? 'View rental route' : 'View buying route'}
-              className={cx(styles.previewCard, 'v2-preview-card')}
-            />
+        <div className={styles.propertyIntro}>
+          <SectionHeading
+            label="Ready routes"
+            title="Scan buyer and rental options without forcing a decision"
+            body="Cards link to existing public routes and keep commercial details neutral until an advisor confirms the current facts."
+          />
+        </div>
+        <div className={styles.propertyRail}>
+          {data.propertyCards.slice(0, 4).map((property) => (
+            <V2PropertyCard key={property.id} property={property} />
           ))}
         </div>
       </section>
@@ -209,8 +440,8 @@ export function V2PreviewPage({ data }: { data: V2PreviewData }) {
       <section className={styles.areaSection} aria-labelledby="v2-preview-areas-title">
         <SectionHeading
           label="Areas"
-          title="Choose by beach, commute, and daily rhythm"
-          body="Area cards keep the lifestyle question close to the property search without making unverified performance claims."
+          title="Choose by beach, commute, and lifestyle rhythm"
+          body="Area cards stay lifestyle-led and avoid performance claims until advisor verification is available."
           align="center"
         />
         <div className={styles.areaGrid}>
@@ -221,17 +452,15 @@ export function V2PreviewPage({ data }: { data: V2PreviewData }) {
       </section>
 
       <section className={styles.trustSection} aria-labelledby="v2-preview-trust-title">
-        <div className={styles.trustIntro}>
-          <SectionHeading
-            label="Advisor workflow"
-            title="The shortlist is only useful when the next question is clear"
-            body="The v2 foundation is designed around a human follow-up path, so buyers know what needs confirmation before a viewing or reservation conversation."
-          />
-        </div>
+        <SectionHeading
+          label="Advisor workflow"
+          title="A clearer next question before any viewing"
+          body="The preview favors buyer confidence, transparent verification, and a calmer handoff to the sales team."
+        />
         <ol className={styles.trustList}>
           {TRUST_STEPS.map((step, index) => (
-            <li key={step.title} className={styles.trustItem}>
-              <span className={styles.trustIndex}>{String(index + 1).padStart(2, '0')}</span>
+            <li key={step.title}>
+              <span>{String(index + 1).padStart(2, '0')}</span>
               <div>
                 <h3>{step.title}</h3>
                 <p>{step.body}</p>
@@ -241,41 +470,8 @@ export function V2PreviewPage({ data }: { data: V2PreviewData }) {
         </ol>
       </section>
 
-      <section id="v2-preview-contact" className={styles.contactSection} aria-labelledby="v2-preview-contact-title">
-        <div className={styles.contactCopy}>
-          <p className={styles.sectionLabel}>Lead handoff</p>
-          <h2 id="v2-preview-contact-title">Speak with a Pattaya property advisor</h2>
-          <p>
-            Share the brief once. The existing inquiry workflow can carry the route, budget, area, and timeline
-            context into advisor follow-up.
-          </p>
-          <ul className={styles.contactChecks}>
-            <li>Request updated price list</li>
-            <li>Confirm availability before viewing</li>
-            <li>Compare areas before committing</li>
-          </ul>
-        </div>
-        <div className={styles.formPanel}>
-          <LeadForm
-            locale="en"
-            formId="v2-preview-advisor"
-            heading="Speak with a Pattaya property advisor"
-            description="Tell us what you are comparing and the sales team will respond with the clearest next step."
-            submitLabel="Send brief to advisor"
-            defaultMessage="I am reviewing the AMP Public v2 preview and would like help comparing Pattaya projects, areas, and current availability."
-            defaultTimeframe="flexible"
-            inquiryIntent="project_consultation"
-            inquirySource="v2_preview"
-            inquiryTags={['v2_preview', 'english_public', 'advisor_led']}
-            contextSummary={[
-              'Source route: /en/v2-preview',
-              'Intent: advisor-led Pattaya property shortlist',
-              'Fallback labels are used when price or availability is not confirmed',
-            ]}
-            hideSupport
-          />
-        </div>
-      </section>
+      <AdvisorCta />
+      <V2Footer />
     </main>
   );
 }

--- a/admin-app/app/(site)/[locale]/v2-preview/_lib/v2-preview-data.ts
+++ b/admin-app/app/(site)/[locale]/v2-preview/_lib/v2-preview-data.ts
@@ -179,12 +179,17 @@ const FALLBACK_AREA_CARDS: V2PreviewAreaCard[] = [
   },
 ];
 
-async function resolveOrEmpty<T>(promise: Promise<T[]>): Promise<T[]> {
+async function resolveArray<T>(promise: Promise<unknown>): Promise<T[]> {
   try {
-    return await promise;
+    const value = await promise;
+    return Array.isArray(value) ? (value as T[]) : [];
   } catch {
     return [];
   }
+}
+
+function responseDataArray<T>(response: { data?: unknown } | null | undefined): T[] {
+  return Array.isArray(response?.data) ? (response.data as T[]) : [];
 }
 
 function trimString(value: unknown): string | null {
@@ -243,7 +248,9 @@ function safePropertyCard(card: V2PreviewPropertyCard): V2PreviewPropertyCard {
   };
 }
 
-function mapProjectCard(project: ProjectItem): V2PreviewProjectCard | null {
+function mapProjectCard(project: ProjectItem | null | undefined): V2PreviewProjectCard | null {
+  if (!project) return null;
+
   const source = project as ProjectItem & {
     area_name?: string | null;
     city?: string | null;
@@ -282,7 +289,9 @@ function mapProjectCard(project: ProjectItem): V2PreviewProjectCard | null {
   });
 }
 
-function mapPropertyCard(property: PropertyListItem): V2PreviewPropertyCard | null {
+function mapPropertyCard(property: PropertyListItem | null | undefined): V2PreviewPropertyCard | null {
+  if (!property) return null;
+
   const source = property as PropertyListItem & {
     area_name?: string | null;
     cover_image_url?: string | null;
@@ -318,7 +327,9 @@ function mapPropertyCard(property: PropertyListItem): V2PreviewPropertyCard | nu
   });
 }
 
-function mapAreaCard(area: AreaItem): V2PreviewAreaCard | null {
+function mapAreaCard(area: AreaItem | null | undefined): V2PreviewAreaCard | null {
+  if (!area) return null;
+
   const slug = area.slug?.trim();
   const name = area.name?.trim();
   if (!slug || !name) return null;
@@ -354,14 +365,14 @@ function pickHeroImage(projectCards: V2PreviewProjectCard[]): Pick<V2PreviewData
 
 export async function loadV2PreviewData(): Promise<V2PreviewData> {
   const [projects, saleProperties, rentProperties, areas] = await Promise.all([
-    resolveOrEmpty(fetchProjects({ limit: 12 })),
+    resolveArray<ProjectItem>(fetchProjects({ limit: 12 })),
     fetchProperties({ type: 'resale', limit: 8, sort: 'newest' })
-      .then((response) => response.data ?? [])
+      .then((response) => responseDataArray<PropertyListItem>(response))
       .catch(() => [] as PropertyListItem[]),
     fetchProperties({ type: 'rent', limit: 6, sort: 'newest' })
-      .then((response) => response.data ?? [])
+      .then((response) => responseDataArray<PropertyListItem>(response))
       .catch(() => [] as PropertyListItem[]),
-    resolveOrEmpty(fetchAreas()),
+    resolveArray<AreaItem>(fetchAreas()),
   ]);
 
   const projectCards = projects

--- a/admin-app/app/(site)/[locale]/v2-preview/_lib/v2-preview-data.ts
+++ b/admin-app/app/(site)/[locale]/v2-preview/_lib/v2-preview-data.ts
@@ -1,0 +1,265 @@
+import 'server-only';
+
+import {
+  fetchAreas,
+  fetchProjects,
+  fetchProperties,
+  type AreaItem,
+} from '@/app/_lib/public-api-server';
+import {
+  mapProjectToPublicCardData,
+  mapPropertyToPublicCardData,
+} from '@/app/_lib/public-card-mappers';
+import type { PublicProjectCardData } from '@/components/public-system/components/ProjectCard';
+import type { PublicPropertyCardData } from '@/components/public-system/components/PropertyCard';
+import type { PropertyListItem } from '@/app/public/_shared/types';
+
+const PRICE_ON_REQUEST = 'Price on request';
+const AVAILABILITY_TO_CONFIRM = 'Availability to be confirmed';
+const REQUEST_PRICE_LIST = 'Request updated price list';
+const ADVISOR_CTA = 'Speak with a Pattaya property advisor';
+
+export type V2PreviewAreaCard = {
+  id: string;
+  name: string;
+  href: string;
+  imageSrc: string;
+  imageAlt: string;
+  description: string;
+};
+
+export type V2PreviewSourceState = {
+  projectsFromApi: boolean;
+  propertiesFromApi: boolean;
+  areasFromApi: boolean;
+};
+
+export type V2PreviewData = {
+  heroImageSrc: string;
+  heroImageAlt: string;
+  projectCards: PublicProjectCardData[];
+  propertyCards: PublicPropertyCardData[];
+  areaCards: V2PreviewAreaCard[];
+  sourceState: V2PreviewSourceState;
+};
+
+const FALLBACK_PROJECT_CARDS: PublicProjectCardData[] = [
+  {
+    id: 'v2-fallback-riviera-palm-beach',
+    name: 'The Riviera Palm Beach',
+    href: '/en/projects/the-riviera-palm-beach',
+    imageSrc: '/media/import-assets/projects/the-riviera-palm-beach/asset_1789e74af538.jpg',
+    imageAlt: 'Project image for The Riviera Palm Beach in Jomtien',
+    location: 'Jomtien',
+    startingPriceLabel: PRICE_ON_REQUEST,
+    completionLabel: AVAILABILITY_TO_CONFIRM,
+    statusLabel: AVAILABILITY_TO_CONFIRM,
+    highlights: [REQUEST_PRICE_LIST, ADVISOR_CTA],
+  },
+  {
+    id: 'v2-fallback-once-wongamat',
+    name: 'Once Wongamat',
+    href: '/en/projects/once-wongamat',
+    imageSrc: '/media/import-assets/projects/once-wongamat/asset_b4ef0491685f.jpg',
+    imageAlt: 'Project image for Once Wongamat in Wongamat',
+    location: 'Wongamat',
+    startingPriceLabel: PRICE_ON_REQUEST,
+    completionLabel: AVAILABILITY_TO_CONFIRM,
+    statusLabel: AVAILABILITY_TO_CONFIRM,
+    highlights: [REQUEST_PRICE_LIST, ADVISOR_CTA],
+  },
+  {
+    id: 'v2-fallback-embassy-life',
+    name: 'Embassy Life',
+    href: '/en/projects/embassy-life',
+    imageSrc: '/media/import-assets/projects/embassy-life/asset_81006320dc6a.png',
+    imageAlt: 'Project image for Embassy Life in Pattaya',
+    location: 'Pattaya',
+    startingPriceLabel: PRICE_ON_REQUEST,
+    completionLabel: AVAILABILITY_TO_CONFIRM,
+    statusLabel: AVAILABILITY_TO_CONFIRM,
+    highlights: [REQUEST_PRICE_LIST, ADVISOR_CTA],
+  },
+];
+
+const FALLBACK_PROPERTY_CARDS: PublicPropertyCardData[] = [
+  {
+    id: 'v2-fallback-sale-jomtien',
+    title: 'Pattaya coastal condominium',
+    href: '/en/buy',
+    imageSrc: '/media/import-assets/units-buy/amp-s010126-arom-jomtien/asset_19abb0a5cf9d.jpg',
+    imageAlt: 'Pattaya coastal condominium interior',
+    location: 'Jomtien',
+    priceLabel: PRICE_ON_REQUEST,
+    listingType: 'sale',
+    propertyType: 'Condominium',
+    statusLabel: AVAILABILITY_TO_CONFIRM,
+  },
+  {
+    id: 'v2-fallback-sale-central',
+    title: 'City-view Pattaya residence',
+    href: '/en/buy',
+    imageSrc: '/media/import-assets/units-buy/amp-s010726-grand-solaire-pattaya/asset_4f131eb7400b.jpg',
+    imageAlt: 'City-view Pattaya residence interior',
+    location: 'Central Pattaya',
+    priceLabel: PRICE_ON_REQUEST,
+    listingType: 'sale',
+    propertyType: 'Condominium',
+    statusLabel: AVAILABILITY_TO_CONFIRM,
+  },
+  {
+    id: 'v2-fallback-rent-wongamat',
+    title: 'Wongamat rental residence',
+    href: '/en/rent',
+    imageSrc: '/media/import-assets/units-rent/amp-r030926-the-riviera-wongamat-beach/asset_0a4420696493.jpg',
+    imageAlt: 'Wongamat rental residence interior',
+    location: 'Wongamat',
+    priceLabel: PRICE_ON_REQUEST,
+    listingType: 'rent',
+    propertyType: 'Condominium',
+    statusLabel: AVAILABILITY_TO_CONFIRM,
+  },
+];
+
+const FALLBACK_AREA_CARDS: V2PreviewAreaCard[] = [
+  {
+    id: 'area-jomtien',
+    name: 'Jomtien',
+    href: '/en/areas/jomtien',
+    imageSrc: '/images/area-guide-pattaya.png',
+    imageAlt: 'Pattaya coastal area guide image',
+    description: 'A practical beachside route for buyers comparing lifestyle, rental use, and access to central Pattaya.',
+  },
+  {
+    id: 'area-wongamat',
+    name: 'Wongamat',
+    href: '/en/areas/wongamat',
+    imageSrc: '/images/condo-view.png',
+    imageAlt: 'Wongamat condominium view',
+    description: 'A quieter coastal fit for buyers who want a more residential feel near the sea.',
+  },
+  {
+    id: 'area-pratumnak',
+    name: 'Pratumnak',
+    href: '/en/areas/pratumnak',
+    imageSrc: '/images/property-pool.png',
+    imageAlt: 'Pratumnak property pool and residence',
+    description: 'A hillside-to-coast option for comparing privacy, access, and everyday convenience.',
+  },
+  {
+    id: 'area-central',
+    name: 'Central Pattaya',
+    href: '/en/areas/central',
+    imageSrc: '/images/property-exterior.png',
+    imageAlt: 'Central Pattaya property exterior',
+    description: 'A city-led route for buyers who prioritize transport, restaurants, and active rental demand.',
+  },
+];
+
+async function resolveOrEmpty<T>(promise: Promise<T[]>): Promise<T[]> {
+  try {
+    return await promise;
+  } catch {
+    return [];
+  }
+}
+
+function limitTextList(values: string[] | undefined, fallback: string[]): string[] {
+  const cleaned = (values ?? []).map((item) => item.trim()).filter(Boolean);
+  const source = cleaned.length ? cleaned : fallback;
+  return Array.from(new Set(source)).slice(0, 3);
+}
+
+function safeProjectCard(card: PublicProjectCardData): PublicProjectCardData {
+  return {
+    ...card,
+    startingPriceLabel: card.startingPriceLabel?.trim() || PRICE_ON_REQUEST,
+    completionLabel: card.completionLabel?.trim() || AVAILABILITY_TO_CONFIRM,
+    statusLabel: card.statusLabel?.trim() || AVAILABILITY_TO_CONFIRM,
+    highlights: limitTextList(card.highlights, [REQUEST_PRICE_LIST, ADVISOR_CTA]),
+  };
+}
+
+function safePropertyCard(card: PublicPropertyCardData): PublicPropertyCardData {
+  return {
+    ...card,
+    priceLabel: card.priceLabel?.trim() || PRICE_ON_REQUEST,
+    statusLabel: card.statusLabel?.trim() || AVAILABILITY_TO_CONFIRM,
+  };
+}
+
+function mapAreaCard(area: AreaItem): V2PreviewAreaCard | null {
+  const slug = area.slug?.trim();
+  const name = area.name?.trim();
+  if (!slug || !name) return null;
+
+  const fallback = FALLBACK_AREA_CARDS.find((item) => item.href.endsWith(`/${slug}`));
+
+  return {
+    id: area.id || `area-${slug}`,
+    name,
+    href: `/en/areas/${encodeURIComponent(slug)}`,
+    imageSrc: area.hero_image_url?.trim() || fallback?.imageSrc || '/images/area-guide-pattaya.png',
+    imageAlt: `${name} area guide image`,
+    description:
+      fallback?.description ||
+      `Compare ${name} by lifestyle fit, access, and advisor context before shortlisting properties.`,
+  };
+}
+
+function pickHeroImage(projectCards: PublicProjectCardData[]): Pick<V2PreviewData, 'heroImageSrc' | 'heroImageAlt'> {
+  const heroProject = projectCards.find((card) => card.imageSrc?.startsWith('/images/') && card.imageSrc !== '/images/project-overview.png');
+  if (heroProject) {
+    return {
+      heroImageSrc: heroProject.imageSrc,
+      heroImageAlt: heroProject.imageAlt,
+    };
+  }
+
+  return {
+    heroImageSrc: '/images/hero-banner-20260318.webp',
+    heroImageAlt: 'Luxury Pattaya property view',
+  };
+}
+
+export async function loadV2PreviewData(): Promise<V2PreviewData> {
+  const [projects, saleProperties, rentProperties, areas] = await Promise.all([
+    resolveOrEmpty(fetchProjects({ limit: 12 })),
+    fetchProperties({ type: 'resale', limit: 8, sort: 'newest' })
+      .then((response) => response.data ?? [])
+      .catch(() => [] as PropertyListItem[]),
+    fetchProperties({ type: 'rent', limit: 6, sort: 'newest' })
+      .then((response) => response.data ?? [])
+      .catch(() => [] as PropertyListItem[]),
+    resolveOrEmpty(fetchAreas()),
+  ]);
+
+  const projectCards = projects
+    .map((project) => safeProjectCard(mapProjectToPublicCardData(project, { locale: 'en' })))
+    .slice(0, 6);
+
+  const propertyCards = [...saleProperties.slice(0, 3), ...rentProperties.slice(0, 3)]
+    .map((property) => safePropertyCard(mapPropertyToPublicCardData(property, { locale: 'en' })))
+    .slice(0, 6);
+
+  const areaCards = areas
+    .map(mapAreaCard)
+    .filter((area): area is V2PreviewAreaCard => Boolean(area))
+    .slice(0, 4);
+
+  const resolvedProjectCards = projectCards.length ? projectCards : FALLBACK_PROJECT_CARDS;
+  const resolvedPropertyCards = propertyCards.length ? propertyCards : FALLBACK_PROPERTY_CARDS;
+  const resolvedAreaCards = areaCards.length ? areaCards : FALLBACK_AREA_CARDS;
+
+  return {
+    ...pickHeroImage(resolvedProjectCards),
+    projectCards: resolvedProjectCards,
+    propertyCards: resolvedPropertyCards,
+    areaCards: resolvedAreaCards,
+    sourceState: {
+      projectsFromApi: projectCards.length > 0,
+      propertiesFromApi: propertyCards.length > 0,
+      areasFromApi: areaCards.length > 0,
+    },
+  };
+}

--- a/admin-app/app/(site)/[locale]/v2-preview/_lib/v2-preview-data.ts
+++ b/admin-app/app/(site)/[locale]/v2-preview/_lib/v2-preview-data.ts
@@ -5,13 +5,10 @@ import {
   fetchProjects,
   fetchProperties,
   type AreaItem,
+  type ProjectItem,
 } from '@/app/_lib/public-api-server';
-import {
-  mapProjectToPublicCardData,
-  mapPropertyToPublicCardData,
-} from '@/app/_lib/public-card-mappers';
-import type { PublicProjectCardData } from '@/components/public-system/components/ProjectCard';
-import type { PublicPropertyCardData } from '@/components/public-system/components/PropertyCard';
+import { pickRenderableLocalMedia } from '@/app/_lib/local-media';
+import { pickCoverImage } from '@/app/_lib/public-api-shared';
 import type { PropertyListItem } from '@/app/public/_shared/types';
 
 const PRICE_ON_REQUEST = 'Price on request';
@@ -28,6 +25,32 @@ export type V2PreviewAreaCard = {
   description: string;
 };
 
+export type V2PreviewProjectCard = {
+  id: string;
+  name: string;
+  href: string;
+  imageSrc: string;
+  imageAlt: string;
+  location: string;
+  startingPriceLabel: string;
+  completionLabel: string;
+  statusLabel: string;
+  highlights: string[];
+};
+
+export type V2PreviewPropertyCard = {
+  id: string;
+  title: string;
+  href: string;
+  imageSrc: string;
+  imageAlt: string;
+  location: string;
+  priceLabel: string;
+  listingType: 'sale' | 'rent';
+  propertyType: string;
+  statusLabel: string;
+};
+
 export type V2PreviewSourceState = {
   projectsFromApi: boolean;
   propertiesFromApi: boolean;
@@ -37,13 +60,13 @@ export type V2PreviewSourceState = {
 export type V2PreviewData = {
   heroImageSrc: string;
   heroImageAlt: string;
-  projectCards: PublicProjectCardData[];
-  propertyCards: PublicPropertyCardData[];
+  projectCards: V2PreviewProjectCard[];
+  propertyCards: V2PreviewPropertyCard[];
   areaCards: V2PreviewAreaCard[];
   sourceState: V2PreviewSourceState;
 };
 
-const FALLBACK_PROJECT_CARDS: PublicProjectCardData[] = [
+const FALLBACK_PROJECT_CARDS: V2PreviewProjectCard[] = [
   {
     id: 'v2-fallback-riviera-palm-beach',
     name: 'The Riviera Palm Beach',
@@ -69,12 +92,12 @@ const FALLBACK_PROJECT_CARDS: PublicProjectCardData[] = [
     highlights: [REQUEST_PRICE_LIST, ADVISOR_CTA],
   },
   {
-    id: 'v2-fallback-embassy-life',
-    name: 'Embassy Life',
-    href: '/en/projects/embassy-life',
-    imageSrc: '/media/import-assets/projects/embassy-life/asset_81006320dc6a.png',
-    imageAlt: 'Project image for Embassy Life in Pattaya',
-    location: 'Pattaya',
+    id: 'v2-fallback-wyndham-jomtien',
+    name: 'Wyndham Jomtien Pattaya',
+    href: '/en/projects/wyndham-jomtien-pattaya',
+    imageSrc: '/media/import-assets/projects/wyndham-jomtien-pattaya/asset_f20721152575.jpg',
+    imageAlt: 'Project image for Wyndham Jomtien Pattaya in Jomtien',
+    location: 'Jomtien',
     startingPriceLabel: PRICE_ON_REQUEST,
     completionLabel: AVAILABILITY_TO_CONFIRM,
     statusLabel: AVAILABILITY_TO_CONFIRM,
@@ -82,12 +105,12 @@ const FALLBACK_PROJECT_CARDS: PublicProjectCardData[] = [
   },
 ];
 
-const FALLBACK_PROPERTY_CARDS: PublicPropertyCardData[] = [
+const FALLBACK_PROPERTY_CARDS: V2PreviewPropertyCard[] = [
   {
     id: 'v2-fallback-sale-jomtien',
     title: 'Pattaya coastal condominium',
     href: '/en/buy',
-    imageSrc: '/media/import-assets/units-buy/amp-s010126-arom-jomtien/asset_19abb0a5cf9d.jpg',
+    imageSrc: '/media/import-assets/units-buy/amp-s010126-arom-jomtien/asset_ee3843fba37d.jpg',
     imageAlt: 'Pattaya coastal condominium interior',
     location: 'Jomtien',
     priceLabel: PRICE_ON_REQUEST,
@@ -99,7 +122,7 @@ const FALLBACK_PROPERTY_CARDS: PublicPropertyCardData[] = [
     id: 'v2-fallback-sale-central',
     title: 'City-view Pattaya residence',
     href: '/en/buy',
-    imageSrc: '/media/import-assets/units-buy/amp-s010726-grand-solaire-pattaya/asset_4f131eb7400b.jpg',
+    imageSrc: '/media/import-assets/units-buy/resale-en-condo-for-sale-3457/asset_3271c159a374.jpg',
     imageAlt: 'City-view Pattaya residence interior',
     location: 'Central Pattaya',
     priceLabel: PRICE_ON_REQUEST,
@@ -109,14 +132,14 @@ const FALLBACK_PROPERTY_CARDS: PublicPropertyCardData[] = [
   },
   {
     id: 'v2-fallback-rent-wongamat',
-    title: 'Wongamat rental residence',
+    title: 'Pattaya rental residence',
     href: '/en/rent',
-    imageSrc: '/media/import-assets/units-rent/amp-r030926-the-riviera-wongamat-beach/asset_0a4420696493.jpg',
-    imageAlt: 'Wongamat rental residence interior',
-    location: 'Wongamat',
+    imageSrc: '/media/import-assets/units-rent/rent-en-villa-for-rent-3400/asset_5c40f79016c9.jpg',
+    imageAlt: 'Pattaya rental residence exterior',
+    location: 'Pattaya',
     priceLabel: PRICE_ON_REQUEST,
     listingType: 'rent',
-    propertyType: 'Condominium',
+    propertyType: 'Residence',
     statusLabel: AVAILABILITY_TO_CONFIRM,
   },
 ];
@@ -126,7 +149,7 @@ const FALLBACK_AREA_CARDS: V2PreviewAreaCard[] = [
     id: 'area-jomtien',
     name: 'Jomtien',
     href: '/en/areas/jomtien',
-    imageSrc: '/images/area-guide-pattaya.png',
+    imageSrc: '/media/import-assets/projects/the-riviera-palm-beach/asset_1789e74af538.jpg',
     imageAlt: 'Pattaya coastal area guide image',
     description: 'A practical beachside route for buyers comparing lifestyle, rental use, and access to central Pattaya.',
   },
@@ -134,7 +157,7 @@ const FALLBACK_AREA_CARDS: V2PreviewAreaCard[] = [
     id: 'area-wongamat',
     name: 'Wongamat',
     href: '/en/areas/wongamat',
-    imageSrc: '/images/condo-view.png',
+    imageSrc: '/media/import-assets/projects/once-wongamat/asset_b4ef0491685f.jpg',
     imageAlt: 'Wongamat condominium view',
     description: 'A quieter coastal fit for buyers who want a more residential feel near the sea.',
   },
@@ -142,7 +165,7 @@ const FALLBACK_AREA_CARDS: V2PreviewAreaCard[] = [
     id: 'area-pratumnak',
     name: 'Pratumnak',
     href: '/en/areas/pratumnak',
-    imageSrc: '/images/property-pool.png',
+    imageSrc: '/media/import-assets/units-buy/resale-en-condo-for-sale-1904/asset_60a7db9f5d72.jpg',
     imageAlt: 'Pratumnak property pool and residence',
     description: 'A hillside-to-coast option for comparing privacy, access, and everyday convenience.',
   },
@@ -150,7 +173,7 @@ const FALLBACK_AREA_CARDS: V2PreviewAreaCard[] = [
     id: 'area-central',
     name: 'Central Pattaya',
     href: '/en/areas/central',
-    imageSrc: '/images/property-exterior.png',
+    imageSrc: '/media/import-assets/units-buy/resale-en-condo-for-sale-3389/asset_5a44ec786f49.jpg',
     imageAlt: 'Central Pattaya property exterior',
     description: 'A city-led route for buyers who prioritize transport, restaurants, and active rental demand.',
   },
@@ -164,13 +187,45 @@ async function resolveOrEmpty<T>(promise: Promise<T[]>): Promise<T[]> {
   }
 }
 
+function trimString(value: unknown): string | null {
+  const trimmed = typeof value === 'string' || typeof value === 'number'
+    ? String(value).trim()
+    : '';
+  return trimmed || null;
+}
+
+function firstText(...values: unknown[]): string | null {
+  for (const value of values) {
+    const trimmed = trimString(value);
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function cleanPropertyTitle(raw: string): string {
+  return raw
+    .replace(/\s*-\s*#[A-Z0-9]+\s*\|\s*\w+$/i, '')
+    .replace(/\s*\|\s*Renthai$/i, '')
+    .trim() || raw;
+}
+
+function humanizeToken(value: unknown): string | null {
+  const trimmed = trimString(value);
+  if (!trimmed) return null;
+  return trimmed
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
 function limitTextList(values: string[] | undefined, fallback: string[]): string[] {
   const cleaned = (values ?? []).map((item) => item.trim()).filter(Boolean);
   const source = cleaned.length ? cleaned : fallback;
   return Array.from(new Set(source)).slice(0, 3);
 }
 
-function safeProjectCard(card: PublicProjectCardData): PublicProjectCardData {
+function safeProjectCard(card: V2PreviewProjectCard): V2PreviewProjectCard {
   return {
     ...card,
     startingPriceLabel: card.startingPriceLabel?.trim() || PRICE_ON_REQUEST,
@@ -180,12 +235,87 @@ function safeProjectCard(card: PublicProjectCardData): PublicProjectCardData {
   };
 }
 
-function safePropertyCard(card: PublicPropertyCardData): PublicPropertyCardData {
+function safePropertyCard(card: V2PreviewPropertyCard): V2PreviewPropertyCard {
   return {
     ...card,
     priceLabel: card.priceLabel?.trim() || PRICE_ON_REQUEST,
     statusLabel: card.statusLabel?.trim() || AVAILABILITY_TO_CONFIRM,
   };
+}
+
+function mapProjectCard(project: ProjectItem): V2PreviewProjectCard | null {
+  const source = project as ProjectItem & {
+    area_name?: string | null;
+    city?: string | null;
+    cover_image?: string | null;
+    imageAlt?: string | null;
+    image_url?: string | null;
+    location?: string | null;
+    status_label?: string | null;
+    title?: string | null;
+  };
+  const slug = trimString(project.slug);
+  const name = firstText(project.name, source.title);
+
+  if (!slug || !name) return null;
+
+  const location = firstText(source.location, project.area?.name, source.area_name, source.city) ?? 'Pattaya';
+  const imageSrc = pickRenderableLocalMedia({
+    cover_image: source.cover_image ?? null,
+    cover_image_url: project.cover_image_url ?? null,
+    hero_image_url: project.hero_image_url ?? null,
+    image_url: source.image_url ?? null,
+    images: project.images ?? null,
+  }) ?? '/images/project-overview.png';
+
+  return safeProjectCard({
+    id: firstText(project.id) ?? `project-${slug}`,
+    name,
+    href: `/en/projects/${encodeURIComponent(slug)}`,
+    imageSrc,
+    imageAlt: firstText(source.imageAlt) ?? `Project image for ${name} in ${location}`,
+    location,
+    startingPriceLabel: PRICE_ON_REQUEST,
+    completionLabel: AVAILABILITY_TO_CONFIRM,
+    statusLabel: AVAILABILITY_TO_CONFIRM,
+    highlights: [REQUEST_PRICE_LIST, ADVISOR_CTA],
+  });
+}
+
+function mapPropertyCard(property: PropertyListItem): V2PreviewPropertyCard | null {
+  const source = property as PropertyListItem & {
+    area_name?: string | null;
+    cover_image_url?: string | null;
+    imageAlt?: string | null;
+    image_url?: string | null;
+    location?: string | null;
+  };
+  const slug = trimString(property.slug);
+  const title = firstText(property.title);
+
+  if (!title) return null;
+
+  const listingType = String(property.type ?? '').trim().toLowerCase() === 'rent' ? 'rent' : 'sale';
+  const location = firstText(source.location, property.address, property.city, source.area_name) ?? 'Pattaya';
+  const fallbackHref = listingType === 'rent' ? '/en/rent' : '/en/buy';
+  const imageSrc = pickCoverImage({
+    cover_image: property.cover_image ?? source.cover_image_url ?? source.image_url ?? null,
+    local_images: property.local_images ?? null,
+    images: property.images ?? null,
+  }) ?? '/images/property-exterior.png';
+
+  return safePropertyCard({
+    id: firstText(property.id, property.source_id, slug) ?? `property-${listingType}`,
+    title: cleanPropertyTitle(title),
+    href: slug ? `/en/property/${encodeURIComponent(slug)}` : fallbackHref,
+    imageSrc,
+    imageAlt: firstText(source.imageAlt) ?? `${cleanPropertyTitle(title)} in ${location}`,
+    location,
+    priceLabel: PRICE_ON_REQUEST,
+    listingType,
+    propertyType: humanizeToken(property.property_type) ?? 'Residence',
+    statusLabel: AVAILABILITY_TO_CONFIRM,
+  });
 }
 
 function mapAreaCard(area: AreaItem): V2PreviewAreaCard | null {
@@ -207,7 +337,7 @@ function mapAreaCard(area: AreaItem): V2PreviewAreaCard | null {
   };
 }
 
-function pickHeroImage(projectCards: PublicProjectCardData[]): Pick<V2PreviewData, 'heroImageSrc' | 'heroImageAlt'> {
+function pickHeroImage(projectCards: V2PreviewProjectCard[]): Pick<V2PreviewData, 'heroImageSrc' | 'heroImageAlt'> {
   const heroProject = projectCards.find((card) => card.imageSrc?.startsWith('/images/') && card.imageSrc !== '/images/project-overview.png');
   if (heroProject) {
     return {
@@ -235,11 +365,13 @@ export async function loadV2PreviewData(): Promise<V2PreviewData> {
   ]);
 
   const projectCards = projects
-    .map((project) => safeProjectCard(mapProjectToPublicCardData(project, { locale: 'en' })))
+    .map(mapProjectCard)
+    .filter((project): project is V2PreviewProjectCard => Boolean(project))
     .slice(0, 6);
 
   const propertyCards = [...saleProperties.slice(0, 3), ...rentProperties.slice(0, 3)]
-    .map((property) => safePropertyCard(mapPropertyToPublicCardData(property, { locale: 'en' })))
+    .map(mapPropertyCard)
+    .filter((property): property is V2PreviewPropertyCard => Boolean(property))
     .slice(0, 6);
 
   const areaCards = areas

--- a/admin-app/app/(site)/[locale]/v2-preview/page.tsx
+++ b/admin-app/app/(site)/[locale]/v2-preview/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { loadV2PreviewData } from './_lib/v2-preview-data';
+import { V2PreviewPage } from './_components/V2PreviewPage';
+
+export const revalidate = 300;
+
+type PageProps = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  await params;
+
+  return {
+    title: 'AMP Public v2 Preview | AMP Pattaya',
+    description: 'English-only AMP Pattaya public frontend preview for advisor-led property discovery.',
+    alternates: {
+      canonical: '/en/v2-preview',
+    },
+    robots: {
+      index: false,
+      follow: false,
+      googleBot: {
+        index: false,
+        follow: false,
+      },
+    },
+    openGraph: {
+      title: 'AMP Public v2 Preview | AMP Pattaya',
+      description: 'English-only AMP Pattaya public frontend preview for advisor-led property discovery.',
+      url: '/en/v2-preview',
+      type: 'website',
+      locale: 'en_US',
+      siteName: 'AMP Pattaya',
+    },
+  };
+}
+
+export default async function AmpPublicV2PreviewPage({ params }: PageProps) {
+  const { locale } = await params;
+
+  if (locale !== 'en') {
+    notFound();
+  }
+
+  const data = await loadV2PreviewData();
+  return <V2PreviewPage data={data} />;
+}

--- a/admin-app/app/(site)/[locale]/v2-preview/v2-preview.module.css
+++ b/admin-app/app/(site)/[locale]/v2-preview/v2-preview.module.css
@@ -1,192 +1,643 @@
+:global(body):has(.page) :global(.site-header.header),
+:global(body):has(.page) :global(.site-footer.footer) {
+  display: none !important;
+}
+
 .page {
-  background:
-    linear-gradient(180deg, #ffffff 0%, #f7f3ea 36%, #ffffff 68%, #f6efe0 100%);
-  color: var(--public-color-ink);
+  --v2-bg: #101c18;
+  --v2-bg-2: #17241f;
+  --v2-ink: #fffaf0;
+  --v2-muted: rgba(255, 250, 240, 0.68);
+  --v2-paper: #fff8ed;
+  --v2-paper-2: #f4eadb;
+  --v2-line: rgba(255, 250, 240, 0.16);
+  --v2-coral: #e46b4f;
+  --v2-coral-2: #f07c5d;
+  --v2-gold: #dfbf89;
+  min-height: 100vh;
+  background: #f7efe1;
+  color: #14201f;
   overflow-x: clip;
 }
 
+.v2Header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: minmax(180px, 0.8fr) minmax(0, 1.1fr) auto;
+  gap: 22px;
+  align-items: center;
+  min-height: 70px;
+  padding: 10px clamp(18px, 4vw, 64px);
+  border-bottom: 1px solid rgba(255, 250, 240, 0.09);
+  background: #14221d;
+  color: var(--v2-ink);
+}
+
+.logoLink,
+.logo {
+  color: inherit;
+  text-decoration: none;
+}
+
+.logo {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+}
+
+.logoMark {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 250, 240, 0.66);
+  border-radius: 7px;
+  color: var(--v2-ink);
+  font-size: 0.86rem;
+}
+
+.logoCopy {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.logoCopy span {
+  color: var(--v2-ink);
+  font-family: var(--font-serif), Georgia, 'Times New Roman', serif;
+  font-size: clamp(1.12rem, 1.45vw, 1.45rem);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.logoCopy em {
+  font-style: italic;
+}
+
+.logoCopy small {
+  overflow: hidden;
+  color: rgba(255, 250, 240, 0.66);
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1.1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.v2Nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(10px, 1.6vw, 24px);
+}
+
+.v2Nav a,
+.headerActions a,
+.mobileMenuPanel a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.v2Nav a {
+  color: rgba(255, 250, 240, 0.86);
+  font-size: 0.9rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.v2Nav a:hover,
+.v2Nav a:focus-visible {
+  color: #ffffff;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.headerPill {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  border: 1px solid rgba(255, 250, 240, 0.16);
+  border-radius: 999px;
+  padding: 0 13px;
+  color: rgba(255, 250, 240, 0.9);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.headerCta,
+.primaryButton,
+.heroFormButton,
+.searchButton,
+.advisorPanel a,
+.mobileMenuCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--v2-coral);
+  color: #ffffff;
+  font-weight: 900;
+  text-align: center;
+  text-decoration: none;
+}
+
+.headerCta {
+  min-height: 44px;
+  padding: 0 22px;
+  white-space: nowrap;
+}
+
+.headerCta:hover,
+.primaryButton:hover,
+.heroFormButton:hover,
+.searchButton:hover,
+.advisorPanel a:hover,
+.mobileMenuCta:hover,
+.headerCta:focus-visible,
+.primaryButton:focus-visible,
+.heroFormButton:focus-visible,
+.searchButton:focus-visible,
+.advisorPanel a:focus-visible,
+.mobileMenuCta:focus-visible {
+  background: var(--v2-coral-2);
+  color: #ffffff;
+}
+
+.mobileMenu {
+  display: none;
+  position: relative;
+  justify-self: end;
+}
+
+.mobileMenu summary {
+  display: inline-grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 1px solid rgba(255, 250, 240, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  list-style: none;
+}
+
+.mobileMenu summary::-webkit-details-marker {
+  display: none;
+}
+
+.mobileMenu summary span {
+  width: 18px;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(255, 250, 240, 0.84);
+}
+
+.mobileMenuPanel {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  display: grid;
+  width: min(78vw, 320px);
+  gap: 6px;
+  border: 1px solid rgba(255, 250, 240, 0.14);
+  border-radius: 8px;
+  background: #16251f;
+  padding: 14px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.32);
+}
+
+.mobileMenuPanel a {
+  border-radius: 8px;
+  padding: 12px 14px;
+  color: rgba(255, 250, 240, 0.86);
+  font-weight: 800;
+}
+
+.mobileMenuPanel a:hover,
+.mobileMenuPanel a:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+}
+
+.mobileMenuPanel .mobileMenuCta {
+  margin-top: 8px;
+  color: #ffffff;
+}
+
 .hero {
-  background: #0f2f2f;
-  color: #fffaf0;
-  padding: 56px var(--public-container-gutter-mobile) 40px;
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  background: var(--v2-bg);
+  color: var(--v2-ink);
+  padding: clamp(42px, 5vw, 72px) clamp(18px, 4vw, 64px) 0;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  inset: auto 0 0;
+  height: 36%;
+  background: linear-gradient(180deg, transparent, rgba(10, 19, 16, 0.96));
+  pointer-events: none;
 }
 
 .heroGrid {
+  position: relative;
+  z-index: 1;
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 32px;
-  max-width: 1280px;
-  margin: 0 auto;
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 460px);
+  gap: clamp(28px, 5vw, 76px);
+  max-width: 1296px;
+  min-height: 604px;
   align-items: center;
-}
-
-.heroCopy {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  min-width: 0;
-}
-
-.brandLine {
-  margin: 0;
-  color: #f0d4a1;
-  font-size: 0.92rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.heroCopy h1 {
-  margin: 0;
-  max-width: 780px;
-  color: #fffaf0;
-  font-family: var(--public-font-family-title);
-  font-size: 2.8rem;
-  font-weight: 700;
-  line-height: 1.04;
-  letter-spacing: 0;
-}
-
-.heroLead {
-  max-width: 640px;
-  margin: 0;
-  color: rgba(255, 250, 240, 0.82);
-  font-size: 1.08rem;
-  line-height: 1.7;
-}
-
-.heroActions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.heroPrimaryCta,
-.heroSecondaryCta {
-  min-height: 48px;
-  white-space: normal;
-}
-
-.heroSecondaryCta {
-  border-color: rgba(240, 212, 161, 0.32);
-  background: rgba(255, 255, 255, 0.06);
-  color: #fffaf0;
-}
-
-.heroSecondaryCta:hover,
-.heroSecondaryCta:focus-visible {
-  border-color: rgba(240, 212, 161, 0.54);
-  background: rgba(255, 255, 255, 0.12);
-  color: #fffaf0;
-}
-
-.page :global(.v2-preview-hero-secondary.btn-secondary) {
-  border-color: rgba(240, 212, 161, 0.36) !important;
-  background: rgba(255, 255, 255, 0.08) !important;
-  color: #fffaf0 !important;
-}
-
-.page :global(.v2-preview-hero-secondary.btn-secondary:hover),
-.page :global(.v2-preview-hero-secondary.btn-secondary:focus-visible) {
-  border-color: rgba(240, 212, 161, 0.58) !important;
-  background: rgba(255, 255, 255, 0.14) !important;
-  color: #fffaf0 !important;
-}
-
-.heroProofGrid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
-  max-width: 680px;
-  margin: 4px 0 0;
-}
-
-.heroProofGrid div {
-  min-width: 0;
-  border: 1px solid rgba(240, 212, 161, 0.28);
-  background: rgba(255, 255, 255, 0.06);
-  padding: 16px;
-}
-
-.heroProofGrid dt {
-  color: rgba(255, 250, 240, 0.64);
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.heroProofGrid dd {
-  margin: 7px 0 0;
-  color: #fffaf0;
-  font-size: 1rem;
-  font-weight: 700;
-}
-
-.heroMediaPanel {
-  position: relative;
-  min-width: 0;
-}
-
-.heroImageFrame {
-  position: relative;
-  overflow: hidden;
-  min-height: 360px;
-  border: 1px solid rgba(240, 212, 161, 0.34);
-  background: #183f3d;
-  box-shadow: 0 32px 70px rgba(0, 0, 0, 0.34);
+  margin: 0 auto;
 }
 
 .coverImage {
   object-fit: cover;
 }
 
-.heroAdvisorPanel {
-  position: relative;
-  width: min(88%, 420px);
-  margin: -76px 20px 0 auto;
-  border: 1px solid rgba(240, 212, 161, 0.34);
-  background: rgba(15, 47, 47, 0.92);
-  padding: 20px;
-  color: #fffaf0;
-  box-shadow: 0 22px 46px rgba(0, 0, 0, 0.28);
+.heroBackgroundImage {
+  z-index: -3;
+  object-position: center;
+  filter: brightness(0.42) contrast(1.06) saturate(0.9);
+  transform: scale(1.02);
 }
 
-.heroAdvisorPanel p {
-  margin: 0 0 12px;
-  color: #f0d4a1;
-  font-size: 0.86rem;
-  font-weight: 700;
+.heroShade {
+  position: absolute;
+  z-index: -2;
+  inset: 0;
+  background:
+    radial-gradient(circle at 84% 24%, rgba(255, 250, 240, 0.22), transparent 0 13%, transparent 34%),
+    linear-gradient(90deg, rgba(8, 17, 14, 0.94) 0%, rgba(15, 22, 19, 0.76) 46%, rgba(8, 17, 14, 0.9) 100%),
+    linear-gradient(180deg, rgba(12, 22, 19, 0.16) 0%, rgba(9, 19, 16, 0.72) 100%);
+  pointer-events: none;
 }
 
-.heroAdvisorPanel ul {
-  display: grid;
+.heroCopy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: clamp(18px, 2vw, 24px);
+  padding-bottom: clamp(44px, 5vw, 72px);
+}
+
+.heroStatusPill {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
   gap: 8px;
   margin: 0;
-  padding: 0;
-  list-style: none;
+  border: 1px solid rgba(255, 250, 240, 0.2);
+  border-radius: 999px;
+  background: rgba(21, 28, 25, 0.58);
+  padding: 8px 13px;
+  color: rgba(255, 250, 240, 0.88);
+  font-size: 0.78rem;
+  font-weight: 800;
+  line-height: 1;
+  backdrop-filter: blur(10px);
 }
 
-.heroAdvisorPanel li {
-  border-top: 1px solid rgba(255, 250, 240, 0.16);
-  padding-top: 8px;
+.heroStatusPill span {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--v2-coral);
+  box-shadow: 0 0 0 4px rgba(228, 107, 79, 0.16);
+}
+
+.heroCopy h1 {
+  max-width: 790px;
+  margin: 0;
+  color: var(--v2-ink);
+  font-family: var(--font-serif), Georgia, 'Times New Roman', serif;
+  font-size: clamp(3.2rem, 6.4vw, 5.9rem);
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 0.92;
+  text-wrap: balance;
+}
+
+.heroCopy h1 em {
+  color: var(--v2-gold);
+  font-style: italic;
+  font-weight: 400;
+}
+
+.heroLead {
+  max-width: 690px;
+  margin: 0;
+  color: rgba(255, 250, 240, 0.84);
+  font-size: clamp(1rem, 1.2vw, 1.14rem);
+  line-height: 1.62;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 6px;
+}
+
+.primaryButton,
+.secondaryButton {
+  min-height: 52px;
+  padding: 0 26px;
+  gap: 10px;
+}
+
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 250, 240, 0.24);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--v2-ink);
+  font-weight: 900;
+  text-align: center;
+  text-decoration: none;
+  backdrop-filter: blur(12px);
+}
+
+.secondaryButton:hover,
+.secondaryButton:focus-visible {
+  border-color: rgba(255, 250, 240, 0.42);
+  background: rgba(255, 255, 255, 0.14);
+  color: #ffffff;
+}
+
+.heroProofGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: clamp(16px, 3vw, 38px);
+  max-width: 760px;
+  margin: clamp(18px, 3vw, 28px) 0 0;
+  border-top: 1px solid rgba(255, 250, 240, 0.18);
+  padding-top: clamp(18px, 2.4vw, 26px);
+}
+
+.heroProofGrid dt {
+  color: var(--v2-ink);
+  font-family: var(--font-serif), Georgia, 'Times New Roman', serif;
+  font-size: clamp(1.45rem, 2.4vw, 2.1rem);
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.heroProofGrid dd {
+  margin: 7px 0 0;
+  color: rgba(255, 250, 240, 0.64);
+  font-size: 0.82rem;
+  line-height: 1.3;
+}
+
+.heroLeadCard {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  border: 1px solid rgba(255, 250, 240, 0.16);
+  border-radius: 8px;
+  background: linear-gradient(180deg, rgba(31, 38, 35, 0.9), rgba(15, 27, 24, 0.92));
+  padding: clamp(22px, 2.4vw, 28px);
+  color: var(--v2-ink);
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.34);
+  backdrop-filter: blur(18px);
+}
+
+.heroLeadCardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.heroLeadCardHeader p,
+.sectionHeading p,
+.advisorSection p,
+.footerLinks span {
+  margin: 0;
+  font-family: var(--public-type-mono-family);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
   line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.heroLeadCardHeader p {
+  color: rgba(255, 250, 240, 0.54);
+}
+
+.heroLeadCardHeader span {
+  color: rgba(255, 250, 240, 0.58);
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.heroLeadCardHeader span::before,
+.advisorPanel span::before {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 6px;
+  border-radius: 999px;
+  background: #2fc96b;
+  vertical-align: 1px;
+}
+
+.heroLeadCard h2,
+.advisorPanel strong {
+  margin: 0;
+  color: var(--v2-ink);
+  font-family: var(--font-serif), Georgia, 'Times New Roman', serif;
+  font-size: clamp(1.5rem, 2vw, 1.9rem);
+  font-weight: 400;
+  line-height: 1.05;
+}
+
+.heroVisualForm {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.heroVisualForm span {
+  display: flex;
+  min-height: 46px;
+  min-width: 0;
+  align-items: center;
+  border: 1px solid rgba(255, 250, 240, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0 14px;
+  color: rgba(255, 250, 240, 0.66);
+  font-size: 0.9rem;
+  line-height: 1.25;
+}
+
+.heroVisualForm .visualInputWide {
+  grid-column: 1 / -1;
+}
+
+.heroConsentLine {
+  margin: 14px 0 16px;
+  color: rgba(255, 250, 240, 0.78);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.heroConsentLine::before {
+  content: '';
+  display: inline-block;
+  width: 11px;
+  height: 6px;
+  margin-right: 9px;
+  border-bottom: 1px solid var(--v2-ink);
+  border-left: 1px solid var(--v2-ink);
+  transform: rotate(-45deg) translateY(-2px);
+}
+
+.heroFormButton {
+  width: 100%;
+  min-height: 52px;
+}
+
+.heroFinePrint {
+  margin: 14px 0 0;
+  color: rgba(255, 250, 240, 0.46);
+  font-family: var(--font-serif), Georgia, 'Times New Roman', serif;
+  font-size: 0.76rem;
+  text-align: center;
+}
+
+.heroSearchPanel {
+  position: relative;
+  z-index: 2;
+  max-width: 1296px;
+  margin: 0 auto;
+  border: 1px solid rgba(25, 32, 29, 0.08);
+  border-radius: 8px 8px 0 0;
+  background: var(--v2-paper);
+  box-shadow: 0 -12px 42px rgba(10, 20, 17, 0.18);
+  transform: translateY(1px);
+}
+
+.searchTabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 14px 20px 8px;
+}
+
+.searchTabs a {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 16px;
+  color: #6e746d;
+  font-size: 0.9rem;
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.searchTabs a:hover,
+.searchTabs a:focus-visible {
+  color: #14201f;
+}
+
+.searchTabs .searchTabActive {
+  background: #12221e;
+  color: #ffffff;
+}
+
+.searchFields {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr)) minmax(190px, 0.76fr);
+  align-items: stretch;
+  border-top: 1px solid #ece3d3;
+}
+
+.searchFields a {
+  display: grid;
+  min-width: 0;
+  gap: 7px;
+  border-right: 1px solid #ece3d3;
+  padding: 18px 20px;
+  color: #14201f;
+  text-decoration: none;
+}
+
+.searchFields a span {
+  color: #9a9d97;
+  font-family: var(--public-type-mono-family);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.searchFields a strong {
+  min-width: 0;
+  overflow: hidden;
+  color: #333d39;
+  font-size: 0.95rem;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.searchFields a:hover strong,
+.searchFields a:focus-visible strong {
+  color: var(--v2-coral);
+}
+
+.searchFields .searchButton {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  margin: 12px;
+  border: 0;
+  padding: 0 18px;
+  color: #ffffff;
+  font-size: 0.9rem;
+  white-space: normal;
 }
 
 .fitSection,
 .projectSection,
 .propertySection,
-.areaSection,
 .trustSection,
-.contactSection {
-  max-width: 1280px;
+.advisorSection {
+  max-width: 1296px;
   margin: 0 auto;
-  padding: 72px var(--public-container-gutter-mobile);
+  padding: clamp(70px, 8vw, 112px) clamp(18px, 4vw, 64px);
 }
 
 .sectionHeading {
   max-width: 760px;
-  margin-bottom: 32px;
+  margin-bottom: 34px;
 }
 
 .sectionHeadingCenter {
@@ -195,31 +646,31 @@
   text-align: center;
 }
 
-.sectionLabel {
-  margin: 0 0 10px;
-  color: var(--public-color-coral-2);
-  font-size: 0.84rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
+.sectionHeading p,
+.advisorSection p,
+.footerLinks span {
+  color: var(--v2-coral);
 }
 
 .sectionHeading h2,
-.contactCopy h2 {
+.advisorSection h2 {
   margin: 0;
-  color: var(--public-color-ink);
-  font-family: var(--public-font-family-title);
-  font-size: 2.2rem;
-  line-height: 1.12;
+  color: #14201f;
+  font-family: var(--font-serif), Georgia, 'Times New Roman', serif;
+  font-size: clamp(2.25rem, 4vw, 4rem);
+  font-weight: 400;
   letter-spacing: 0;
+  line-height: 0.98;
+  text-wrap: balance;
 }
 
-.sectionHeading p,
-.contactCopy p {
-  margin: 14px 0 0;
-  color: var(--public-color-ink-3);
+.sectionHeading span,
+.advisorSection > div > span {
+  display: block;
+  margin-top: 16px;
+  color: rgba(20, 32, 31, 0.7);
   font-size: 1rem;
-  line-height: 1.7;
+  line-height: 1.68;
 }
 
 .fitGrid {
@@ -229,108 +680,192 @@
 }
 
 .fitCard {
-  display: flex;
+  display: grid;
   min-width: 0;
-  flex-direction: column;
-  gap: 16px;
-  border: 1px solid var(--public-color-line-soft);
-  background: #ffffff;
-  padding: 26px;
-  box-shadow: var(--public-shadow-claude-card);
+  gap: 18px;
+  border: 1px solid rgba(20, 32, 31, 0.1);
+  border-radius: 8px;
+  background: #fffdf8;
+  padding: 28px;
+  color: inherit;
+  text-decoration: none;
+  box-shadow: 0 18px 42px rgba(20, 32, 31, 0.08);
 }
 
-.fitCard h3 {
-  margin: 0;
-  color: var(--public-color-ink);
-  font-size: 1.24rem;
-  line-height: 1.25;
+.fitCard span,
+.propertyCopy h3 {
+  color: #14201f;
+  font-family: var(--font-serif), Georgia, 'Times New Roman', serif;
+  font-size: 1.55rem;
+  font-weight: 400;
+  line-height: 1.08;
 }
 
 .fitCard p {
   margin: 0;
-  color: var(--public-color-ink-3);
-  line-height: 1.65;
+  color: rgba(20, 32, 31, 0.68);
+  line-height: 1.62;
 }
 
-.textLink {
-  color: var(--public-color-teal-2);
-  font-weight: 700;
-  text-decoration: none;
+.projectSection {
+  max-width: none;
+  background: #12221e;
+  color: var(--v2-ink);
 }
 
-.textLink:hover,
-.textLink:focus-visible {
-  color: var(--public-color-coral-2);
-  text-decoration: underline;
-  text-underline-offset: 4px;
+.projectSection .sectionHeading {
+  max-width: 1296px;
+  margin-right: auto;
+  margin-left: auto;
 }
 
-.cardRail {
+.projectSection .sectionHeading h2 {
+  color: var(--v2-ink);
+}
+
+.projectSection .sectionHeading span {
+  color: rgba(255, 250, 240, 0.68);
+}
+
+.projectGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 22px;
+  max-width: 1296px;
+  margin: 0 auto;
 }
 
-.previewCard {
+.projectCard,
+.propertyCard,
+.areaCard {
+  color: inherit;
+  text-decoration: none;
+}
+
+.projectCard {
+  display: grid;
   min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgba(255, 250, 240, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
 }
 
-.previewCard :global(.public-card-foundation__media) {
-  aspect-ratio: 1.18 / 1;
+.cardImage {
+  position: relative;
+  display: block;
+  min-height: 300px;
+  background: #1b3029;
 }
 
-.previewCard :global(.public-card-foundation__meta-row) {
-  align-items: flex-start;
-  gap: 8px;
+.cardBody,
+.cardFooter {
+  display: grid;
+  gap: 10px;
+  padding: 20px;
 }
 
-.previewCard :global(.public-card-foundation__location),
-.previewCard :global(.public-card-foundation__type) {
+.cardKicker,
+.propertyCopy > span:first-child {
+  color: var(--v2-gold);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.cardBody h3 {
+  margin: 0;
+  color: var(--v2-ink);
+  font-family: var(--font-serif), Georgia, 'Times New Roman', serif;
+  font-size: clamp(1.55rem, 2vw, 2rem);
+  font-weight: 400;
+  line-height: 1.04;
+}
+
+.propertyCopy h3 {
+  margin: 0;
+}
+
+.cardBody > span:last-child {
+  color: rgba(255, 250, 240, 0.7);
+  font-weight: 800;
+}
+
+.cardFooter {
+  grid-template-columns: 1fr;
+  border-top: 1px solid rgba(255, 250, 240, 0.12);
+  color: rgba(255, 250, 240, 0.66);
+  font-size: 0.88rem;
+}
+
+.cardFooter span:last-child {
+  color: var(--v2-gold);
+  font-weight: 900;
+}
+
+.propertySection {
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
+  gap: 42px;
+  align-items: start;
+}
+
+.propertyIntro {
+  position: sticky;
+  top: 96px;
+}
+
+.propertyRail {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.propertyCard {
+  display: grid;
   min-width: 0;
-  max-width: 100%;
-  overflow: visible;
-  text-overflow: clip;
-  white-space: normal;
-  overflow-wrap: anywhere;
-  line-height: 1.3;
+  overflow: hidden;
+  border: 1px solid rgba(20, 32, 31, 0.1);
+  border-radius: 8px;
+  background: #fffdf8;
+  box-shadow: 0 18px 42px rgba(20, 32, 31, 0.08);
 }
 
-.page :global(.v2-preview-card .public-card-foundation__location),
-.page :global(.v2-preview-card .public-card-foundation__type) {
-  max-width: 100%;
-  overflow: visible;
-  text-overflow: clip;
-  white-space: normal;
-  overflow-wrap: anywhere;
+.propertyImage {
+  position: relative;
+  display: block;
+  min-height: 210px;
+  background: #eadfcd;
+}
+
+.propertyCopy {
+  display: grid;
+  gap: 10px;
+  padding: 20px;
+}
+
+.propertyCopy > span:last-of-type {
+  color: rgba(20, 32, 31, 0.62);
+  line-height: 1.4;
+}
+
+.propertyCopy em {
+  color: var(--v2-coral);
+  font-style: normal;
+  font-weight: 900;
 }
 
 .areaSection {
-  max-width: none;
-  background: #122d2d;
-  color: #fffaf0;
-}
-
-.areaSection .sectionHeading {
-  max-width: 780px;
-}
-
-.areaSection .sectionLabel {
-  color: #f0d4a1;
-}
-
-.areaSection h2 {
-  color: #fffaf0;
-}
-
-.areaSection .sectionHeading p {
-  color: rgba(255, 250, 240, 0.74);
+  padding: clamp(70px, 8vw, 112px) clamp(18px, 4vw, 64px);
+  background: #f7efe1;
 }
 
 .areaGrid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 18px;
-  max-width: 1280px;
+  max-width: 1296px;
   margin: 0 auto;
 }
 
@@ -338,225 +873,269 @@
   display: grid;
   min-width: 0;
   overflow: hidden;
-  border: 1px solid rgba(240, 212, 161, 0.28);
-  background: rgba(255, 255, 255, 0.06);
-  color: inherit;
-  text-decoration: none;
+  border-radius: 8px;
+  background: #14221d;
+  color: var(--v2-ink);
 }
 
 .areaImage {
   position: relative;
-  min-height: 180px;
-  background: #1a403f;
+  display: block;
+  min-height: 210px;
+  background: #1b3029;
 }
 
 .areaBody {
   display: grid;
-  gap: 12px;
+  gap: 10px;
   padding: 20px;
 }
 
-.areaName {
-  color: #fffaf0;
-  font-size: 1.16rem;
-  font-weight: 800;
-  overflow-wrap: anywhere;
+.areaBody span {
+  font-family: var(--font-serif), Georgia, 'Times New Roman', serif;
+  font-size: 1.55rem;
+  line-height: 1.06;
 }
 
-.areaDescription {
-  color: rgba(255, 250, 240, 0.72);
-  font-size: 0.94rem;
-  line-height: 1.55;
-}
-
-.areaCard .textLink {
-  color: #f0d4a1;
+.areaBody small {
+  color: rgba(255, 250, 240, 0.68);
+  font-size: 0.9rem;
+  line-height: 1.56;
 }
 
 .trustSection {
   display: grid;
-  grid-template-columns: minmax(0, 0.86fr) minmax(0, 1.14fr);
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
   gap: 42px;
   align-items: start;
 }
 
-.trustIntro .sectionHeading {
-  margin-bottom: 0;
-}
-
 .trustList {
   display: grid;
-  gap: 14px;
+  gap: 16px;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.trustItem {
+.trustList li {
   display: grid;
-  grid-template-columns: 58px minmax(0, 1fr);
+  grid-template-columns: 64px minmax(0, 1fr);
   gap: 18px;
-  border: 1px solid var(--public-color-line-soft);
-  background: #ffffff;
-  padding: 22px;
+  align-items: start;
+  border-top: 1px solid rgba(20, 32, 31, 0.12);
+  padding-top: 20px;
 }
 
-.trustIndex {
-  display: inline-flex;
-  width: 46px;
-  height: 46px;
-  align-items: center;
-  justify-content: center;
-  background: var(--public-color-teal);
-  color: #fffaf0;
-  font-weight: 800;
+.trustList li > span {
+  color: var(--v2-coral);
+  font-family: var(--font-serif), Georgia, 'Times New Roman', serif;
+  font-size: 2rem;
+  line-height: 1;
 }
 
-.trustItem h3 {
+.trustList h3 {
   margin: 0;
-  color: var(--public-color-ink);
-  font-size: 1.1rem;
+  color: #14201f;
+  font-size: 1.05rem;
 }
 
-.trustItem p {
+.trustList p {
   margin: 8px 0 0;
-  color: var(--public-color-ink-3);
+  color: rgba(20, 32, 31, 0.68);
   line-height: 1.62;
 }
 
-.contactSection {
+.advisorSection {
   display: grid;
-  grid-template-columns: minmax(0, 0.92fr) minmax(320px, 1.08fr);
-  gap: 32px;
-  align-items: start;
-  padding-bottom: 88px;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 430px);
+  gap: 38px;
+  align-items: center;
+  border-top: 1px solid rgba(20, 32, 31, 0.1);
 }
 
-.contactCopy {
-  border: 1px solid var(--public-color-line-soft);
-  background: #ffffff;
-  padding: 32px;
-}
-
-.contactChecks {
+.advisorPanel {
   display: grid;
-  gap: 12px;
-  margin: 24px 0 0;
-  padding: 0;
-  list-style: none;
-}
-
-.contactChecks li {
-  border-top: 1px solid var(--public-color-line-soft);
-  padding-top: 12px;
-  color: var(--public-color-ink-2);
-  font-weight: 700;
-}
-
-.formPanel {
-  min-width: 0;
+  gap: 18px;
   border: 1px solid rgba(20, 32, 31, 0.12);
-  background: #ffffff;
-  padding: 24px;
-  box-shadow: var(--public-shadow-claude-lg);
+  border-radius: 8px;
+  background: #fffdf8;
+  padding: 28px;
+  box-shadow: 0 22px 56px rgba(20, 32, 31, 0.12);
 }
 
-@media (min-width: 768px) {
-  .hero,
-  .fitSection,
-  .projectSection,
-  .propertySection,
-  .trustSection,
-  .contactSection {
-    padding-right: var(--public-container-gutter-tablet);
-    padding-left: var(--public-container-gutter-tablet);
-  }
-
-  .hero {
-    padding-top: 64px;
-    padding-bottom: 56px;
-  }
+.advisorPanel span {
+  color: rgba(20, 32, 31, 0.62);
+  font-size: 0.82rem;
+  font-weight: 800;
 }
 
-@media (min-width: 1024px) {
-  .hero {
-    padding-right: var(--public-container-gutter-desktop);
-    padding-left: var(--public-container-gutter-desktop);
+.advisorPanel strong {
+  color: #14201f;
+}
+
+.advisorPanel a {
+  min-height: 52px;
+  padding: 0 22px;
+}
+
+.v2Footer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.9fr);
+  gap: 38px;
+  padding: clamp(44px, 6vw, 74px) clamp(18px, 4vw, 64px);
+  background: #101c18;
+  color: var(--v2-ink);
+}
+
+.footerBrand {
+  display: grid;
+  max-width: 560px;
+  gap: 20px;
+}
+
+.footerBrand p {
+  margin: 0;
+  color: rgba(255, 250, 240, 0.62);
+  line-height: 1.64;
+}
+
+.footerLinks {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 28px;
+}
+
+.footerLinks div {
+  display: grid;
+  gap: 10px;
+}
+
+.footerLinks a {
+  color: rgba(255, 250, 240, 0.72);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.footerLinks a:hover,
+.footerLinks a:focus-visible {
+  color: #ffffff;
+}
+
+@media (max-width: 1180px) {
+  .v2Header {
+    grid-template-columns: minmax(170px, 1fr) auto auto;
   }
 
-  .heroGrid {
-    grid-template-columns: minmax(0, 0.92fr) minmax(420px, 0.98fr);
+  .v2Nav {
+    display: none;
   }
 
-  .heroCopy h1 {
-    font-size: 4rem;
+  .mobileMenu {
+    display: block;
   }
 }
 
 @media (max-width: 1023px) {
-  .fitGrid,
-  .cardRail,
-  .areaGrid,
+  .heroGrid,
+  .propertySection,
   .trustSection,
-  .contactSection {
+  .advisorSection,
+  .v2Footer {
     grid-template-columns: 1fr;
   }
 
+  .heroGrid {
+    min-height: auto;
+  }
+
+  .propertyIntro {
+    position: static;
+  }
+
+  .fitGrid,
+  .projectGrid,
   .areaGrid {
-    max-width: 680px;
+    grid-template-columns: 1fr;
+  }
+
+  .areaGrid,
+  .projectGrid {
+    max-width: 720px;
+  }
+
+  .heroSearchPanel {
+    margin-top: 20px;
+  }
+
+  .searchFields {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .searchFields .searchButton {
+    grid-column: 1 / -1;
+    min-height: 50px;
   }
 }
 
 @media (max-width: 767px) {
+  .v2Header {
+    grid-template-columns: minmax(0, 1fr) auto;
+    min-height: 66px;
+    padding-inline: 18px;
+  }
+
+  .headerActions {
+    display: none;
+  }
+
   .hero {
-    padding-top: 36px;
+    padding-top: 34px;
   }
 
   .heroCopy h1 {
-    font-size: 2.35rem;
+    font-size: clamp(2.18rem, 11vw, 2.9rem);
   }
 
   .heroLead {
     font-size: 1rem;
   }
 
+  .heroActions {
+    flex-direction: column;
+  }
+
+  .primaryButton,
+  .secondaryButton {
+    width: 100%;
+  }
+
   .heroProofGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .heroVisualForm,
+  .propertyRail,
+  .footerLinks {
     grid-template-columns: 1fr;
   }
 
-  .heroImageFrame {
-    min-height: 300px;
+  .searchTabs {
+    padding: 12px 12px 6px;
   }
 
-  .heroAdvisorPanel {
-    width: auto;
-    margin: -40px 12px 0;
-  }
-
-  .fitSection,
-  .projectSection,
-  .propertySection,
-  .areaSection,
-  .trustSection,
-  .contactSection {
-    padding-top: 56px;
-    padding-bottom: 56px;
-  }
-
-  .sectionHeading h2,
-  .contactCopy h2 {
-    font-size: 1.85rem;
-  }
-
-  .fitCard,
-  .trustItem,
-  .contactCopy,
-  .formPanel {
-    padding: 20px;
-  }
-
-  .trustItem {
+  .searchFields {
     grid-template-columns: 1fr;
+  }
+
+  .searchFields a {
+    border-right: 0;
+    border-top: 1px solid #ece3d3;
+    padding: 14px 16px;
+  }
+
+  .cardImage {
+    min-height: 260px;
   }
 }
 
@@ -567,16 +1146,13 @@
   .propertySection,
   .areaSection,
   .trustSection,
-  .contactSection {
+  .advisorSection,
+  .v2Footer {
     padding-right: 18px;
     padding-left: 18px;
   }
 
-  .heroCopy h1 {
-    font-size: 2rem;
-  }
-
-  .heroActions {
-    flex-direction: column;
+  .logoCopy span {
+    font-size: 1rem;
   }
 }

--- a/admin-app/app/(site)/[locale]/v2-preview/v2-preview.module.css
+++ b/admin-app/app/(site)/[locale]/v2-preview/v2-preview.module.css
@@ -1,0 +1,582 @@
+.page {
+  background:
+    linear-gradient(180deg, #ffffff 0%, #f7f3ea 36%, #ffffff 68%, #f6efe0 100%);
+  color: var(--public-color-ink);
+  overflow-x: clip;
+}
+
+.hero {
+  background: #0f2f2f;
+  color: #fffaf0;
+  padding: 56px var(--public-container-gutter-mobile) 40px;
+}
+
+.heroGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 32px;
+  max-width: 1280px;
+  margin: 0 auto;
+  align-items: center;
+}
+
+.heroCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 0;
+}
+
+.brandLine {
+  margin: 0;
+  color: #f0d4a1;
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.heroCopy h1 {
+  margin: 0;
+  max-width: 780px;
+  color: #fffaf0;
+  font-family: var(--public-font-family-title);
+  font-size: 2.8rem;
+  font-weight: 700;
+  line-height: 1.04;
+  letter-spacing: 0;
+}
+
+.heroLead {
+  max-width: 640px;
+  margin: 0;
+  color: rgba(255, 250, 240, 0.82);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.heroPrimaryCta,
+.heroSecondaryCta {
+  min-height: 48px;
+  white-space: normal;
+}
+
+.heroSecondaryCta {
+  border-color: rgba(240, 212, 161, 0.32);
+  background: rgba(255, 255, 255, 0.06);
+  color: #fffaf0;
+}
+
+.heroSecondaryCta:hover,
+.heroSecondaryCta:focus-visible {
+  border-color: rgba(240, 212, 161, 0.54);
+  background: rgba(255, 255, 255, 0.12);
+  color: #fffaf0;
+}
+
+.page :global(.v2-preview-hero-secondary.btn-secondary) {
+  border-color: rgba(240, 212, 161, 0.36) !important;
+  background: rgba(255, 255, 255, 0.08) !important;
+  color: #fffaf0 !important;
+}
+
+.page :global(.v2-preview-hero-secondary.btn-secondary:hover),
+.page :global(.v2-preview-hero-secondary.btn-secondary:focus-visible) {
+  border-color: rgba(240, 212, 161, 0.58) !important;
+  background: rgba(255, 255, 255, 0.14) !important;
+  color: #fffaf0 !important;
+}
+
+.heroProofGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  max-width: 680px;
+  margin: 4px 0 0;
+}
+
+.heroProofGrid div {
+  min-width: 0;
+  border: 1px solid rgba(240, 212, 161, 0.28);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 16px;
+}
+
+.heroProofGrid dt {
+  color: rgba(255, 250, 240, 0.64);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.heroProofGrid dd {
+  margin: 7px 0 0;
+  color: #fffaf0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.heroMediaPanel {
+  position: relative;
+  min-width: 0;
+}
+
+.heroImageFrame {
+  position: relative;
+  overflow: hidden;
+  min-height: 360px;
+  border: 1px solid rgba(240, 212, 161, 0.34);
+  background: #183f3d;
+  box-shadow: 0 32px 70px rgba(0, 0, 0, 0.34);
+}
+
+.coverImage {
+  object-fit: cover;
+}
+
+.heroAdvisorPanel {
+  position: relative;
+  width: min(88%, 420px);
+  margin: -76px 20px 0 auto;
+  border: 1px solid rgba(240, 212, 161, 0.34);
+  background: rgba(15, 47, 47, 0.92);
+  padding: 20px;
+  color: #fffaf0;
+  box-shadow: 0 22px 46px rgba(0, 0, 0, 0.28);
+}
+
+.heroAdvisorPanel p {
+  margin: 0 0 12px;
+  color: #f0d4a1;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.heroAdvisorPanel ul {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.heroAdvisorPanel li {
+  border-top: 1px solid rgba(255, 250, 240, 0.16);
+  padding-top: 8px;
+  line-height: 1.4;
+}
+
+.fitSection,
+.projectSection,
+.propertySection,
+.areaSection,
+.trustSection,
+.contactSection {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 72px var(--public-container-gutter-mobile);
+}
+
+.sectionHeading {
+  max-width: 760px;
+  margin-bottom: 32px;
+}
+
+.sectionHeadingCenter {
+  margin-right: auto;
+  margin-left: auto;
+  text-align: center;
+}
+
+.sectionLabel {
+  margin: 0 0 10px;
+  color: var(--public-color-coral-2);
+  font-size: 0.84rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.sectionHeading h2,
+.contactCopy h2 {
+  margin: 0;
+  color: var(--public-color-ink);
+  font-family: var(--public-font-family-title);
+  font-size: 2.2rem;
+  line-height: 1.12;
+  letter-spacing: 0;
+}
+
+.sectionHeading p,
+.contactCopy p {
+  margin: 14px 0 0;
+  color: var(--public-color-ink-3);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.fitGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.fitCard {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 16px;
+  border: 1px solid var(--public-color-line-soft);
+  background: #ffffff;
+  padding: 26px;
+  box-shadow: var(--public-shadow-claude-card);
+}
+
+.fitCard h3 {
+  margin: 0;
+  color: var(--public-color-ink);
+  font-size: 1.24rem;
+  line-height: 1.25;
+}
+
+.fitCard p {
+  margin: 0;
+  color: var(--public-color-ink-3);
+  line-height: 1.65;
+}
+
+.textLink {
+  color: var(--public-color-teal-2);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.textLink:hover,
+.textLink:focus-visible {
+  color: var(--public-color-coral-2);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.cardRail {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 22px;
+}
+
+.previewCard {
+  min-width: 0;
+}
+
+.previewCard :global(.public-card-foundation__media) {
+  aspect-ratio: 1.18 / 1;
+}
+
+.previewCard :global(.public-card-foundation__meta-row) {
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.previewCard :global(.public-card-foundation__location),
+.previewCard :global(.public-card-foundation__type) {
+  min-width: 0;
+  max-width: 100%;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.3;
+}
+
+.page :global(.v2-preview-card .public-card-foundation__location),
+.page :global(.v2-preview-card .public-card-foundation__type) {
+  max-width: 100%;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.areaSection {
+  max-width: none;
+  background: #122d2d;
+  color: #fffaf0;
+}
+
+.areaSection .sectionHeading {
+  max-width: 780px;
+}
+
+.areaSection .sectionLabel {
+  color: #f0d4a1;
+}
+
+.areaSection h2 {
+  color: #fffaf0;
+}
+
+.areaSection .sectionHeading p {
+  color: rgba(255, 250, 240, 0.74);
+}
+
+.areaGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.areaCard {
+  display: grid;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgba(240, 212, 161, 0.28);
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  text-decoration: none;
+}
+
+.areaImage {
+  position: relative;
+  min-height: 180px;
+  background: #1a403f;
+}
+
+.areaBody {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+
+.areaName {
+  color: #fffaf0;
+  font-size: 1.16rem;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.areaDescription {
+  color: rgba(255, 250, 240, 0.72);
+  font-size: 0.94rem;
+  line-height: 1.55;
+}
+
+.areaCard .textLink {
+  color: #f0d4a1;
+}
+
+.trustSection {
+  display: grid;
+  grid-template-columns: minmax(0, 0.86fr) minmax(0, 1.14fr);
+  gap: 42px;
+  align-items: start;
+}
+
+.trustIntro .sectionHeading {
+  margin-bottom: 0;
+}
+
+.trustList {
+  display: grid;
+  gap: 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.trustItem {
+  display: grid;
+  grid-template-columns: 58px minmax(0, 1fr);
+  gap: 18px;
+  border: 1px solid var(--public-color-line-soft);
+  background: #ffffff;
+  padding: 22px;
+}
+
+.trustIndex {
+  display: inline-flex;
+  width: 46px;
+  height: 46px;
+  align-items: center;
+  justify-content: center;
+  background: var(--public-color-teal);
+  color: #fffaf0;
+  font-weight: 800;
+}
+
+.trustItem h3 {
+  margin: 0;
+  color: var(--public-color-ink);
+  font-size: 1.1rem;
+}
+
+.trustItem p {
+  margin: 8px 0 0;
+  color: var(--public-color-ink-3);
+  line-height: 1.62;
+}
+
+.contactSection {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(320px, 1.08fr);
+  gap: 32px;
+  align-items: start;
+  padding-bottom: 88px;
+}
+
+.contactCopy {
+  border: 1px solid var(--public-color-line-soft);
+  background: #ffffff;
+  padding: 32px;
+}
+
+.contactChecks {
+  display: grid;
+  gap: 12px;
+  margin: 24px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.contactChecks li {
+  border-top: 1px solid var(--public-color-line-soft);
+  padding-top: 12px;
+  color: var(--public-color-ink-2);
+  font-weight: 700;
+}
+
+.formPanel {
+  min-width: 0;
+  border: 1px solid rgba(20, 32, 31, 0.12);
+  background: #ffffff;
+  padding: 24px;
+  box-shadow: var(--public-shadow-claude-lg);
+}
+
+@media (min-width: 768px) {
+  .hero,
+  .fitSection,
+  .projectSection,
+  .propertySection,
+  .trustSection,
+  .contactSection {
+    padding-right: var(--public-container-gutter-tablet);
+    padding-left: var(--public-container-gutter-tablet);
+  }
+
+  .hero {
+    padding-top: 64px;
+    padding-bottom: 56px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .hero {
+    padding-right: var(--public-container-gutter-desktop);
+    padding-left: var(--public-container-gutter-desktop);
+  }
+
+  .heroGrid {
+    grid-template-columns: minmax(0, 0.92fr) minmax(420px, 0.98fr);
+  }
+
+  .heroCopy h1 {
+    font-size: 4rem;
+  }
+}
+
+@media (max-width: 1023px) {
+  .fitGrid,
+  .cardRail,
+  .areaGrid,
+  .trustSection,
+  .contactSection {
+    grid-template-columns: 1fr;
+  }
+
+  .areaGrid {
+    max-width: 680px;
+  }
+}
+
+@media (max-width: 767px) {
+  .hero {
+    padding-top: 36px;
+  }
+
+  .heroCopy h1 {
+    font-size: 2.35rem;
+  }
+
+  .heroLead {
+    font-size: 1rem;
+  }
+
+  .heroProofGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .heroImageFrame {
+    min-height: 300px;
+  }
+
+  .heroAdvisorPanel {
+    width: auto;
+    margin: -40px 12px 0;
+  }
+
+  .fitSection,
+  .projectSection,
+  .propertySection,
+  .areaSection,
+  .trustSection,
+  .contactSection {
+    padding-top: 56px;
+    padding-bottom: 56px;
+  }
+
+  .sectionHeading h2,
+  .contactCopy h2 {
+    font-size: 1.85rem;
+  }
+
+  .fitCard,
+  .trustItem,
+  .contactCopy,
+  .formPanel {
+    padding: 20px;
+  }
+
+  .trustItem {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .hero,
+  .fitSection,
+  .projectSection,
+  .propertySection,
+  .areaSection,
+  .trustSection,
+  .contactSection {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .heroCopy h1 {
+    font-size: 2rem;
+  }
+
+  .heroActions {
+    flex-direction: column;
+  }
+}

--- a/admin-app/components/layout/Header.tsx
+++ b/admin-app/components/layout/Header.tsx
@@ -157,6 +157,15 @@ function getShellCtaLabel(locale: Locale, item: PublicCtaItem): string {
   return locale === 'th' ? 'คุยกับที่ปรึกษาอสังหาฯ พัทยา' : 'Speak with a Pattaya Property Advisor';
 }
 
+function normalizePathForSurface(pathname: string): string {
+  const normalized = pathname.replace(/\/+$/, '');
+  return normalized || '/';
+}
+
+function isV2PreviewPath(pathname: string): boolean {
+  return normalizePathForSurface(pathname) === '/v2-preview';
+}
+
 export function SiteHeader({
   locale,
   dict: dictProp,
@@ -208,7 +217,7 @@ export function SiteHeader({
 
   /** Strip /<locale> prefix from pathname to compare with nav item hrefs */
   const pathWithoutLocale = pathname?.replace(new RegExp(`^/${locale}`), '') || '/';
-  const isV2PreviewSurface = pathWithoutLocale === '/v2-preview';
+  const isV2PreviewSurface = isV2PreviewPath(pathWithoutLocale);
   function isActive(href: string): boolean {
     if (href === '/') return pathWithoutLocale === '/' || pathWithoutLocale === '';
     if (href === '/area-guide') {

--- a/admin-app/components/layout/Header.tsx
+++ b/admin-app/components/layout/Header.tsx
@@ -208,6 +208,7 @@ export function SiteHeader({
 
   /** Strip /<locale> prefix from pathname to compare with nav item hrefs */
   const pathWithoutLocale = pathname?.replace(new RegExp(`^/${locale}`), '') || '/';
+  const isV2PreviewSurface = pathWithoutLocale === '/v2-preview';
   function isActive(href: string): boolean {
     if (href === '/') return pathWithoutLocale === '/' || pathWithoutLocale === '';
     if (href === '/area-guide') {
@@ -288,7 +289,7 @@ export function SiteHeader({
           </nav>
 
           <div className="header-actions">
-            {shortlistCta ? (
+            {shortlistCta && !isV2PreviewSurface ? (
               <Link
                 href={resolveCtaHref(locale, shortlistCta)}
                 prefetch={false}

--- a/admin-app/components/layout/PublicClientEnhancements.tsx
+++ b/admin-app/components/layout/PublicClientEnhancements.tsx
@@ -45,6 +45,15 @@ const AIChatWidget = dynamic(
   { ssr: false },
 );
 
+function normalizePathForSurface(pathname: string): string {
+  const normalized = pathname.replace(/\/+$/, '');
+  return normalized || '/';
+}
+
+function isV2PreviewPath(pathname: string): boolean {
+  return normalizePathForSurface(pathname) === '/v2-preview';
+}
+
 export function PublicClientEnhancements() {
   const pathname = usePathname() ?? '/';
   const [showAnalytics, setShowAnalytics] = useState(false);
@@ -53,7 +62,7 @@ export function PublicClientEnhancements() {
   const [showAiWidget, setShowAiWidget] = useState(false);
   const showFloatingWhatsApp = shouldRenderFloatingWhatsApp(pathname);
   const pathWithoutLocale = pathname.replace(/^\/(en|th)(?=\/|$)/, '') || '/';
-  const isPreviewSurface = pathWithoutLocale === '/v2-preview';
+  const isPreviewSurface = isV2PreviewPath(pathWithoutLocale);
   const isCalmerSurface = pathWithoutLocale === '/' || pathWithoutLocale === '/projects' || isPreviewSurface;
 
   useEffect(() => {

--- a/admin-app/components/layout/PublicClientEnhancements.tsx
+++ b/admin-app/components/layout/PublicClientEnhancements.tsx
@@ -53,7 +53,8 @@ export function PublicClientEnhancements() {
   const [showAiWidget, setShowAiWidget] = useState(false);
   const showFloatingWhatsApp = shouldRenderFloatingWhatsApp(pathname);
   const pathWithoutLocale = pathname.replace(/^\/(en|th)(?=\/|$)/, '') || '/';
-  const isCalmerSurface = pathWithoutLocale === '/' || pathWithoutLocale === '/projects';
+  const isPreviewSurface = pathWithoutLocale === '/v2-preview';
+  const isCalmerSurface = pathWithoutLocale === '/' || pathWithoutLocale === '/projects' || isPreviewSurface;
 
   useEffect(() => {
     const locale = localeFromPathname(pathname);
@@ -176,8 +177,8 @@ export function PublicClientEnhancements() {
           {showFloatingWhatsApp && !showAiWidget ? <FloatingWhatsAppCTA /> : null}
         </>
       ) : null}
-      <StickyMobileCTA />
-      {showAiWidget ? <AIChatWidget /> : null}
+      {isPreviewSurface ? null : <StickyMobileCTA />}
+      {showAiWidget && !isPreviewSurface ? <AIChatWidget /> : null}
       {showConsent ? <CookieConsent /> : null}
     </>
   );

--- a/admin-app/middleware.ts
+++ b/admin-app/middleware.ts
@@ -18,6 +18,7 @@ const NON_LOCALIZED_ROUTE_PREFIXES = [
   '/home-composer',
   '/telemetry',
 ] as const;
+const ENGLISH_ONLY_PREVIEW_BLOCKED_PATHS = new Set(['/th/v2-preview', '/th/v2-preview/']);
 
 function isLocale(value: string | undefined): value is Locale {
   return (LOCALES as readonly string[]).includes(value ?? '');
@@ -148,6 +149,16 @@ export function middleware(req: NextRequest) {
   // Ignore admin routes (keep existing URLs stable).
   if (NON_LOCALIZED_ROUTE_PREFIXES.some((prefix) => hasRoutePrefix(pathname, prefix))) {
     return NextResponse.next();
+  }
+
+  // AMP Public v2 Phase 1 is English-only. Force a real HTTP 404 for the Thai preview path.
+  if (ENGLISH_ONLY_PREVIEW_BLOCKED_PATHS.has(pathname)) {
+    const response = new NextResponse(null, { status: 404 });
+    response.headers.set('x-next-pathname', pathname);
+    response.headers.set('Cache-Control', 'no-store');
+    setSecurityHeaders(response);
+    persistLocaleCookie(response, req, 'th');
+    return response;
   }
 
   const segments = pathname.split('/').filter(Boolean);


### PR DESCRIPTION
## Summary
- Adds isolated English-only AMP Public v2 preview route at `/en/v2-preview`.
- Uses Figma Make as visual/design reference only.
- Keeps production routes unchanged.
- Adds `/th/v2-preview` 404 behavior (including trailing slash).
- Adds noindex/nofollow metadata for preview.
- Keeps preview out of sitemap.
- Uses existing public layout/header/footer.
- Uses existing public API/media helpers and safe fallback labels.
- Suppresses sticky mobile CTA and AI chat on preview to avoid QA obstruction.
- Hardens preview-surface detection for trailing slash paths (`/en/v2-preview/`).
- Hardens v2 preview data loader against null/non-array API responses with safe mapper guards.

**Latest head:** `1741e221d4e439eb78aa40773fddcdb1bf1adc8f` (`fix(public): harden v2 preview surface`)

## Files changed
- `admin-app/__tests__/header_cta_visibility.test.tsx`
- `admin-app/__tests__/middleware_locale_routing.test.ts`
- `admin-app/__tests__/public_client_enhancements_locale_semantics.test.tsx`
- `admin-app/__tests__/v2_preview_route.test.tsx`
- `admin-app/app/(site)/[locale]/v2-preview/_components/V2PreviewPage.tsx`
- `admin-app/app/(site)/[locale]/v2-preview/_lib/v2-preview-data.ts`
- `admin-app/app/(site)/[locale]/v2-preview/page.tsx`
- `admin-app/app/(site)/[locale]/v2-preview/v2-preview.module.css`
- `admin-app/components/layout/Header.tsx`
- `admin-app/components/layout/PublicClientEnhancements.tsx`
- `admin-app/middleware.ts`

## Preview
- `/en/v2-preview`: 200
- `/en/v2-preview/`: 200 (preview surface; trailing slash safe)
- `/th/v2-preview`: 404
- `/th/v2-preview/`: 404
- `/sitemap.xml`: no `v2-preview`

## Validation

### GitHub CI (head `1741e221`)
- **Governance Gate:** PASS
- **admin-smoke-e2e:** PASS

### Focused tests
- **PASS** — 4 files, 25 tests

```bash
pnpm test -- v2_preview_route.test.tsx middleware_locale_routing.test.ts public_client_enhancements_locale_semantics.test.tsx header_cta_visibility.test.tsx
```

Coverage highlights:
- Preview route metadata (noindex/nofollow), sitemap exclusion, Thai 404
- Trailing-slash preview detection in Header and PublicClientEnhancements
- Null/non-array API response fallback in v2 preview data loader
- Middleware 404 for `/th/v2-preview/`

### Local build
- `FLOWBIZ_FORCE_FULL_BUILD=1 pnpm build`: **FAIL** on this machine after fresh install
- Next.js compile completed; failure occurred at ESLint step loading `eslint-plugin-jsx-a11y` (`Invalid or unexpected token`)
- No evidence this local environment failure is caused by the PR diff; GitHub CI passed on the same head

## QA
- Preview used: `http://127.0.0.1:3002/en/v2-preview`
- Desktop 1440: pass
- Tablet 768: pass
- Mobile 390: pass
- No horizontal overflow
- No text overflow
- Header/footer present
- Sticky CTA/chat absent on preview (including trailing slash)
- CTA links valid
- No Figma mock-data text leakage

**Recommended final visual QA before merge:**
- `/en/v2-preview`
- `/en/v2-preview/`
- `/th/v2-preview`
- `/th/v2-preview/`

## Safety
- No deploy
- No production route replacement
- No admin changes
- No backend/API/schema/env/deployment changes
- No Thai implementation beyond 404 guard
- No `src/` prototype files
- No sitemap exposure
- Preview metadata noindex/nofollow
- No Figma mock source imports
- No lockfile committed (`admin-app/pnpm-lock.yaml` excluded from hardening commit)

## Remaining risks
- Local `eslint-plugin-jsx-a11y` load failure may block `pnpm build` on some dev machines; rely on GitHub CI for build gate until local env is repaired.
- Existing local dev CSP vs React-refresh `unsafe-eval` console error.
- `next start` remains incompatible with this repo's standalone output; visual QA used `next dev` after forced full build.
