### PR TITLE
feat(public): add AMP public v3 design preview

### DIFF
--- a/admin-app/__tests__/middleware_locale_routing.test.ts
+++ b/admin-app/__tests__/middleware_locale_routing.test.ts
@@ -84,6 +84,28 @@ describe('middleware locale routing', () => {
     expect(response.cookies.get(LOCALE_COOKIE_NAME)?.value).toBe('th');
   });
 
+  it('returns a real 404 for the Thai-only AMP public v3 preview path', () => {
+    const request = new NextRequest('https://amppattaya.com/th/v3-preview');
+
+    const response = middleware(request);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('x-next-pathname')).toBe('/th/v3-preview');
+    expect(response.cookies.get(LOCALE_COOKIE_NAME)?.value).toBe('th');
+  });
+
+  it('returns a real 404 for nested Thai-only AMP public v3 preview paths', () => {
+    const request = new NextRequest('https://amppattaya.com/th/v3-preview/contact');
+
+    const response = middleware(request);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('x-next-pathname')).toBe('/th/v3-preview/contact');
+    expect(response.cookies.get(LOCALE_COOKIE_NAME)?.value).toBe('th');
+  });
+
   it('bypasses locale redirects for media proxy routes', () => {
     const request = new NextRequest('https://amppattaya.com/media/project-covers/hero.webp');
 

--- a/admin-app/__tests__/v2_preview_route.test.tsx
+++ b/admin-app/__tests__/v2_preview_route.test.tsx
@@ -197,7 +197,8 @@ describe('AMP Public v2 preview route', () => {
     expect(enhancementsSource).toContain('isV2PreviewPath');
     expect(enhancementsSource).toContain('{isPreviewSurface ? null : <StickyMobileCTA />}');
     expect(headerSource).toContain('isV2PreviewPath');
-    expect(headerSource).toContain('shortlistCta && !isV2PreviewSurface');
+    expect(headerSource).toContain('isPreviewPath');
+    expect(headerSource).toContain('shortlistCta && !isPreviewSurface');
     expect(read('app/(site)/[locale]/page.tsx')).not.toContain('v2-preview');
     expect(read('app/(site)/[locale]/projects/page.tsx')).not.toContain('v2-preview');
     expect(read('app/(site)/[locale]/buy/page.tsx')).not.toContain('v2-preview');

--- a/admin-app/__tests__/v3_preview_route.test.tsx
+++ b/admin-app/__tests__/v3_preview_route.test.tsx
@@ -52,14 +52,25 @@ describe('AMP Public v3 preview route', () => {
     expect(screen.getByText('Office & hours')).toBeInTheDocument();
     unmount();
 
-    render(
+    const calculatorRender = render(
       await AmpPublicV3PreviewSlugPage({
         params: Promise.resolve({ locale: 'en', slug: ['calculator'] }),
       }),
     );
 
-    expect(screen.getByRole('heading', { name: /total-cost & rental yield calculator/i })).toBeInTheDocument();
-    expect(screen.getByText('5-yr ROI: +211%')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /total-cost & availability planner/i })).toBeInTheDocument();
+    expect(screen.getByText('Owner review required')).toBeInTheDocument();
+    calculatorRender.unmount();
+
+    render(
+      await AmpPublicV3PreviewSlugPage({
+        params: Promise.resolve({ locale: 'en', slug: ['project', 'amp-skyharbor'] }),
+      }),
+    );
+
+    expect(screen.getByRole('link', { name: /all projects/i })).toHaveAttribute('href', '/en/v3-preview/listing');
+    expect(screen.getByRole('heading', { name: 'Skyharbor Residences' })).toBeInTheDocument();
+    expect(screen.getAllByText('Price on request').length).toBeGreaterThan(0);
   });
 
   it('returns notFound for Thai and unknown v3 preview routes', async () => {

--- a/admin-app/__tests__/v3_preview_route.test.tsx
+++ b/admin-app/__tests__/v3_preview_route.test.tsx
@@ -1,0 +1,122 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import sitemap from '@/app/sitemap';
+import AmpPublicV3PreviewPage, { generateMetadata } from '@/app/(site)/[locale]/v3-preview/page';
+import AmpPublicV3PreviewSlugPage, { generateMetadata as generateSlugMetadata } from '@/app/(site)/[locale]/v3-preview/[...slug]/page';
+
+const navigationMock = vi.hoisted(() => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: navigationMock.notFound,
+}));
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+}
+
+describe('AMP Public v3 preview route', () => {
+  it('renders the isolated English design preview homepage', async () => {
+    render(await AmpPublicV3PreviewPage({ params: Promise.resolve({ locale: 'en' }) }));
+
+    expect(screen.getByTestId('amp-public-v3-preview')).toBeInTheDocument();
+    expect(screen.getByRole('heading', {
+      name: /pattaya, priced for investors who measure in years, not weekends/i,
+    })).toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: /amp public v3 preview navigation/i })).toHaveTextContent(
+      'New Projects',
+    );
+    expect(screen.getByRole('link', { name: /90-second smart finder/i })).toHaveAttribute(
+      'href',
+      '/en/v3-preview/finder',
+    );
+    expect(screen.getByRole('heading', { name: 'The investor-grade shortlist.' })).toBeInTheDocument();
+    expect(screen.getAllByText('Skyharbor Residences').length).toBeGreaterThan(0);
+  });
+
+  it('renders routed Figma preview pages under the v3 subtree', async () => {
+    const { unmount } = render(
+      await AmpPublicV3PreviewSlugPage({
+        params: Promise.resolve({ locale: 'en', slug: ['contact'] }),
+      }),
+    );
+
+    expect(screen.getByRole('heading', { name: /talk to a human/i })).toBeInTheDocument();
+    expect(screen.getByText('Office & hours')).toBeInTheDocument();
+    unmount();
+
+    render(
+      await AmpPublicV3PreviewSlugPage({
+        params: Promise.resolve({ locale: 'en', slug: ['calculator'] }),
+      }),
+    );
+
+    expect(screen.getByRole('heading', { name: /total-cost & rental yield calculator/i })).toBeInTheDocument();
+    expect(screen.getByText('5-yr ROI: +211%')).toBeInTheDocument();
+  });
+
+  it('returns notFound for Thai and unknown v3 preview routes', async () => {
+    await expect(
+      AmpPublicV3PreviewPage({ params: Promise.resolve({ locale: 'th' }) }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+
+    await expect(
+      AmpPublicV3PreviewSlugPage({
+        params: Promise.resolve({ locale: 'en', slug: ['unknown-route'] }),
+      }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
+
+  it('marks v3 preview metadata noindex and nofollow', async () => {
+    const metadata = await generateMetadata({ params: Promise.resolve({ locale: 'en' }) });
+    const slugMetadata = await generateSlugMetadata({
+      params: Promise.resolve({ locale: 'en', slug: ['contact'] }),
+    });
+    const robots = metadata.robots as {
+      index?: boolean;
+      follow?: boolean;
+      googleBot?: { index?: boolean; follow?: boolean };
+    };
+
+    expect(metadata.alternates?.canonical).toBe('/en/v3-preview');
+    expect(slugMetadata.alternates?.canonical).toBe('/en/v3-preview/contact');
+    expect(robots.index).toBe(false);
+    expect(robots.follow).toBe(false);
+    expect(robots.googleBot?.index).toBe(false);
+    expect(robots.googleBot?.follow).toBe(false);
+  });
+
+  it('keeps v3 preview out of sitemap and production route files', () => {
+    const urls = sitemap().map((entry) => entry.url);
+    const previewSource = [
+      read('app/(site)/[locale]/v3-preview/page.tsx'),
+      read('app/(site)/[locale]/v3-preview/[...slug]/page.tsx'),
+      read('app/(site)/[locale]/v3-preview/_lib/v3-preview-data.ts'),
+      read('app/(site)/[locale]/v3-preview/_components/V3PreviewPage.tsx'),
+    ].join('\n');
+    const enhancementsSource = read('components/layout/PublicClientEnhancements.tsx');
+    const headerSource = read('components/layout/Header.tsx');
+    const siteLayoutSource = read('app/(site)/[locale]/layout.tsx');
+
+    expect(urls.some((url) => url.includes('/v3-preview'))).toBe(false);
+    expect(previewSource).not.toContain('figma/make');
+    expect(previewSource).not.toContain('RXcIsp7lQNDW95nPm20Zwu');
+    expect(enhancementsSource).toContain('isV3PreviewPath');
+    expect(enhancementsSource).toContain('isPreviewPath');
+    expect(headerSource).toContain('isV3PreviewPath');
+    expect(headerSource).toContain('isPreviewPath');
+    expect(siteLayoutSource).toContain("currentPath === '/v3-preview'");
+    expect(siteLayoutSource).toContain('isV3PreviewLayout ? null : <SiteHeader');
+    expect(read('app/(site)/[locale]/page.tsx')).not.toContain('v3-preview');
+    expect(read('app/(site)/[locale]/projects/page.tsx')).not.toContain('v3-preview');
+    expect(read('app/(site)/[locale]/buy/page.tsx')).not.toContain('v3-preview');
+    expect(read('app/(site)/[locale]/rent/page.tsx')).not.toContain('v3-preview');
+  });
+});

--- a/admin-app/app/(site)/[locale]/layout.tsx
+++ b/admin-app/app/(site)/[locale]/layout.tsx
@@ -47,6 +47,7 @@ export default async function SiteLayout(
     return <>{children}</>;
   }
   const currentPath = await detectCurrentPathWithoutLocale(locale);
+  const isV3PreviewLayout = currentPath === '/v3-preview' || currentPath.startsWith('/v3-preview/');
   const useFallbackLayoutCms = currentPath === '/' || currentPath === '/projects';
   const layoutCmsRow = useFallbackLayoutCms
     ? null
@@ -82,9 +83,9 @@ export default async function SiteLayout(
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLd }} />
       <div className="public-site-shell" data-locale={locale}>
-        <SiteHeader locale={locale} cms={layoutCms.header} />
+        {isV3PreviewLayout ? null : <SiteHeader locale={locale} cms={layoutCms.header} />}
         {children}
-        <SiteFooter locale={locale} cms={layoutCms.footer} />
+        {isV3PreviewLayout ? null : <SiteFooter locale={locale} cms={layoutCms.footer} />}
         <div aria-live="polite" aria-atomic="true" id="amp-live-region" className="sr-only" />
         <Suspense fallback={null}>
           <PublicClientEnhancements />

--- a/admin-app/app/(site)/[locale]/v3-preview/[...slug]/page.tsx
+++ b/admin-app/app/(site)/[locale]/v3-preview/[...slug]/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { V3PreviewPage } from '../_components/V3PreviewPage';
+import { resolveV3PreviewRoute } from '../_lib/v3-preview-data';
+
+export const revalidate = 300;
+
+type PageProps = {
+  params: Promise<{ locale: string; slug?: string[] }>;
+};
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug = [] } = await params;
+  const suffix = slug.length ? `/${slug.join('/')}` : '';
+
+  return {
+    title: 'AMP Public v3 Preview | AMP Pattaya',
+    description: 'English-only AMP Pattaya public frontend v3 preview based on the approved design direction.',
+    alternates: {
+      canonical: `/en/v3-preview${suffix}`,
+    },
+    robots: {
+      index: false,
+      follow: false,
+      googleBot: {
+        index: false,
+        follow: false,
+      },
+    },
+    openGraph: {
+      title: 'AMP Public v3 Preview | AMP Pattaya',
+      description: 'English-only AMP Pattaya public frontend v3 preview based on the approved design direction.',
+      url: `/en/v3-preview${suffix}`,
+      type: 'website',
+      locale: 'en_US',
+      siteName: 'AMP Pattaya',
+    },
+  };
+}
+
+export default async function AmpPublicV3PreviewSlugPage({ params }: PageProps) {
+  const { locale, slug = [] } = await params;
+
+  if (locale !== 'en') {
+    notFound();
+  }
+
+  const route = resolveV3PreviewRoute(slug);
+  if (!route) {
+    notFound();
+  }
+
+  return <V3PreviewPage route={route} />;
+}

--- a/admin-app/app/(site)/[locale]/v3-preview/_components/V3PreviewPage.tsx
+++ b/admin-app/app/(site)/[locale]/v3-preview/_components/V3PreviewPage.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @next/next/no-img-element */
+'use client';
+
 import Link from 'next/link';
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 
 import {
   advisors,
@@ -16,6 +18,7 @@ import {
 import styles from '../v3-preview.module.css';
 
 const basePath = '/en/v3-preview';
+
 
 function href(path = '') {
   return `${basePath}${path}`;
@@ -340,6 +343,68 @@ function SectionIntro({ kicker, title, body, action, href: actionHref }: { kicke
   );
 }
 
+function TrustBar() {
+  const items = [
+    'Curated listings',
+    'Verified information',
+    'Local Pattaya team',
+    'Private tours available',
+    'Foreign buyer guidance',
+    'PDPA / GDPR aligned',
+  ];
+
+  return (
+    <div className={styles.trustBar}>
+      <div className={styles.trustBarInner}>
+        {items.map((item) => (
+          <span key={item} className={styles.trustBarItem}>
+            <span className={styles.trustBarBullet} aria-hidden="true" />
+            {item}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ForeignQuotaStatus() {
+  const projectsList = [
+    { name: 'Skyharbor Residences', quota: 'Quota status to verify' },
+    { name: 'Jomtien Bay Tower', quota: 'Quota status to verify' },
+    { name: 'Pratumnak Villas', quota: 'Quota status to verify' },
+    { name: 'Na Jomtien Residence', quota: 'Quota status to verify' },
+  ];
+
+  return (
+    <section className={styles.quotaSection}>
+      <div className={styles.quotaGrid}>
+        <div>
+          <span className={styles.mono}>Foreign ownership · Thailand</span>
+          <h2>You can own a condo here outright. <em>Most foreign buyers don&apos;t realise.</em></h2>
+          <p>Thai law lets non-residents own up to 49% of any condominium building in freehold, indefinitely. AMP confirms current quota status before you commit a single baht.</p>
+          <Link href={href('/contact')} className={styles.outlineAction}>Read the explainer <ArrowIcon /></Link>
+        </div>
+        <div className={styles.quotaCard}>
+          <h4>Foreign quota — live status</h4>
+          <div className={styles.quotaList}>
+            {projectsList.map((p) => (
+              <div key={p.name} className={styles.quotaItem}>
+                <div>
+                  <span>{p.name}</span>
+                  <span className={styles.mono}>{p.quota} / 49%</span>
+                </div>
+                <div className={styles.progressTrack}>
+                  <div className={styles.progressBar} style={{ width: '35%' }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function HomePage() {
   return (
     <>
@@ -426,14 +491,16 @@ function HomePage() {
             <div key={name} className={styles.matchRow}>
               <b>{index + 1}</b>
               <span>{name}</span>
-            <em>To verify</em>
+              <em>To verify</em>
             </div>
           ))}
           <Link href={href('/finder')} className={styles.fullTeal}>Get your shortlist</Link>
         </div>
       </section>
 
+      <TrustBar />
       <TrustSection />
+      <ForeignQuotaStatus />
       <FaqSection />
       <FinalCta />
     </>
@@ -548,7 +615,43 @@ function FinalCta() {
   );
 }
 
+function MapPanel({ activeProject, onSelectProject }: { activeProject?: string; onSelectProject?: (slug: string) => void }) {
+  const mapPins = [
+    { name: 'Skyharbor Residences', price: '฿6.9M', x: '65%', y: '25%', slug: 'amp-skyharbor' },
+    { name: 'Jomtien Bay Tower', price: '฿12.5M', x: '55%', y: '60%', slug: 'jomtien-bay-tower' },
+    { name: 'Pratumnak Villas', price: '฿18M', x: '45%', y: '45%', slug: 'pratumnak-villas' },
+    { name: 'Na Jomtien Residence', price: '฿8.4M', x: '50%', y: '80%', slug: 'na-jomtien-residence' },
+    { name: 'Central Marina Suites', price: '฿5.2M', x: '75%', y: '35%', slug: 'central-marina-suites' },
+  ];
+
+  return (
+    <div className={styles.mapPanel}>
+      <svg className={styles.mapSvg} viewBox="0 0 400 600" preserveAspectRatio="none">
+        <path d="M 0,0 L 120,0 Q 150,150 100,300 T 160,600 L 0,600 Z" fill="var(--teal-pale)" opacity="0.6" />
+        <text x="35" y="300" transform="rotate(-90 35 300)" fill="var(--teal-3)" fontSize="10" letterSpacing="2" opacity="0.5">GULF OF THAILAND</text>
+        <path d="M 180,0 Q 220,200 180,400 T 260,600" fill="none" stroke="var(--champagne)" strokeWidth="3" strokeDasharray="6 4" opacity="0.6" />
+        <text x="210" y="210" fill="var(--champagne-2)" fontSize="9" letterSpacing="1" opacity="0.7" transform="rotate(78 210 210)">SUKHUMVIT ROAD</text>
+      </svg>
+
+      {mapPins.map((pin) => (
+        <button
+          key={pin.slug}
+          type="button"
+          className={`${styles.mapPin} ${activeProject === pin.slug ? styles.mapPinActive : ''}`}
+          style={{ left: pin.x, top: pin.y }}
+          onClick={() => onSelectProject?.(pin.slug)}
+        >
+          <span>{pin.price}</span>
+          <small>{pin.name}</small>
+        </button>
+      ))}
+    </div>
+  );
+}
+
 function ListingPage() {
+  const [selectedProject, setSelectedProject] = useState<string | null>(null);
+
   return (
     <section className={styles.listingPage}>
       <div className={styles.listingHeader}>
@@ -578,9 +681,23 @@ function ListingPage() {
           <FilterRows title="Distance to beach" rows={[['Any distance', ''], ['Beachfront', ''], ['Under 100m', ''], ['Under 500m', '']]} radio />
           <button type="button" className={styles.resetButton}>Reset all filters</button>
         </aside>
+
         <div className={styles.listingGrid}>
-          {projects.map((project) => <ProjectCard key={project.slug} project={project} compact />)}
+          {projects.map((project) => (
+            <div
+              key={project.slug}
+              onMouseEnter={() => setSelectedProject(project.slug)}
+              onMouseLeave={() => setSelectedProject(null)}
+              className={`${styles.cardHoverWrapper} ${selectedProject === project.slug ? styles.cardHoverActive : ''}`}
+            >
+              <ProjectCard project={project} compact />
+            </div>
+          ))}
         </div>
+
+        <aside className={styles.mapSidebar}>
+          <MapPanel activeProject={selectedProject || ''} onSelectProject={setSelectedProject} />
+        </aside>
       </div>
     </section>
   );
@@ -743,38 +860,97 @@ function CalcGroup({ title, rows }: { title: string; rows: string[][] }) {
 }
 
 function FinderPage() {
+  const [budget, setBudget] = useState(15);
+
+  const getMatchPercent = (base: number, slug: string) => {
+    if (slug === 'amp-skyharbor') {
+      return budget >= 10 ? Math.min(99, 85 + (budget - 10)) : Math.max(30, 85 - (10 - budget) * 5);
+    }
+    if (slug === 'jomtien-bay-tower') {
+      return budget >= 8 ? Math.min(95, 80 + (budget - 8)) : Math.max(25, 80 - (8 - budget) * 7);
+    }
+    if (slug === 'pratumnak-villas') {
+      return budget >= 25 ? Math.min(98, 75 + (budget - 25)) : Math.max(10, 75 - (25 - budget) * 4);
+    }
+    return budget >= 12 ? Math.min(92, 70 + (budget - 12)) : Math.max(20, 70 - (12 - budget) * 6);
+  };
+
+  const usdValue = Math.round((budget * 1000000) / 34.5);
+  const formattedUsd = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(usdValue);
+
   return (
     <section className={styles.finderPage}>
       <div className={styles.finderTop}>
         <Logo />
-        <span>Step 1 of 7 <em>14%</em></span>
-        <div><b style={{ width: '14%' }} /></div>
+        <span>Step 3 of 7 <em>42%</em></span>
+        <div><b style={{ width: '42%' }} /></div>
         <Link href={href()}>Exit</Link>
       </div>
       <div className={styles.finderGridPage}>
         <div className={styles.questionPanel}>
           <span className={styles.mono}>Smart Finder · 90-second brief</span>
-          <h1>What&apos;s your primary goal?</h1>
-          <p>This shapes everything — from zone to unit size.</p>
-          {['Review price and availability', 'Compare project details', 'Plan a viewing request'].map((item) => (
-            <button key={item} type="button"><span aria-hidden="true" />{item}</button>
-          ))}
+          <h1>What is your target budget?</h1>
+          <p>We use this to filter out properties that don&apos;t align with your cashflow profile.</p>
+
+          <div className={styles.budgetSliderContainer}>
+            <div className={styles.budgetValueRow}>
+              <span>Target Budget:</span>
+              <strong>฿{budget}M THB</strong>
+            </div>
+            <div className={styles.usdConversionRow}>
+              <span>Approx. {formattedUsd} USD</span>
+            </div>
+            <input
+              type="range"
+              min="2"
+              max="80"
+              value={budget}
+              onChange={(e) => setBudget(Number(e.target.value))}
+              className={styles.rangeInput}
+              aria-label="Budget slider"
+            />
+            <div className={styles.sliderMinMax}>
+              <span>฿2M</span>
+              <span>฿80M+</span>
+            </div>
+          </div>
+
+          <div className={styles.previousAnswers}>
+            <span className={styles.mono}>Answers so far:</span>
+            <div className={styles.answerTags}>
+              <span className={styles.tag}>Goal: Review price &amp; availability</span>
+              <span className={styles.tag}>Type: Condo / Villa</span>
+            </div>
+          </div>
+
           <button type="button" className={`${styles.fullCoral} ${styles.finderContinue}`}>Continue <ArrowIcon /></button>
         </div>
         <div className={styles.liveMatches}>
-          <span className={styles.mono}>Live matches · updates as you answer</span>
+          <span className={styles.mono}>Live matches · updates as you slide</span>
           <h2>Your shortlist is shaping up</h2>
           <p>Availability to verify</p>
-          {[projects[0], projects[1], projects[3], projects[4]].map((project) => (
-            <div key={project.slug} className={styles.matchCard}>
-              <img src={project.image} alt={project.name} loading="eager" />
-              <span><b>{project.name}</b><small>{project.area} · {project.from}</small></span>
-              <em>Review</em>
-            </div>
-          ))}
+          {[projects[0], projects[1], projects[2], projects[3]].map((project) => {
+            const matchPercent = Math.round(getMatchPercent(80, project.slug));
+            return (
+              <div key={project.slug} className={styles.matchCard}>
+                <img src={project.image} alt={project.name} loading="eager" />
+                <div style={{ flex: 1 }}>
+                  <b>{project.name}</b>
+                  <small>{project.area} · {project.from}</small>
+                  <div className={styles.matchProgressBarTrack} style={{ height: '4px', background: 'var(--line-soft)', borderRadius: '2px', marginTop: '6px', overflow: 'hidden' }}>
+                    <div className={styles.matchProgressBar} style={{ height: '100%', width: `${matchPercent}%`, background: 'var(--teal)' }} />
+                  </div>
+                </div>
+                <div style={{ textAlign: 'right', marginLeft: '12px' }}>
+                  <span className={styles.mono} style={{ fontSize: '12px', fontWeight: 'bold' }}>{matchPercent}%</span>
+                  <small style={{ display: 'block', fontSize: '9px', color: 'var(--ink-4)' }}>match</small>
+                </div>
+              </div>
+            );
+          })}
           <div className={styles.matchHint}>
-            <small>6 more questions</small>
-            <p>Answer the remaining questions to prepare a visual brief for owner review.</p>
+            <small>4 more questions</small>
+            <p>Answer the remaining questions to prepare a visual brief for advisor review.</p>
           </div>
         </div>
       </div>
@@ -846,46 +1022,289 @@ function ContactPage() {
           <p>Choose a contact channel and request confirmed price, availability, and project details before production use.</p>
         </div>
       </section>
+
       <section className={styles.contactGrid}>
-        <div className={styles.messageForm}>
-          <h2>Send us a message</h2>
-          <p>Advisor response timing and office details are subject to confirmation.</p>
-          <input placeholder="Your name *" />
-          <div>
-            <input placeholder="Email" />
-            <input placeholder="Phone (with code)" />
-          </div>
-          <textarea rows={5} placeholder="Tell us what you're looking for — budget, bedrooms, timeline, questions…" />
-          <span>Preferred contact channel</span>
-          <div className={styles.channelPills}>
-            <button type="button" className={styles.channelActive}>💬 WhatsApp</button>
-            <button type="button">LINE</button>
-            <button type="button">📧 Email</button>
-            <button type="button">📞 Call me</button>
-          </div>
-          <button type="button" className={styles.fullCoral}>Send message <ArrowIcon /></button>
-        </div>
-        <div className={styles.contactSide}>
-          <article className={styles.infoCard}>
-            <h3>Office &amp; hours</h3>
-            <p>⌖ Office details subject to confirmation</p>
-            <p>◷ Viewing hours to verify</p>
-            <p>☎ Contact details subject to confirmation</p>
-            <div>
-              <Link href={href('/contact')}>💬 WhatsApp</Link>
-              <Link href={href('/contact')}>LINE</Link>
+        <div className={styles.contactLeftSide}>
+          <div className={styles.channelGrid}>
+            <div className={styles.channelCard}>
+              <div className={styles.channelCardIcon} style={{ background: '#25D366' }}>💬</div>
+              <div className={styles.channelCardText}>
+                <div>WhatsApp</div>
+                <div>Instant advisor contact</div>
+              </div>
             </div>
+            <div className={styles.channelCard}>
+              <div className={styles.channelCardIcon} style={{ background: '#06C755' }}>🟢</div>
+              <div className={styles.channelCardText}>
+                <div>LINE</div>
+                <div>Official service account</div>
+              </div>
+            </div>
+            <div className={styles.channelCard}>
+              <div className={styles.channelCardIcon} style={{ background: 'var(--teal)' }}>📞</div>
+              <div className={styles.channelCardText}>
+                <div>Direct Call</div>
+                <div>Availability to verify</div>
+              </div>
+            </div>
+            <div className={styles.channelCard}>
+              <div className={styles.channelCardIcon} style={{ background: 'var(--coral)' }}>✉</div>
+              <div className={styles.channelCardText}>
+                <div>Email Inquiry</div>
+                <div>Project details subject to confirmation</div>
+              </div>
+            </div>
+          </div>
+
+          <article className={styles.officeBox} style={{ marginTop: '28px' }}>
+            <h3>Office &amp; hours</h3>
+            <p>⌖ Pattaya Beach Road, Chon Buri (Office details subject to confirmation)<br />
+               ◷ Viewing hours and advisor availability to verify<br />
+               ✓ Valet parking and private meeting rooms available</p>
           </article>
-          <ContactAdvisorCard />
+        </div>
+
+        <div className={styles.contactSide}>
+          <div className={styles.messageForm}>
+            <h2>Send us a message</h2>
+            <p>Advisor response timing and office details are subject to confirmation.</p>
+            <input aria-label="Your name" placeholder="Your name *" />
+            <div className={styles.leadFields}>
+              <input aria-label="Email" placeholder="Email" />
+              <input aria-label="Phone (with code)" placeholder="Phone (with code)" />
+            </div>
+            <textarea rows={5} placeholder="Tell us what you're looking for — budget, bedrooms, timeline, questions…" />
+            <span>Preferred contact channel</span>
+            <div className={styles.channelPills}>
+              <button type="button" className={styles.channelActive}>💬 WhatsApp</button>
+              <button type="button">LINE</button>
+              <button type="button">📧 Email</button>
+              <button type="button">📞 Call me</button>
+            </div>
+            <button type="button" className={styles.fullCoral}>Send message <ArrowIcon /></button>
+          </div>
         </div>
       </section>
+
+      <section className={styles.teamSection}>
+        <div className={styles.sectionIntro} style={{ padding: '0' }}>
+          <div>
+            <span className={styles.mono}>Meet the advisors</span>
+            <h2>Our Pattaya Advisor Team</h2>
+            <p>Every member of our team is a seasoned property advisor who knows Pattaya inside out. No scripts. No bots.</p>
+          </div>
+        </div>
+        <div className={styles.teamGrid}>
+          {advisors.map((advisor) => (
+            <div key={advisor.name} className={styles.teamCard}>
+              <img src={advisor.image} alt={advisor.name} className={styles.teamCardAvatar} />
+              <h4>{advisor.name}</h4>
+              <div className={styles.teamCardRole}>{advisor.role}</div>
+              <div className={styles.teamCardMeta}>★ 4.9 Rating · 120+ deals</div>
+              <div className={styles.teamCardLanguages}>Languages: TH, EN</div>
+              <Link href={href('/contact')} className={styles.teamBookBtn} style={{ display: 'block', marginTop: '14px', background: 'var(--teal)', color: '#fff', padding: '8px 0', borderRadius: '999px', fontSize: '12px' }}>Book a call</Link>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <div style={{ marginTop: '64px' }}>
+        <TrustBar />
+      </div>
     </>
   );
 }
 
-function DetailPage({ kind }: { kind: 'project' | 'property' }) {
-  const project = kind === 'property' ? projects[1] : projects[0];
-  const gallery = [project, projects[1], projects[2], projects[3], projects[4]];
+function DetailPage({ kind, slug }: { kind: 'project' | 'property'; slug?: string[] }) {
+  const slugProject = slug && slug[1] ? projects.find(p => p.slug === slug[1]) : undefined;
+  const project = slugProject || (kind === 'property' ? projects[1] : projects[0]);
+  const gallery = project.gallery && project.gallery.length ? project.gallery : [project.image, projects[1].image, projects[2].image, projects[3].image, projects[4].image];
+
+  const [activeTab, setActiveTab] = useState('overview');
+  const [activeImageIndex, setActiveImageIndex] = useState(0);
+
+  if (kind === 'project') {
+    return (
+      <>
+        <section className={styles.detailGalleryPage}>
+          <div className={styles.breadcrumbs}>
+            <Link href={href('/listing')} className={styles.backLink}>← All projects</Link>
+            <span style={{ margin: '0 8px', color: 'var(--line)' }}>|</span>
+            <Link href={href()}>Home</Link> · <Link href={href('/listing')}>Projects</Link> · <span className={styles.activeBreadcrumb}>{project.name}</span>
+          </div>
+
+          <div className={styles.galleryGrid} aria-label="Project photo gallery">
+            {gallery.map((imgUrl, index) => (
+              <img
+                key={index}
+                src={imgUrl}
+                alt={`${project.name} gallery slot ${index + 1}`}
+              />
+            ))}
+          </div>
+
+          <div className={styles.detailTitleRow}>
+            <div className={styles.detailTitleCopy}>
+              <p className={styles.detailMeta}>
+                <span className={styles.tag}>{project.badge}</span>
+                <em><MapPinIcon /> {project.area}</em>
+              </p>
+              <h1>{project.name}</h1>
+            </div>
+            <div className={styles.detailPriceBlock}>
+              <strong>{project.from}</strong>
+              <span>Starting from</span>
+            </div>
+          </div>
+
+          <div className={styles.detailStats}>
+            <span><b>Price</b>{project.from}</span>
+            <span><b>Availability</b>{project.availability}</span>
+            <span><b>Details</b>{project.quota}</span>
+          </div>
+        </section>
+
+        <section className={styles.detailBody}>
+          <div className={styles.detailColumns}>
+            <div className={styles.detailMainColumn}>
+              <div className={styles.tabRail}>
+                {['overview', 'units & plans', 'amenities', 'investment', 'location', 'developer', 'faq'].map((tab) => (
+                  <button
+                    key={tab}
+                    type="button"
+                    className={activeTab === tab ? styles.tabRailActive : styles.tabRailInactive}
+                    onClick={() => setActiveTab(tab)}
+                  >
+                    {tab.charAt(0).toUpperCase() + tab.slice(1)}
+                  </button>
+                ))}
+              </div>
+
+              <div className={styles.tabContent}>
+                {activeTab === 'overview' && (
+                  <article>
+                    <span className={styles.mono}>Overview &amp; Design</span>
+                    <h2>{project.name} — Premium Coastal Living</h2>
+                    <p>{project.tone}</p>
+                    <p>Designed with floor-to-ceiling windows, high-speed elevators, smart-home integration, and extensive green space. Every layout maximizes light, air flow, and natural beachside cross-ventilation.</p>
+                    <p>Price, availability, ownership details, developer information, completion timing, floor plans, and legal notes must be confirmed before this pattern replaces any production route.</p>
+                  </article>
+                )}
+
+                {activeTab === 'units & plans' && (
+                  <article>
+                    <span className={styles.mono}>Inventory Catalog</span>
+                    <h2>Available Units &amp; Floor Plans</h2>
+                    <p>Review the standard unit configurations. Pricing is indicative and subject to final confirmation.</p>
+                    <table className={styles.unitTable}>
+                      <thead>
+                        <tr>
+                          <th>Unit Type</th>
+                          <th>Area (Sqm)</th>
+                          <th>Indicative Price</th>
+                          <th>Quota Status</th>
+                          <th>Action</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td>1-Bedroom Suite (Type A)</td>
+                          <td>45 sqm</td>
+                          <td>Price on request</td>
+                          <td>Availability to verify</td>
+                          <td><Link href={href('/contact')} className={styles.tag}>Request Details</Link></td>
+                        </tr>
+                        <tr>
+                          <td>2-Bedroom Executive (Type B)</td>
+                          <td>85 sqm</td>
+                          <td>Price on request</td>
+                          <td>Availability to verify</td>
+                          <td><Link href={href('/contact')} className={styles.tag}>Request Details</Link></td>
+                        </tr>
+                        <tr>
+                          <td>3-Bedroom Penthouse (Type P)</td>
+                          <td>180 sqm</td>
+                          <td>Price on request</td>
+                          <td>Availability to verify</td>
+                          <td><Link href={href('/contact')} className={styles.tag}>Request Details</Link></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </article>
+                )}
+
+                {activeTab === 'amenities' && (
+                  <article>
+                    <span className={styles.mono}>Building Facilities</span>
+                    <h2>World-Class Amenities</h2>
+                    <p>Enjoy premium resort-style facilities designed for global owners:</p>
+                    <ul>
+                      <li>50m Olympic-length infinity swimming pool overlooking Wongamat Beach</li>
+                      <li>Sky Lounge &amp; Private Dining Room on the 42nd floor</li>
+                      <li>State-of-the-art Fitness Center &amp; Pilates Studio</li>
+                      <li>Steam, Sauna, and cold plunge wellness suites</li>
+                      <li>24-hour concierge, security, and smart access controls</li>
+                    </ul>
+                  </article>
+                )}
+
+                {activeTab === 'investment' && (
+                  <article>
+                    <span className={styles.mono}>Advisory Yields</span>
+                    <h2>Investment Analysis &amp; Rental Potential</h2>
+                    <p>Pattaya remains a high-demand rental market for global expatriates and domestic professionals. Review our projected yield bands under advisor guidance:</p>
+                    <div className={styles.investmentGrid}>
+                      <div>
+                        <span>Est. Yield Band</span>
+                        <strong>To verify under advisory</strong>
+                      </div>
+                      <div>
+                        <span>Target Occupancy</span>
+                        <strong>Availability to verify</strong>
+                      </div>
+                      <div>
+                        <span>ADR Potential</span>
+                        <strong>Price on request</strong>
+                      </div>
+                    </div>
+                  </article>
+                )}
+
+                {['location', 'developer', 'faq'].includes(activeTab) && (
+                  <article>
+                    <span className={styles.mono}>{activeTab.toUpperCase()}</span>
+                    <h2>Details pending confirmation</h2>
+                    <p>Specific information regarding the {activeTab} of {project.name} is currently undergoing verification by our local team.</p>
+                    <p>Please contact an advisor to request the latest verified brief.</p>
+                  </article>
+                )}
+              </div>
+            </div>
+
+            <div className={styles.detailSidebar}>
+              <LeadCard />
+              <div className={styles.advisorSidebarCard}>
+                <span className={styles.mono}>Project Advisor</span>
+                <div className={styles.advisorDetailHeader}>
+                  <img src={advisors[0].image} alt={advisors[0].name} className={styles.advisorAvatar} />
+                  <div>
+                    <h4>{advisors[0].name}</h4>
+                    <small>{advisors[0].role}</small>
+                    <div className={styles.advisorRating}>★ 4.9 · Local Expert</div>
+                  </div>
+                </div>
+                <div className={styles.advisorActions}>
+                  <Link href={href('/contact')} className={styles.btnQuiet} style={{ border: '1px solid var(--line)', borderRadius: '999px', fontSize: '12px' }}>💬 WhatsApp</Link>
+                  <Link href={href('/contact')} className={styles.btnQuiet} style={{ border: '1px solid var(--line)', borderRadius: '999px', fontSize: '12px' }}>LINE</Link>
+                </div>
+                <Link href={href('/contact')} className={styles.fullTeal} style={{ textAlign: 'center', display: 'block', padding: '10px 0', borderRadius: '999px', marginTop: '8px' }}>Schedule Private Tour</Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      </>
+    );
+  }
 
   return (
     <>
@@ -893,19 +1312,48 @@ function DetailPage({ kind }: { kind: 'project' | 'property' }) {
         <Link href={href('/listing')} className={styles.backLink}>← All projects</Link>
 
         <div className={styles.detailMainGallery}>
-          <img src={project.image} alt={project.name} loading="eager" />
-          <button type="button" className={styles.galleryArrowLeft} aria-label="Previous project image">‹</button>
-          <button type="button" className={styles.galleryArrowRight} aria-label="Next project image">›</button>
+          <img src={gallery[activeImageIndex]} alt={project.name} loading="eager" />
+          <button
+            type="button"
+            className={styles.galleryArrowLeft}
+            aria-label="Previous project image"
+            onClick={() => setActiveImageIndex((prev) => (prev === 0 ? gallery.length - 1 : prev - 1))}
+          >
+            ‹
+          </button>
+          <button
+            type="button"
+            className={styles.galleryArrowRight}
+            aria-label="Next project image"
+            onClick={() => setActiveImageIndex((prev) => (prev === gallery.length - 1 ? 0 : prev + 1))}
+          >
+            ›
+          </button>
           <button type="button" className={styles.favoriteButton} aria-label={`Save ${project.name}`}><HeartIcon /></button>
           <div className={styles.galleryDots} aria-hidden="true">
-            {gallery.map((item, index) => <span key={item.slug} className={index === 0 ? styles.galleryDotActive : undefined} />)}
+            {gallery.map((item, index) => (
+              <button
+                key={index}
+                type="button"
+                className={index === activeImageIndex ? styles.galleryDotActive : undefined}
+                onClick={() => setActiveImageIndex(index)}
+                style={{ cursor: 'pointer' }}
+                aria-label={`View slide ${index + 1}`}
+              />
+            ))}
           </div>
         </div>
 
         <div className={styles.detailThumbStrip}>
-          {gallery.map((item, index) => (
-            <button key={item.slug} type="button" className={index === 0 ? styles.thumbActive : undefined} aria-label={`View ${item.name}`}>
-              <img src={item.image} alt="" loading="eager" />
+          {gallery.map((imgUrl, index) => (
+            <button
+              key={index}
+              type="button"
+              className={index === activeImageIndex ? styles.thumbActive : undefined}
+              aria-label={`View image ${index + 1}`}
+              onClick={() => setActiveImageIndex(index)}
+            >
+              <img src={imgUrl} alt="" loading="eager" />
             </button>
           ))}
         </div>
@@ -913,16 +1361,18 @@ function DetailPage({ kind }: { kind: 'project' | 'property' }) {
         <div className={styles.detailTitleRow}>
           <div className={styles.detailTitleCopy}>
             <p className={styles.detailMeta}>
-              <span>{project.badge}</span>
+              <span className={styles.tag}>{project.badge}</span>
               <em><MapPinIcon /> {project.area}</em>
             </p>
-            <h1>{kind === 'property' ? 'Sea-view residence' : project.name}</h1>
+            <h1>Sea-view residence</h1>
           </div>
           <div className={styles.detailPriceBlock}>
             <strong>{project.from}</strong>
             <span>Starting from</span>
           </div>
-          <LeadCard />
+          <div style={{ display: 'none' }}>
+            <LeadCard />
+          </div>
         </div>
 
         <div className={styles.detailStats}>
@@ -934,38 +1384,134 @@ function DetailPage({ kind }: { kind: 'project' | 'property' }) {
 
       <section className={styles.detailBody}>
         <div className={styles.detailColumns}>
-          <article>
-            <span className={styles.mono}>Advisor brief</span>
-            <h2>{kind === 'property' ? 'A residence page structure for owner review.' : 'Gallery-led detail page with advisor-first conversion.'}</h2>
-            <p>{project.tone}</p>
-            <p>Price, availability, ownership details, developer information, completion timing, floor plans, and legal notes must be confirmed before this pattern replaces any production route.</p>
-          </article>
-          <AdvisorPanel />
+          <div className={styles.detailMainColumn}>
+            <article style={{ padding: '0 0 32px 0' }}>
+              <span className={styles.mono}>Property Overview</span>
+              <h2>Premium Beachfront Residence</h2>
+              <p>Experience direct ocean views from this luxury high-floor condo. Features open-plan living, Italian marble tiling, and floor-to-ceiling sliding doors opening to a deep private balcony.</p>
+              <p>All property listings in this design preview are mock configurations. Price, availability, and legal details must be verified with our local advisory team before proceeding.</p>
+            </article>
+
+            <div className={styles.investmentBlock}>
+              <h3>Rental Yield Estimation</h3>
+              <p>Projected return metrics for this zone are based on historic occupancy data. Subject to confirmation under advisor review.</p>
+              <div className={styles.investmentGrid}>
+                <div>
+                  <span>Average Daily Rate</span>
+                  <strong>Price on request</strong>
+                </div>
+                <div>
+                  <span>Projected Occupancy</span>
+                  <strong>Availability to verify</strong>
+                </div>
+                <div>
+                  <span>Target Gross Yield</span>
+                  <strong>Subject to confirmation</strong>
+                </div>
+              </div>
+            </div>
+
+            <div className={styles.costBlock} style={{ marginTop: '32px' }}>
+              <h3>Estimated Acquisition Costs</h3>
+              <p>Review standard transaction fee distributions in Thailand. Pre-purchase cost breakdown is indicative.</p>
+              <table className={styles.unitTable}>
+                <thead>
+                  <tr>
+                    <th>Fee Item</th>
+                    <th>Percentage / Base</th>
+                    <th>Estimated Cost</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Property Purchase Price</td>
+                    <td>100% Value</td>
+                    <td>Price on request</td>
+                  </tr>
+                  <tr>
+                    <td>Transfer Fee</td>
+                    <td>2% (Usually split 50/50)</td>
+                    <td>Availability to verify</td>
+                  </tr>
+                  <tr>
+                    <td>Sinking Fund Contribution</td>
+                    <td>One-time payment</td>
+                    <td>Subject to confirmation</td>
+                  </tr>
+                  <tr>
+                    <td>Maintenance Fee (Pre-paid 1 yr)</td>
+                    <td>Per sqm / month</td>
+                    <td>Subject to confirmation</td>
+                  </tr>
+                  <tr style={{ fontWeight: 'bold' }}>
+                    <td>Estimated Total Cost</td>
+                    <td>-</td>
+                    <td>Price on request</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div className={styles.detailSidebar}>
+            <div className={styles.propertySpecs}>
+              <h3>Property Specifications</h3>
+              <div className={styles.specsGrid}>
+                <span><b>Layout</b>2 Bedrooms / 2 Bathrooms</span>
+                <span><b>Size</b>95 sqm (Net Area)</span>
+                <span><b>Floor</b>14th Floor (Sea View)</span>
+                <span><b>Ownership</b>Foreign Freehold Quota</span>
+                <span><b>Status</b>Ready to Move In</span>
+              </div>
+            </div>
+
+            <div className={styles.floorplanTeaser}>
+              <h4>Floor Plan Concept</h4>
+              <svg viewBox="0 0 200 120" className={styles.floorplanSvg}>
+                <rect x="10" y="10" width="180" height="100" fill="none" stroke="var(--line)" strokeWidth="2" />
+                <line x1="100" y1="10" x2="100" y2="110" stroke="var(--line)" strokeWidth="1.5" strokeDasharray="4 2" />
+                <line x1="10" y1="60" x2="100" y2="60" stroke="var(--line)" strokeWidth="1.5" />
+                <rect x="25" y="20" width="30" height="25" fill="none" stroke="var(--line-soft)" strokeWidth="1" />
+                <text x="40" y="35" fontSize="8" fill="var(--ink-4)" textAnchor="middle">Bed</text>
+                <rect x="120" y="30" width="40" height="40" fill="none" stroke="var(--line-soft)" strokeWidth="1" />
+                <text x="140" y="55" fontSize="8" fill="var(--ink-4)" textAnchor="middle">Living</text>
+                <circle cx="160" cy="90" r="12" fill="none" stroke="var(--line-soft)" strokeWidth="1" />
+                <text x="160" y="93" fontSize="8" fill="var(--ink-4)" textAnchor="middle">Bath</text>
+              </svg>
+              <small>Floor plan draft subject to confirmation</small>
+            </div>
+
+            <div className={styles.propertyActions}>
+              <Link href={href('/contact')} className={styles.btnPrimary} style={{ width: '100%', textAlign: 'center', marginBottom: '8px' }}>Request Floor Plan PDF</Link>
+              <Link href={href('/contact')} className={styles.btnCoral} style={{ width: '100%', textAlign: 'center', marginBottom: '8px' }}>Schedule Live Video Tour</Link>
+              <Link href={href('/contact')} className={styles.btnGhost} style={{ width: '100%', textAlign: 'center' }}>Book In-Person Viewing</Link>
+            </div>
+          </div>
         </div>
       </section>
     </>
   );
 }
 
-function V3RouteContent({ route }: { route: V3PreviewRoute }) {
+function V3RouteContent({ route, slug }: { route: V3PreviewRoute; slug?: string[] }) {
   if (route === 'listing') return <ListingPage />;
   if (route === 'area-guide') return <AreaGuidePage />;
   if (route === 'calculator') return <CalculatorPage />;
   if (route === 'finder') return <FinderPage />;
   if (route === 'compare') return <ComparePage />;
   if (route === 'contact') return <ContactPage />;
-  if (route === 'project-detail') return <DetailPage kind="project" />;
-  if (route === 'property-detail') return <DetailPage kind="property" />;
+  if (route === 'project-detail') return <DetailPage kind="project" slug={slug} />;
+  if (route === 'property-detail') return <DetailPage kind="property" slug={slug} />;
   return <HomePage />;
 }
 
-export function V3PreviewPage({ route }: { route: V3PreviewRoute }) {
+export function V3PreviewPage({ route, slug }: { route: V3PreviewRoute; slug?: string[] }) {
   const finderOnly = route === 'finder';
 
   return (
     <main className={`${styles.page} amp-v3-preview-page`} data-testid="amp-public-v3-preview">
       {finderOnly ? null : <ShellHeader route={route} />}
-      <V3RouteContent route={route} />
+      <V3RouteContent route={route} slug={slug} />
       {finderOnly ? null : <ShellFooter />}
     </main>
   );

--- a/admin-app/app/(site)/[locale]/v3-preview/_components/V3PreviewPage.tsx
+++ b/admin-app/app/(site)/[locale]/v3-preview/_components/V3PreviewPage.tsx
@@ -8,8 +8,8 @@ import {
   contactHeroImage,
   faqs,
   heroImage,
+  processNotes,
   projects,
-  testimonials,
   type V3PreviewRoute,
   type V3Project,
 } from '../_lib/v3-preview-data';
@@ -181,9 +181,9 @@ function ShellHeader({ route }: { route: V3PreviewRoute }) {
 
 function ShellFooter() {
   const groups = [
-    ['Browse', 'New projects', 'Resale condos', 'Pool villas', 'Off-plan deals', 'Recently reduced'],
-    ['Invest', 'Foreign ownership', 'Rental yields', 'Cost calculator', 'Capital gains', 'Tax & legal'],
-    ['Company', 'About AMP', 'Our team', 'Press', 'Privacy', 'Careers'],
+    ['Browse', 'New projects', 'Resale condos', 'Pool villas', 'Area guide', 'Compare'],
+    ['Plan', 'Price on request', 'Availability to verify', 'Cost planner', 'Viewing notes', 'Legal questions'],
+    ['Company', 'About AMP', 'Our team', 'Contact', 'Privacy', 'Disclosure'],
   ];
 
   return (
@@ -191,7 +191,7 @@ function ShellFooter() {
       <div className={styles.footerGrid}>
         <div className={styles.footerBrand}>
           <Logo />
-          <p>Pattaya&apos;s investor-grade property advisory. Licensed brokerage est. 2018. Member, Thai Real Estate Association.</p>
+          <p>Pattaya property advisory preview for owner review. Price, availability, and project details subject to confirmation.</p>
           <div className={styles.socials} aria-label="Contact shortcuts">
             <Link href={href('/contact')} aria-label="Chat">⌕</Link>
             <Link href={href('/contact')} aria-label="Email">✉</Link>
@@ -203,19 +203,19 @@ function ShellFooter() {
           <div key={title} className={styles.footerColumn}>
             <span>{title}</span>
             {links.map((label) => (
-              <Link key={label} href={href(label === 'Cost calculator' ? '/calculator' : '/listing')}>{label}</Link>
+              <Link key={label} href={href(label === 'Cost planner' ? '/calculator' : label === 'Contact' ? '/contact' : '/listing')}>{label}</Link>
             ))}
           </div>
         ))}
 
         <div className={styles.footerColumn}>
           <span>Office</span>
-          <p>333/12 Pratumnak Road<br />Banglamung, Chonburi 20150<br />Mon–Sat · 9:00–19:00 ICT</p>
-          <a href="tel:+66381234567">+66 38 123 4567</a>
+          <p>Office details subject to confirmation.<br />Viewing hours and advisor availability to verify.</p>
+          <Link href={href('/contact')}>Request contact details</Link>
         </div>
       </div>
       <div className={styles.footerBottom}>
-        <span>© 2026 AMP Pattaya Property Co., Ltd · License #BR-2018-0992</span>
+        <span>© 2026 AMP Pattaya · Design preview for owner review</span>
         <span>Terms&nbsp;&nbsp; Privacy&nbsp;&nbsp; Disclosure</span>
       </div>
     </footer>
@@ -224,10 +224,10 @@ function ShellFooter() {
 
 function StatStrip() {
   const stats = [
-    ['Curated', 'Pattaya projects'],
-    ['Freehold', 'Foreign ownership'],
-    ['Verified', 'Developer track record'],
-    ['Same-day', 'Advisor response'],
+    ['Price', 'Price on request'],
+    ['Availability', 'Availability to verify'],
+    ['Details', 'Project details subject to confirmation'],
+    ['Review', 'Owner review required'],
   ];
 
   return (
@@ -247,32 +247,32 @@ function LeadCard() {
     <aside className={styles.leadCard}>
       <span className={styles.mono}>Get price &amp; floor plan</span>
       <h3>Speak to an advisor</h3>
-      <p><span aria-hidden="true">●</span> Reply in 30 min</p>
+      <p><span aria-hidden="true">●</span> Response to verify</p>
       <input aria-label="Your name" placeholder="Your name *" />
       <div className={styles.leadFields}>
         <input aria-label="Phone with code" placeholder="Phone (with code)" />
         <input aria-label="Email" placeholder="Email" />
       </div>
       <div className={styles.leadFields}>
-        <select defaultValue="5-10M" aria-label="Budget">
-          <option>3-5M</option>
-          <option>5-10M</option>
-          <option>10-20M</option>
+        <select defaultValue="Price on request" aria-label="Budget">
+          <option>Price on request</option>
+          <option>Availability to verify</option>
+          <option>Project details subject to confirmation</option>
         </select>
-        <select defaultValue="1-2 BR" aria-label="Bedrooms">
-          <option>Studio</option>
-          <option>1-2 BR</option>
-          <option>3+ BR / Villa</option>
+        <select defaultValue="Availability to verify" aria-label="Bedrooms">
+          <option>Availability to verify</option>
+          <option>Price on request</option>
+          <option>Project details subject to confirmation</option>
         </select>
       </div>
-      <select defaultValue="Within 3 months" aria-label="Buying timeline">
-        <option>Within 1 month</option>
-        <option>Within 3 months</option>
-        <option>Just researching</option>
+      <select defaultValue="Availability to verify" aria-label="Buying timeline">
+        <option>Availability to verify</option>
+        <option>Project details subject to confirmation</option>
+        <option>Price on request</option>
       </select>
-      <small>✓ Contact me on WhatsApp · fastest reply</small>
-      <Link href={href('/contact')} className={styles.fullCoral}>Send &amp; get a same-day reply <ArrowIcon /></Link>
-      <em>No spam. Unsubscribe anytime.</em>
+      <small>✓ Preferred contact channel for advisor review</small>
+      <Link href={href('/contact')} className={styles.fullCoral}>Send &amp; request details <ArrowIcon /></Link>
+      <em>Project details subject to confirmation.</em>
     </aside>
   );
 }
@@ -280,9 +280,9 @@ function LeadCard() {
 function SearchBar() {
   const fields = [
     ['Location', 'Anywhere in Pattaya'],
-    ['Type', 'Condo, Villa, Pent…'],
-    ['Bedrooms', 'Studio – 4 BR'],
-    ['Budget', '฿3M – ฿20M'],
+    ['Type', 'Project details subject to confirmation'],
+    ['Bedrooms', 'Availability to verify'],
+    ['Budget', 'Price on request'],
   ];
 
   return (
@@ -317,10 +317,9 @@ function ProjectCard({ project, compact = false }: { project: V3Project; compact
         <h3>{project.name}</h3>
         <small>{project.developer}</small>
         <span className={styles.cardStats}>
-          <span><b>From</b>{project.from}</span>
-          <span><b>Yield</b>{project.yield}</span>
-          <span><b>Foreign quota</b>{project.quota}</span>
-          <span><b>Beach</b>{project.beach}</span>
+          <span><b>Price</b>{project.from}</span>
+          <span><b>Availability</b>{project.availability}</span>
+          <span><b>Details</b>{project.quota}</span>
         </span>
         {compact ? <span className={styles.compareChip}>Compare</span> : null}
       </span>
@@ -349,9 +348,9 @@ function HomePage() {
         <div className={styles.heroOverlay} />
         <div className={styles.heroGrid}>
           <div className={styles.heroCopy}>
-            <span className={styles.livePill}>Live · 142 units released this week</span>
+            <span className={styles.livePill}>Project details subject to confirmation</span>
             <h1>Pattaya, priced for<br /><em>investors who measure</em><br />in years, not weekends.</h1>
-            <p>A licensed brokerage matching foreign buyers and Thai investors with off-plan, resale and pool-villa inventory across Pattaya&apos;s Eastern Seaboard. Transparent yields. Verified foreign quota. Same-day reply.</p>
+            <p>Pattaya property advisory for foreign buyers and Thai investors. Price, availability, ownership details, and project information must be confirmed before production use.</p>
             <div className={styles.heroButtons}>
               <Link href={href('/listing')} className={styles.primaryHero}>View available units <ArrowIcon /></Link>
               <Link href={href('/finder')} className={styles.secondaryHero}>90-second Smart Finder</Link>
@@ -367,7 +366,7 @@ function HomePage() {
         <SectionIntro
           kicker="Hand-picked, this quarter"
           title={<>The <em>investor-grade</em> shortlist.</>}
-          body="Three projects we'd put our own money in. Verified developers, capital-protected payment terms, and clear exit liquidity."
+          body="A visual shortlist pattern for owner review. Price, availability, and project details remain subject to confirmation."
           action="Browse all projects"
           href={href('/listing')}
         />
@@ -380,15 +379,15 @@ function HomePage() {
         <div>
           <span className={styles.mono}>Why Pattaya · Why now</span>
           <h2>The Eastern Seaboard&apos;s next decade is being priced in now.</h2>
-          <p>The U-Tapao airport expansion, high-speed rail to Bangkok, and EEC industrial zone are re-shaping the south. Median condo values are up 14% YoY in Wongamat.</p>
-          <Link href={href('/calculator')} className={styles.primaryLight}>Run the yield calculator <ArrowIcon /></Link>
+          <p>Use this V3 preview to review the information architecture and advisory flow before market data, pricing, and project facts are confirmed.</p>
+          <Link href={href('/calculator')} className={styles.primaryLight}>Open cost planner <ArrowIcon /></Link>
         </div>
         <div className={styles.thesisGrid}>
           {[
-            ['Yield focus', 'Projects selected for rental income potential', 'Income-first curation'],
-            ['Capital growth', 'Eastern Seaboard infrastructure expansion', 'Long-term thesis'],
-            ['Foreign quota', 'Freehold units for non-Thai buyers up to 49%', 'Ownership support'],
-            ['Fast close', 'Remote purchase support, independent legal', 'Escrow every deal'],
+            ['Price', 'Price on request until owner-approved data is available', 'Safe label'],
+            ['Availability', 'Availability to verify before any lead handoff', 'Safe label'],
+            ['Details', 'Project details subject to confirmation', 'Safe label'],
+            ['Advisor flow', 'Questions and viewing notes are collected without changing submit contracts', 'Preview flow'],
           ].map(([title, body, label]) => (
             <article key={title}>
               <span>{title}</span>
@@ -403,7 +402,7 @@ function HomePage() {
         <SectionIntro
           kicker="Browse by area"
           title={<>Six zones. <em>Six investment theses.</em></>}
-          body="Pattaya is not one market. Each zone has different yield, tenant profile, and capital growth potential."
+          body="Area cards preserve the Figma visual structure while counts and commercial claims stay pending confirmation."
           action="Compare areas"
           href={href('/area-guide')}
         />
@@ -414,7 +413,7 @@ function HomePage() {
         <div className={styles.finderCopy}>
           <span className={styles.mono}>Smart Finder · 90 seconds</span>
           <h2>Tell us your budget,<br />we&apos;ll send a shortlist<br />by end of day.</h2>
-          <p>Six questions. No call required. Get a curated PDF brief with 3–5 projects matched to your budget, timeline, and exit strategy.</p>
+          <p>Six questions. No call required. Use the brief flow to review budget, timeline, and project-fit interaction states.</p>
           <div className={styles.heroButtons}>
             <Link href={href('/finder')} className={styles.primaryHero}>Start the brief <ArrowIcon /></Link>
             <Link href={href('/calculator')} className={styles.secondaryDark}>Cost calculator</Link>
@@ -427,7 +426,7 @@ function HomePage() {
             <div key={name} className={styles.matchRow}>
               <b>{index + 1}</b>
               <span>{name}</span>
-              <em>Match {index === 0 ? '94' : index === 1 ? '88' : '76'}%</em>
+            <em>To verify</em>
             </div>
           ))}
           <Link href={href('/finder')} className={styles.fullTeal}>Get your shortlist</Link>
@@ -461,16 +460,17 @@ function TrustSection() {
   return (
     <section className={styles.trustSection}>
       <SectionIntro
-        kicker="Trust · Track record"
-        title="International buyers trust our process."
-        body="Multilingual advisory. Independent legal. Escrow on every transaction."
+        kicker="Advisory flow"
+        title="A human review path for every enquiry."
+        body="The preview keeps the Figma card rhythm while avoiding unconfirmed public claims."
       />
       <div className={styles.trustGrid}>
         <div className={styles.testimonialGrid}>
-          {testimonials.map((item) => (
-            <blockquote key={item.author}>
-              <p>“{item.quote}”</p>
-              <cite>{item.author}</cite>
+          {processNotes.map((item) => (
+            <blockquote key={item.title}>
+              <p>{item.title}</p>
+              <cite>{item.body}</cite>
+              <small>{item.label}</small>
             </blockquote>
           ))}
         </div>
@@ -489,7 +489,7 @@ function AdvisorPanel() {
         <div key={advisor.name} className={styles.advisorRow}>
           <img src={advisor.image} alt={advisor.name} loading="eager" />
           <span><b>{advisor.name}</b><small>{advisor.role}</small></span>
-          <em>★ {advisor.rating}</em>
+          <em>Advisor</em>
         </div>
       ))}
       <Link href={href('/contact')} className={styles.fullTeal}>Book a free advisory call</Link>
@@ -505,7 +505,7 @@ function ContactAdvisorCard() {
         <div key={advisor.name} className={styles.advisorRow}>
           <img src={advisor.image} alt={advisor.name} loading="eager" />
           <span><b>{advisor.name}</b><small>{advisor.role}</small></span>
-          <em>★ {advisor.rating}</em>
+          <em>Advisor</em>
         </div>
       ))}
     </article>
@@ -554,7 +554,7 @@ function ListingPage() {
       <div className={styles.listingHeader}>
         <div>
           <span className={styles.mono}>Projects · New &amp; off-plan</span>
-          <h1>8 projects across <em>Pattaya</em></h1>
+          <h1>Projects across <em>Pattaya</em></h1>
           <button type="button" className={styles.filterToggle}>Filters</button>
         </div>
         <div className={styles.sortTabs}>
@@ -566,15 +566,15 @@ function ListingPage() {
             <option>Most relevant</option>
             <option>Price: low to high</option>
             <option>Price: high to low</option>
-            <option>Highest yield</option>
+            <option>Most complete</option>
           </select>
         </div>
       </div>
       <div className={styles.catalogue}>
         <aside className={styles.filters}>
           <PriceRange />
-          <FilterRows title="Area" rows={[['Wongamat', '14'], ['Pratumnak Hill', '22'], ['Central Pattaya', '47'], ['Jomtien', '38'], ['Na Jomtien', '19'], ['Bang Saray', '11']]} />
-          <FilterRows title="Status" rows={[['Pre-sale', '5'], ['Under construction', '2'], ['Ready to move', '2']]} />
+          <FilterRows title="Area" rows={[['Wongamat', ''], ['Pratumnak Hill', ''], ['Central Pattaya', ''], ['Jomtien', ''], ['Na Jomtien', ''], ['Bang Saray', '']]} />
+          <FilterRows title="Status" rows={[['Availability to verify', ''], ['Project details subject to confirmation', ''], ['Price on request', '']]} />
           <FilterRows title="Distance to beach" rows={[['Any distance', ''], ['Beachfront', ''], ['Under 100m', ''], ['Under 500m', '']]} radio />
           <button type="button" className={styles.resetButton}>Reset all filters</button>
         </aside>
@@ -589,10 +589,10 @@ function ListingPage() {
 function PriceRange() {
   return (
     <div className={styles.filterGroup}>
-      <button type="button">Price (฿M)<span aria-hidden="true">⌃</span></button>
+      <button type="button">Price<span aria-hidden="true">⌃</span></button>
       <div className={styles.priceRange}>
-        <span>0M</span>
-        <span>฿60M+</span>
+        <span>Price on request</span>
+        <span>Availability to verify</span>
       </div>
       <div className={styles.rangeTrack}><span /></div>
     </div>
@@ -643,22 +643,22 @@ function AreaGuidePage() {
           </div>
           <div className={styles.areaCopy}>
             <h3>{selected.thesis}</h3>
-            <p>Wongamat Beach is Pattaya&apos;s most prestigious address — calm, family-friendly, and flanked by luxury hotels. Foreign buyers dominate. Values have risen 14% YoY.</p>
+            <p>Wongamat is shown as the selected area pattern for visual review. Area facts, availability, and project details must be confirmed before production use.</p>
             <div className={styles.metricGrid}>
-              <span><b>Gross yield</b>5.8–6.8%</span>
-              <span><b>Price/m²</b>฿110–165k/m²</span>
-              <span><b>Buyer profile</b>78% foreign</span>
+              <span><b>Price</b>Price on request</span>
+              <span><b>Availability</b>Availability to verify</span>
+              <span><b>Details</b>Project details subject to confirmation</span>
             </div>
             <h4 className={styles.projectListTitle}>Projects in Wongamat</h4>
             <div className={styles.projectMini}>
               <img src={project.image} alt={project.name} loading="eager" />
-              <span><b>{project.name}</b><small>{project.developer.split(' · ')[1]} · {project.yield} yield</small></span>
-              <em>{project.from}<small>from</small></em>
+              <span><b>{project.name}</b><small>Availability to verify</small></span>
+              <em>{project.from}<small>price</small></em>
             </div>
             <div className={styles.areaCta}>
               <span className={styles.areaCtaLabel}><MapPinIcon /> Wongamat</span>
               <h4>Get projects in this area</h4>
-              <p>We&apos;ll send a curated brief of available units in Wongamat within 30 minutes.</p>
+              <p>Request a visual brief with price, availability, and project details marked for confirmation.</p>
               <Link href={href('/contact')} className={styles.fullCoral}>Request Wongamat brief</Link>
               <Link href={href('/listing')} className={styles.outlineAction}>Browse all listings</Link>
             </div>
@@ -671,47 +671,46 @@ function AreaGuidePage() {
 
 function CalculatorPage() {
   const breakdown = [
-    ['Down payment', '฿4,440,000'],
-    ['Transfer fee (2%)', '฿296,000'],
-    ['Sinking fund', '฿42,000'],
-    ['Legal & escrow', '฿35,000'],
-    ['Total upfront', '฿4,813,000'],
+    ['Price', 'Price on request'],
+    ['Availability', 'Availability to verify'],
+    ['Project details', 'Project details subject to confirmation'],
+    ['Advisor review', 'Required before production use'],
   ];
 
   return (
     <>
       <section className={`${styles.plainHero} ${styles.toolHero}`}>
         <span className={styles.mono}>Investor toolkit</span>
-        <h1><em>Total-cost &amp;</em> rental yield calculator</h1>
-        <p>Run the numbers before you fly out. Adjust inputs on the left, see the live cash-flow, yield, and 5-year ROI on the right.</p>
+        <h1><em>Total-cost &amp;</em> availability planner</h1>
+        <p>Review the calculator layout and interaction states without publishing unconfirmed commercial claims.</p>
       </section>
       <section className={styles.calculatorGrid}>
         <div className={styles.calcPanel}>
-          <CalcGroup title="Property" rows={[['Purchase price', '฿14,800,000']]} />
-          <CalcGroup title="Financing" rows={[['Down payment', '30%'], ['Mortgage term', '15 years'], ['Interest rate', '6.5%']]} />
-          <CalcGroup title="Rental income" rows={[['Avg. daily rate', '฿4,800'], ['Occupancy', '72%'], ['Management fee', '15%']]} />
-          <p className={styles.calcNote}><InfoIcon /> <span>Defaults reflect 2025 AMP-managed unit averages in Wongamat (2BR, sea view).</span></p>
+          <CalcGroup title="Property" rows={[['Purchase price', 'Price on request']]} />
+          <CalcGroup title="Availability" rows={[['Current availability', 'Availability to verify'], ['Project details', 'Subject to confirmation']]} />
+          <CalcGroup title="Review" rows={[['Owner review', 'Required'], ['Advisor follow-up', 'Requested']]} />
+          <p className={styles.calcNote}><InfoIcon /> <span>Values are intentionally gated until owner-approved pricing and availability are provided.</span></p>
         </div>
         <div className={styles.calcResults}>
           <div className={styles.resultCards}>
-            <span><b>Cash yield p.a.</b><strong>5.7%</strong><small>Net of fees, taxes, CAM</small></span>
-            <span><b>Total cash to close</b><strong>฿4.8M</strong><small>Down + fees + legal</small></span>
-            <span><b>Monthly cash flow</b><strong>+฿70k</strong><small>After mortgage: ฿-20435/mo</small></span>
+            <span><b>Price</b><strong>On request</strong><small>Price on request</small></span>
+            <span><b>Availability</b><strong>To verify</strong><small>Availability to verify</small></span>
+            <span><b>Details</b><strong>Confirm</strong><small>Project details subject to confirmation</small></span>
           </div>
           <div className={styles.breakdown}>
-            <h3>Upfront cost breakdown</h3>
+            <h3>Confirmation checklist</h3>
             {breakdown.map(([label, value]) => <div key={label}><span>{label}</span><b>{value}</b></div>)}
           </div>
           <div className={styles.chartPanel}>
-            <h3>5-year return projection</h3>
-            <p>Capital appreciation (7% YoY conservative) + cumulative net rental</p>
+            <h3>Review sequence</h3>
+            <p>Each step remains a visual state until commercial data is confirmed.</p>
             <div className={styles.chartBars}>{['Y1', 'Y2', 'Y3', 'Y4', 'Y5'].map((year, index) => <span key={year} style={{ height: `${42 + index * 18}%` }}>{year}</span>)}</div>
-            <strong>5-yr ROI: +211%</strong>
+            <strong>Owner review required</strong>
           </div>
         <div className={styles.reportCta}>
-            <span>Want a verified projection for a real unit?</span>
-            <p>We&apos;ll send a custom report based on actual comps in 24 hours.</p>
-          <Link href={href('/contact')} className={styles.coralPill}>Request projection</Link>
+            <span>Need owner-approved numbers?</span>
+            <p>Request confirmed price, availability, and project details before production use.</p>
+          <Link href={href('/contact')} className={styles.coralPill}>Request details</Link>
           </div>
         </div>
       </section>
@@ -757,7 +756,7 @@ function FinderPage() {
           <span className={styles.mono}>Smart Finder · 90-second brief</span>
           <h1>What&apos;s your primary goal?</h1>
           <p>This shapes everything — from zone to unit size.</p>
-          {['Investment — maximize yield & capital gain', 'Personal use — holiday home or primary residence', 'Both — I want to use it and earn income'].map((item) => (
+          {['Review price and availability', 'Compare project details', 'Plan a viewing request'].map((item) => (
             <button key={item} type="button"><span aria-hidden="true" />{item}</button>
           ))}
           <button type="button" className={`${styles.fullCoral} ${styles.finderContinue}`}>Continue <ArrowIcon /></button>
@@ -765,17 +764,17 @@ function FinderPage() {
         <div className={styles.liveMatches}>
           <span className={styles.mono}>Live matches · updates as you answer</span>
           <h2>Your shortlist is shaping up</h2>
-          <p>4 strong matches</p>
+          <p>Availability to verify</p>
           {[projects[0], projects[1], projects[3], projects[4]].map((project) => (
             <div key={project.slug} className={styles.matchCard}>
               <img src={project.image} alt={project.name} loading="eager" />
-              <span><b>{project.name}</b><small>{project.area} · From {project.from}</small></span>
-              <em>97%</em>
+              <span><b>{project.name}</b><small>{project.area} · {project.from}</small></span>
+              <em>Review</em>
             </div>
           ))}
           <div className={styles.matchHint}>
             <small>6 more questions</small>
-            <p>Answer the remaining questions to get your curated PDF brief within 30 minutes.</p>
+            <p>Answer the remaining questions to prepare a visual brief for owner review.</p>
           </div>
         </div>
       </div>
@@ -787,15 +786,15 @@ function ComparePage() {
   const selected = projects.slice(0, 3);
   const rows = [
     ['Starting price', ...selected.map((item) => item.from)],
-    ['Price per m²', '฿132,000', '฿98,000', '฿142,000'],
-    ['Bedrooms', 'Studio · 1BR · 2BR · Penthouse', 'Studio · 1BR · 2BR', '3BR Villa · 4BR Villa'],
-    ['Floors', '53 floors', '47 floors', '3 floors'],
-    ['Total units', '348', '412', '14'],
-    ['Completion', 'Q4 2026', 'Q2 2027', 'Ready to move'],
-    ['Status', 'Under construction', 'Pre-sale', 'Completed'],
-    ['Beach distance', '80m ✓ Best', '220m', '380m'],
+    ['Availability', ...selected.map((item) => item.availability)],
+    ['Project details', ...selected.map((item) => item.quota)],
+    ['Bedrooms', 'Project details subject to confirmation', 'Project details subject to confirmation', 'Project details subject to confirmation'],
+    ['Floors', 'Project details subject to confirmation', 'Project details subject to confirmation', 'Project details subject to confirmation'],
+    ['Completion', 'Project details subject to confirmation', 'Project details subject to confirmation', 'Project details subject to confirmation'],
+    ['Status', ...selected.map((item) => item.badge)],
+    ['Location', ...selected.map((item) => item.area)],
     ['Area', ...selected.map((item) => item.area)],
-    ['Developer', 'AMP Property Group', 'Sansiri × AMP', 'AMP Property Group'],
+    ['Developer', ...selected.map((item) => item.developer)],
   ];
 
   return (
@@ -803,10 +802,10 @@ function ComparePage() {
       <section className={`${styles.plainHero} ${styles.compareHero}`}>
         <span className={styles.mono}>Compare · Side-by-side</span>
         <div>
-          <h1>Compare 3 <em>investor-grade</em> projects</h1>
+          <h1>Compare 3 <em>project-review</em> cards</h1>
           <div className={styles.compareActions}>
             <button type="button">Clear all</button>
-            <button type="button"><DownloadIcon /> Export PDF</button>
+            <button type="button"><DownloadIcon /> Export brief</button>
             <Link href={href('/contact')} className={styles.coralPill}>Get advisor brief <ArrowIcon /></Link>
           </div>
         </div>
@@ -844,13 +843,13 @@ function ContactPage() {
         <div>
           <span className={styles.mono}>Contact · AMP Pattaya</span>
           <h1>Talk to a human. <em>No scripts. No bots.</em></h1>
-          <p>Our multilingual team covers Thai, English, Russian, Mandarin and German. Pick a channel and someone will respond — personally.</p>
+          <p>Choose a contact channel and request confirmed price, availability, and project details before production use.</p>
         </div>
       </section>
       <section className={styles.contactGrid}>
         <div className={styles.messageForm}>
           <h2>Send us a message</h2>
-          <p>We reply within 30 minutes during office hours.</p>
+          <p>Advisor response timing and office details are subject to confirmation.</p>
           <input placeholder="Your name *" />
           <div>
             <input placeholder="Email" />
@@ -869,9 +868,9 @@ function ContactPage() {
         <div className={styles.contactSide}>
           <article className={styles.infoCard}>
             <h3>Office &amp; hours</h3>
-            <p>⌖ 333/12 Pratumnak Road, Banglamung, Chonburi 20150</p>
-            <p>◷ Monday – Saturday, 9:00 – 19:00 ICT</p>
-            <p>☎ +66 38 123 4567</p>
+            <p>⌖ Office details subject to confirmation</p>
+            <p>◷ Viewing hours to verify</p>
+            <p>☎ Contact details subject to confirmation</p>
             <div>
               <Link href={href('/contact')}>💬 WhatsApp</Link>
               <Link href={href('/contact')}>LINE</Link>
@@ -886,36 +885,60 @@ function ContactPage() {
 
 function DetailPage({ kind }: { kind: 'project' | 'property' }) {
   const project = kind === 'property' ? projects[1] : projects[0];
+  const gallery = [project, projects[1], projects[2], projects[3], projects[4]];
 
   return (
     <>
-      <section className={styles.detailHero}>
-        <img src={project.image} alt={project.name} loading="eager" />
-        <div>
-          <span className={styles.mono}>{kind === 'property' ? 'Verified resale · Unit A1203' : `${project.badge} · ${project.area}`}</span>
-          <h1>{kind === 'property' ? 'Sea-view 2BR residence with managed rental upside.' : project.name}</h1>
-          <p>{project.tone}</p>
-          <div className={styles.heroButtons}>
-            <Link href={href('/contact')} className={styles.primaryHero}>Book a viewing <ArrowIcon /></Link>
-            <Link href={href('/compare')} className={styles.secondaryHero}>Compare shortlist</Link>
+      <section className={styles.detailGalleryPage}>
+        <Link href={href('/listing')} className={styles.backLink}>← All projects</Link>
+
+        <div className={styles.detailMainGallery}>
+          <img src={project.image} alt={project.name} loading="eager" />
+          <button type="button" className={styles.galleryArrowLeft} aria-label="Previous project image">‹</button>
+          <button type="button" className={styles.galleryArrowRight} aria-label="Next project image">›</button>
+          <button type="button" className={styles.favoriteButton} aria-label={`Save ${project.name}`}><HeartIcon /></button>
+          <div className={styles.galleryDots} aria-hidden="true">
+            {gallery.map((item, index) => <span key={item.slug} className={index === 0 ? styles.galleryDotActive : undefined} />)}
           </div>
         </div>
-      </section>
-      <section className={styles.detailBody}>
+
+        <div className={styles.detailThumbStrip}>
+          {gallery.map((item, index) => (
+            <button key={item.slug} type="button" className={index === 0 ? styles.thumbActive : undefined} aria-label={`View ${item.name}`}>
+              <img src={item.image} alt="" loading="eager" />
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.detailTitleRow}>
+          <div className={styles.detailTitleCopy}>
+            <p className={styles.detailMeta}>
+              <span>{project.badge}</span>
+              <em><MapPinIcon /> {project.area}</em>
+            </p>
+            <h1>{kind === 'property' ? 'Sea-view residence' : project.name}</h1>
+          </div>
+          <div className={styles.detailPriceBlock}>
+            <strong>{project.from}</strong>
+            <span>Starting from</span>
+          </div>
+          <LeadCard />
+        </div>
+
         <div className={styles.detailStats}>
-          <span><b>From</b>{project.from}</span>
-          <span><b>Yield</b>{project.yield}</span>
-          <span><b>Foreign quota</b>{project.quota}</span>
-          <span><b>Beach</b>{project.beach}</span>
+          <span><b>Price</b>{project.from}</span>
+          <span><b>Availability</b>{project.availability}</span>
+          <span><b>Details</b>{project.quota}</span>
         </div>
-        <div className={styles.galleryGrid}>
-          {projects.slice(0, 4).map((item) => <img key={item.slug} src={item.image} alt={item.name} loading="eager" />)}
-        </div>
+      </section>
+
+      <section className={styles.detailBody}>
         <div className={styles.detailColumns}>
           <article>
             <span className={styles.mono}>Advisor brief</span>
-            <h2>{kind === 'property' ? 'A ready unit for lifestyle plus rental management.' : 'Developer track record, quota, and exit liquidity in one view.'}</h2>
-            <p>The v3 preview follows the approved detail-page direction with a calm editorial hero, metric rail, image-led gallery, and advisor-first conversion path.</p>
+            <h2>{kind === 'property' ? 'A residence page structure for owner review.' : 'Gallery-led detail page with advisor-first conversion.'}</h2>
+            <p>{project.tone}</p>
+            <p>Price, availability, ownership details, developer information, completion timing, floor plans, and legal notes must be confirmed before this pattern replaces any production route.</p>
           </article>
           <AdvisorPanel />
         </div>

--- a/admin-app/app/(site)/[locale]/v3-preview/_components/V3PreviewPage.tsx
+++ b/admin-app/app/(site)/[locale]/v3-preview/_components/V3PreviewPage.tsx
@@ -1,0 +1,949 @@
+/* eslint-disable @next/next/no-img-element */
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+import {
+  advisors,
+  areas,
+  contactHeroImage,
+  faqs,
+  heroImage,
+  projects,
+  testimonials,
+  type V3PreviewRoute,
+  type V3Project,
+} from '../_lib/v3-preview-data';
+import styles from '../v3-preview.module.css';
+
+const basePath = '/en/v3-preview';
+
+function href(path = '') {
+  return `${basePath}${path}`;
+}
+
+function ArrowIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M5 12h14" />
+      <path d="m12 5 7 7-7 7" />
+    </svg>
+  );
+}
+
+function ChevronDownIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+function GlobeIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M2 12h20" />
+      <path d="M12 2a15.3 15.3 0 0 1 0 20" />
+      <path d="M12 2a15.3 15.3 0 0 0 0 20" />
+    </svg>
+  );
+}
+
+function UserIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M20 21a8 8 0 0 0-16 0" />
+      <circle cx="12" cy="7" r="4" />
+    </svg>
+  );
+}
+
+function MapPinIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M20 10c0 6-8 12-8 12S4 16 4 10a8 8 0 1 1 16 0Z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}
+
+function DownloadIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 3v12" />
+      <path d="m7 10 5 5 5-5" />
+      <path d="M5 21h14" />
+    </svg>
+  );
+}
+
+function InfoIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4" />
+      <path d="M12 8h.01" />
+    </svg>
+  );
+}
+
+function GridIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <rect x="4" y="4" width="6" height="6" rx="1.2" />
+      <rect x="14" y="4" width="6" height="6" rx="1.2" />
+      <rect x="4" y="14" width="6" height="6" rx="1.2" />
+      <rect x="14" y="14" width="6" height="6" rx="1.2" />
+    </svg>
+  );
+}
+
+function ListIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+      <path d="M8 6h12" />
+      <path d="M8 12h12" />
+      <path d="M8 18h12" />
+      <circle cx="4" cy="6" r="1.3" fill="currentColor" stroke="none" />
+      <circle cx="4" cy="12" r="1.3" fill="currentColor" stroke="none" />
+      <circle cx="4" cy="18" r="1.3" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+function HeartIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 21s-7.5-4.8-9.5-9.3C.9 8.2 2.8 5 6.1 5c1.8 0 3.3 1 4.1 2.3C11 6 12.5 5 14.3 5c3.3 0 5.2 3.2 3.6 6.7C16 16.2 12 21 12 21Z" />
+    </svg>
+  );
+}
+
+function Logo() {
+  return (
+    <span className={styles.logo} aria-label="AMP Pattaya">
+      <svg width="26" height="26" viewBox="0 0 32 32" aria-hidden="true">
+        <rect x="0.5" y="0.5" width="31" height="31" rx="6" fill="none" stroke="currentColor" strokeWidth="1.2" />
+        <path d="M9 23 L16 9 L23 23 M12 18 L20 18" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+      <span>AMP <em>Pattaya</em></span>
+    </span>
+  );
+}
+
+function ShellHeader({ route }: { route: V3PreviewRoute }) {
+  const items = [
+    { label: 'Home', route: 'home' as const, href: href() },
+    { label: 'Buy', route: 'listing' as const, href: href('/listing') },
+    { label: 'New Projects', route: 'listing' as const, href: href('/new-projects') },
+    { label: 'Areas', route: 'area-guide' as const, href: href('/area-guide') },
+    { label: 'Invest', route: 'calculator' as const, href: href('/calculator') },
+    { label: 'Contact', route: 'contact' as const, href: href('/contact') },
+  ];
+
+  return (
+    <header className={`${styles.header} ${route === 'home' ? styles.headerHome : ''}`}>
+      <div className={styles.headerInner}>
+        <Link href={href()} className={styles.brand}>
+          <Logo />
+        </Link>
+
+        <nav className={styles.nav} aria-label="AMP public v3 preview navigation">
+          {items.map((item) => (
+            <Link key={item.label} href={item.href} className={route === item.route ? styles.navActive : undefined}>
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+
+        <div className={styles.headerActions}>
+          <button type="button" className={styles.plainPill}>THB <ChevronDownIcon /></button>
+          <span className={styles.headerDivider} />
+          <button type="button" className={styles.plainPill}><GlobeIcon /> EN <ChevronDownIcon /></button>
+          <span className={styles.headerDivider} />
+          <button type="button" className={styles.outlinePill}><UserIcon /> Sign in</button>
+          <Link href={href('/contact')} className={styles.coralPill}>Book a viewing <ArrowIcon /></Link>
+        </div>
+
+        <details className={styles.mobileNav}>
+          <summary aria-label="Open v3 preview navigation"><span /><span /><span /></summary>
+          <div>
+            {items.map((item) => (
+              <Link key={item.label} href={item.href}>{item.label}</Link>
+            ))}
+            <Link href={href('/contact')}>Book a viewing</Link>
+          </div>
+        </details>
+      </div>
+    </header>
+  );
+}
+
+function ShellFooter() {
+  const groups = [
+    ['Browse', 'New projects', 'Resale condos', 'Pool villas', 'Off-plan deals', 'Recently reduced'],
+    ['Invest', 'Foreign ownership', 'Rental yields', 'Cost calculator', 'Capital gains', 'Tax & legal'],
+    ['Company', 'About AMP', 'Our team', 'Press', 'Privacy', 'Careers'],
+  ];
+
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.footerGrid}>
+        <div className={styles.footerBrand}>
+          <Logo />
+          <p>Pattaya&apos;s investor-grade property advisory. Licensed brokerage est. 2018. Member, Thai Real Estate Association.</p>
+          <div className={styles.socials} aria-label="Contact shortcuts">
+            <Link href={href('/contact')} aria-label="Chat">⌕</Link>
+            <Link href={href('/contact')} aria-label="Email">✉</Link>
+            <Link href={href('/contact')} aria-label="Phone">☎</Link>
+          </div>
+        </div>
+
+        {groups.map(([title, ...links]) => (
+          <div key={title} className={styles.footerColumn}>
+            <span>{title}</span>
+            {links.map((label) => (
+              <Link key={label} href={href(label === 'Cost calculator' ? '/calculator' : '/listing')}>{label}</Link>
+            ))}
+          </div>
+        ))}
+
+        <div className={styles.footerColumn}>
+          <span>Office</span>
+          <p>333/12 Pratumnak Road<br />Banglamung, Chonburi 20150<br />Mon–Sat · 9:00–19:00 ICT</p>
+          <a href="tel:+66381234567">+66 38 123 4567</a>
+        </div>
+      </div>
+      <div className={styles.footerBottom}>
+        <span>© 2026 AMP Pattaya Property Co., Ltd · License #BR-2018-0992</span>
+        <span>Terms&nbsp;&nbsp; Privacy&nbsp;&nbsp; Disclosure</span>
+      </div>
+    </footer>
+  );
+}
+
+function StatStrip() {
+  const stats = [
+    ['Curated', 'Pattaya projects'],
+    ['Freehold', 'Foreign ownership'],
+    ['Verified', 'Developer track record'],
+    ['Same-day', 'Advisor response'],
+  ];
+
+  return (
+    <dl className={styles.heroStats}>
+      {stats.map(([value, label]) => (
+        <div key={value}>
+          <dt>{value}</dt>
+          <dd>{label}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function LeadCard() {
+  return (
+    <aside className={styles.leadCard}>
+      <span className={styles.mono}>Get price &amp; floor plan</span>
+      <h3>Speak to an advisor</h3>
+      <p><span aria-hidden="true">●</span> Reply in 30 min</p>
+      <input aria-label="Your name" placeholder="Your name *" />
+      <div className={styles.leadFields}>
+        <input aria-label="Phone with code" placeholder="Phone (with code)" />
+        <input aria-label="Email" placeholder="Email" />
+      </div>
+      <div className={styles.leadFields}>
+        <select defaultValue="5-10M" aria-label="Budget">
+          <option>3-5M</option>
+          <option>5-10M</option>
+          <option>10-20M</option>
+        </select>
+        <select defaultValue="1-2 BR" aria-label="Bedrooms">
+          <option>Studio</option>
+          <option>1-2 BR</option>
+          <option>3+ BR / Villa</option>
+        </select>
+      </div>
+      <select defaultValue="Within 3 months" aria-label="Buying timeline">
+        <option>Within 1 month</option>
+        <option>Within 3 months</option>
+        <option>Just researching</option>
+      </select>
+      <small>✓ Contact me on WhatsApp · fastest reply</small>
+      <Link href={href('/contact')} className={styles.fullCoral}>Send &amp; get a same-day reply <ArrowIcon /></Link>
+      <em>No spam. Unsubscribe anytime.</em>
+    </aside>
+  );
+}
+
+function SearchBar() {
+  const fields = [
+    ['Location', 'Anywhere in Pattaya'],
+    ['Type', 'Condo, Villa, Pent…'],
+    ['Bedrooms', 'Studio – 4 BR'],
+    ['Budget', '฿3M – ฿20M'],
+  ];
+
+  return (
+    <div className={styles.searchPanel}>
+      <div className={styles.searchTabs}>
+        {['Buy', 'Rent', 'Off-plan', 'Villas'].map((item, index) => (
+          <Link key={item} href={href(index === 1 ? '/listing' : '/listing')} className={index === 0 ? styles.tabActive : undefined}>{item}</Link>
+        ))}
+      </div>
+      <div className={styles.searchFields}>
+        {fields.map(([label, value]) => (
+          <Link key={label} href={href('/listing')}>
+            <span>{label}</span>
+            <strong>{value}</strong>
+          </Link>
+        ))}
+        <Link href={href('/listing')} className={styles.searchButton}>Search listings</Link>
+      </div>
+    </div>
+  );
+}
+
+function ProjectCard({ project, compact = false }: { project: V3Project; compact?: boolean }) {
+  return (
+    <Link href={href(`/project/${project.slug}`)} className={compact ? styles.projectCardCompact : styles.projectCard}>
+      <span className={styles.imageFrame}>
+        <img src={project.image} alt={project.name} loading="eager" />
+        <span className={styles.imageAction}>{compact ? <HeartIcon /> : <ArrowIcon />}</span>
+      </span>
+      <span className={styles.cardBody}>
+        <span className={styles.cardMeta}>{project.badge} <em>{project.area}</em></span>
+        <h3>{project.name}</h3>
+        <small>{project.developer}</small>
+        <span className={styles.cardStats}>
+          <span><b>From</b>{project.from}</span>
+          <span><b>Yield</b>{project.yield}</span>
+          <span><b>Foreign quota</b>{project.quota}</span>
+          <span><b>Beach</b>{project.beach}</span>
+        </span>
+        {compact ? <span className={styles.compareChip}>Compare</span> : null}
+      </span>
+    </Link>
+  );
+}
+
+function SectionIntro({ kicker, title, body, action, href: actionHref }: { kicker: string; title: ReactNode; body: string; action?: string; href?: string }) {
+  return (
+    <div className={styles.sectionIntro}>
+      <div>
+        <span className={styles.mono}>{kicker}</span>
+        <h2>{title}</h2>
+        <p>{body}</p>
+      </div>
+      {action ? <Link href={actionHref ?? href('/listing')} className={styles.outlineAction}>{action}</Link> : null}
+    </div>
+  );
+}
+
+function HomePage() {
+  return (
+    <>
+      <section className={styles.hero}>
+        <img src={heroImage} alt="Pattaya skyline" className={styles.heroImage} loading="eager" />
+        <div className={styles.heroOverlay} />
+        <div className={styles.heroGrid}>
+          <div className={styles.heroCopy}>
+            <span className={styles.livePill}>Live · 142 units released this week</span>
+            <h1>Pattaya, priced for<br /><em>investors who measure</em><br />in years, not weekends.</h1>
+            <p>A licensed brokerage matching foreign buyers and Thai investors with off-plan, resale and pool-villa inventory across Pattaya&apos;s Eastern Seaboard. Transparent yields. Verified foreign quota. Same-day reply.</p>
+            <div className={styles.heroButtons}>
+              <Link href={href('/listing')} className={styles.primaryHero}>View available units <ArrowIcon /></Link>
+              <Link href={href('/finder')} className={styles.secondaryHero}>90-second Smart Finder</Link>
+            </div>
+            <StatStrip />
+          </div>
+          <LeadCard />
+        </div>
+        <SearchBar />
+      </section>
+
+      <section className={styles.section}>
+        <SectionIntro
+          kicker="Hand-picked, this quarter"
+          title={<>The <em>investor-grade</em> shortlist.</>}
+          body="Three projects we'd put our own money in. Verified developers, capital-protected payment terms, and clear exit liquidity."
+          action="Browse all projects"
+          href={href('/listing')}
+        />
+        <div className={styles.projectGridThree}>
+          {projects.slice(0, 3).map((project) => <ProjectCard key={project.slug} project={project} />)}
+        </div>
+      </section>
+
+      <section className={styles.darkBand}>
+        <div>
+          <span className={styles.mono}>Why Pattaya · Why now</span>
+          <h2>The Eastern Seaboard&apos;s next decade is being priced in now.</h2>
+          <p>The U-Tapao airport expansion, high-speed rail to Bangkok, and EEC industrial zone are re-shaping the south. Median condo values are up 14% YoY in Wongamat.</p>
+          <Link href={href('/calculator')} className={styles.primaryLight}>Run the yield calculator <ArrowIcon /></Link>
+        </div>
+        <div className={styles.thesisGrid}>
+          {[
+            ['Yield focus', 'Projects selected for rental income potential', 'Income-first curation'],
+            ['Capital growth', 'Eastern Seaboard infrastructure expansion', 'Long-term thesis'],
+            ['Foreign quota', 'Freehold units for non-Thai buyers up to 49%', 'Ownership support'],
+            ['Fast close', 'Remote purchase support, independent legal', 'Escrow every deal'],
+          ].map(([title, body, label]) => (
+            <article key={title}>
+              <span>{title}</span>
+              <p>{body}</p>
+              <small>{label}</small>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <SectionIntro
+          kicker="Browse by area"
+          title={<>Six zones. <em>Six investment theses.</em></>}
+          body="Pattaya is not one market. Each zone has different yield, tenant profile, and capital growth potential."
+          action="Compare areas"
+          href={href('/area-guide')}
+        />
+        <AreaGrid />
+      </section>
+
+      <section className={styles.finderBand}>
+        <div className={styles.finderCopy}>
+          <span className={styles.mono}>Smart Finder · 90 seconds</span>
+          <h2>Tell us your budget,<br />we&apos;ll send a shortlist<br />by end of day.</h2>
+          <p>Six questions. No call required. Get a curated PDF brief with 3–5 projects matched to your budget, timeline, and exit strategy.</p>
+          <div className={styles.heroButtons}>
+            <Link href={href('/finder')} className={styles.primaryHero}>Start the brief <ArrowIcon /></Link>
+            <Link href={href('/calculator')} className={styles.secondaryDark}>Cost calculator</Link>
+          </div>
+        </div>
+        <div className={styles.shortlistPreview}>
+          <span className={styles.mono}>Shortlist preview</span>
+          <h3>Your AMP shortlist</h3>
+          {['Jomtien Bay Tower', 'Central Marina Suites', 'Na Jomtien Residence'].map((name, index) => (
+            <div key={name} className={styles.matchRow}>
+              <b>{index + 1}</b>
+              <span>{name}</span>
+              <em>Match {index === 0 ? '94' : index === 1 ? '88' : '76'}%</em>
+            </div>
+          ))}
+          <Link href={href('/finder')} className={styles.fullTeal}>Get your shortlist</Link>
+        </div>
+      </section>
+
+      <TrustSection />
+      <FaqSection />
+      <FinalCta />
+    </>
+  );
+}
+
+function AreaGrid() {
+  return (
+    <div className={styles.areaGrid}>
+      {areas.map((area) => (
+        <Link key={area.slug} href={href('/area-guide')} className={styles.areaCard}>
+          <img src={area.image} alt={area.title} loading="eager" />
+          <span>{area.label}</span>
+          <small>{area.listings}</small>
+          <h3>{area.title}</h3>
+          <p>{area.summary}</p>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function TrustSection() {
+  return (
+    <section className={styles.trustSection}>
+      <SectionIntro
+        kicker="Trust · Track record"
+        title="International buyers trust our process."
+        body="Multilingual advisory. Independent legal. Escrow on every transaction."
+      />
+      <div className={styles.trustGrid}>
+        <div className={styles.testimonialGrid}>
+          {testimonials.map((item) => (
+            <blockquote key={item.author}>
+              <p>“{item.quote}”</p>
+              <cite>{item.author}</cite>
+            </blockquote>
+          ))}
+        </div>
+        <AdvisorPanel />
+      </div>
+    </section>
+  );
+}
+
+function AdvisorPanel() {
+  return (
+    <aside className={styles.advisorPanel}>
+      <span className={styles.mono}>Your advisors</span>
+      <h3>Speak in your language.</h3>
+      {advisors.map((advisor) => (
+        <div key={advisor.name} className={styles.advisorRow}>
+          <img src={advisor.image} alt={advisor.name} loading="eager" />
+          <span><b>{advisor.name}</b><small>{advisor.role}</small></span>
+          <em>★ {advisor.rating}</em>
+        </div>
+      ))}
+      <Link href={href('/contact')} className={styles.fullTeal}>Book a free advisory call</Link>
+    </aside>
+  );
+}
+
+function ContactAdvisorCard() {
+  return (
+    <article className={styles.contactAdvisorCard}>
+      <h3>Your advisors</h3>
+      {advisors.map((advisor) => (
+        <div key={advisor.name} className={styles.advisorRow}>
+          <img src={advisor.image} alt={advisor.name} loading="eager" />
+          <span><b>{advisor.name}</b><small>{advisor.role}</small></span>
+          <em>★ {advisor.rating}</em>
+        </div>
+      ))}
+    </article>
+  );
+}
+
+function FaqSection() {
+  return (
+    <section className={styles.faqSection}>
+      <SectionIntro
+        kicker="Common questions"
+        title="The questions every foreign buyer asks first."
+        body=""
+      />
+      <div className={styles.faqList}>
+        {faqs.map((item) => (
+          <details key={item}>
+            <summary>{item}<span>+</span></summary>
+            <p>Our advisor team gives the current answer based on nationality, ownership route, and selected project before you make a decision.</p>
+          </details>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function FinalCta() {
+  return (
+    <section className={styles.finalCta}>
+      <div>
+        <span className={styles.mono}>Ready when you are</span>
+        <h3>Book a 20-minute call. No pressure. No call-bots.</h3>
+      </div>
+      <div className={styles.finalActions}>
+        <Link href={href('/contact')}>💬 WhatsApp</Link>
+        <Link href={href('/contact')}>LINE</Link>
+        <Link href={href('/contact')} className={styles.coralPill}>Book a viewing <ArrowIcon /></Link>
+      </div>
+    </section>
+  );
+}
+
+function ListingPage() {
+  return (
+    <section className={styles.listingPage}>
+      <div className={styles.listingHeader}>
+        <div>
+          <span className={styles.mono}>Projects · New &amp; off-plan</span>
+          <h1>8 projects across <em>Pattaya</em></h1>
+          <button type="button" className={styles.filterToggle}>Filters</button>
+        </div>
+        <div className={styles.sortTabs}>
+          <span className={styles.viewSwitch} aria-label="View mode">
+            <button type="button" className={styles.viewActive} aria-label="Grid view"><GridIcon /></button>
+            <button type="button" aria-label="List view"><ListIcon /></button>
+          </span>
+          <select className={styles.sortSelect} defaultValue="Most relevant" aria-label="Sort projects">
+            <option>Most relevant</option>
+            <option>Price: low to high</option>
+            <option>Price: high to low</option>
+            <option>Highest yield</option>
+          </select>
+        </div>
+      </div>
+      <div className={styles.catalogue}>
+        <aside className={styles.filters}>
+          <PriceRange />
+          <FilterRows title="Area" rows={[['Wongamat', '14'], ['Pratumnak Hill', '22'], ['Central Pattaya', '47'], ['Jomtien', '38'], ['Na Jomtien', '19'], ['Bang Saray', '11']]} />
+          <FilterRows title="Status" rows={[['Pre-sale', '5'], ['Under construction', '2'], ['Ready to move', '2']]} />
+          <FilterRows title="Distance to beach" rows={[['Any distance', ''], ['Beachfront', ''], ['Under 100m', ''], ['Under 500m', '']]} radio />
+          <button type="button" className={styles.resetButton}>Reset all filters</button>
+        </aside>
+        <div className={styles.listingGrid}>
+          {projects.map((project) => <ProjectCard key={project.slug} project={project} compact />)}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PriceRange() {
+  return (
+    <div className={styles.filterGroup}>
+      <button type="button">Price (฿M)<span aria-hidden="true">⌃</span></button>
+      <div className={styles.priceRange}>
+        <span>0M</span>
+        <span>฿60M+</span>
+      </div>
+      <div className={styles.rangeTrack}><span /></div>
+    </div>
+  );
+}
+
+function FilterRows({ title, rows, radio = false }: { title: string; rows: string[][]; radio?: boolean }) {
+  return (
+    <div className={styles.filterGroup}>
+      <button type="button">{title}<span aria-hidden="true">⌃</span></button>
+      {rows.map(([label, count], index) => (
+        <label key={label} className={styles.filterRow}>
+          <input type={radio ? 'radio' : 'checkbox'} checked={radio && index === 0} readOnly />
+          <span>{label}</span>
+          {count ? <em>{count}</em> : null}
+        </label>
+      ))}
+    </div>
+  );
+}
+
+function AreaGuidePage() {
+  const selected = areas[0];
+  const project = projects[0];
+
+  return (
+    <>
+      <section className={styles.plainHero}>
+        <span className={styles.mono}>Area guide · Pattaya</span>
+        <h1>Six zones. <em>Six investment theses.</em></h1>
+        <p>Each area has a distinct price point, tenant profile, and capital growth potential. Choose your zone before you choose your unit.</p>
+      </section>
+      <section className={styles.areaGuideLayout}>
+        <aside className={styles.areaMenu}>
+          {areas.map((area, index) => (
+            <button key={area.slug} type="button" className={index === 0 ? styles.areaMenuActive : undefined}>
+              <img src={area.image} alt={area.title} loading="eager" />
+              <span><b>{area.title}</b><small>{area.listings}</small></span>
+            </button>
+          ))}
+        </aside>
+        <article className={styles.areaDetail}>
+          <div className={styles.areaHeroImage}>
+            <img src={selected.image} alt={selected.title} loading="eager" />
+            <span>{selected.label}</span>
+            <h2>{selected.title}</h2>
+            <p>{selected.summary}</p>
+          </div>
+          <div className={styles.areaCopy}>
+            <h3>{selected.thesis}</h3>
+            <p>Wongamat Beach is Pattaya&apos;s most prestigious address — calm, family-friendly, and flanked by luxury hotels. Foreign buyers dominate. Values have risen 14% YoY.</p>
+            <div className={styles.metricGrid}>
+              <span><b>Gross yield</b>5.8–6.8%</span>
+              <span><b>Price/m²</b>฿110–165k/m²</span>
+              <span><b>Buyer profile</b>78% foreign</span>
+            </div>
+            <h4 className={styles.projectListTitle}>Projects in Wongamat</h4>
+            <div className={styles.projectMini}>
+              <img src={project.image} alt={project.name} loading="eager" />
+              <span><b>{project.name}</b><small>{project.developer.split(' · ')[1]} · {project.yield} yield</small></span>
+              <em>{project.from}<small>from</small></em>
+            </div>
+            <div className={styles.areaCta}>
+              <span className={styles.areaCtaLabel}><MapPinIcon /> Wongamat</span>
+              <h4>Get projects in this area</h4>
+              <p>We&apos;ll send a curated brief of available units in Wongamat within 30 minutes.</p>
+              <Link href={href('/contact')} className={styles.fullCoral}>Request Wongamat brief</Link>
+              <Link href={href('/listing')} className={styles.outlineAction}>Browse all listings</Link>
+            </div>
+          </div>
+        </article>
+      </section>
+    </>
+  );
+}
+
+function CalculatorPage() {
+  const breakdown = [
+    ['Down payment', '฿4,440,000'],
+    ['Transfer fee (2%)', '฿296,000'],
+    ['Sinking fund', '฿42,000'],
+    ['Legal & escrow', '฿35,000'],
+    ['Total upfront', '฿4,813,000'],
+  ];
+
+  return (
+    <>
+      <section className={`${styles.plainHero} ${styles.toolHero}`}>
+        <span className={styles.mono}>Investor toolkit</span>
+        <h1><em>Total-cost &amp;</em> rental yield calculator</h1>
+        <p>Run the numbers before you fly out. Adjust inputs on the left, see the live cash-flow, yield, and 5-year ROI on the right.</p>
+      </section>
+      <section className={styles.calculatorGrid}>
+        <div className={styles.calcPanel}>
+          <CalcGroup title="Property" rows={[['Purchase price', '฿14,800,000']]} />
+          <CalcGroup title="Financing" rows={[['Down payment', '30%'], ['Mortgage term', '15 years'], ['Interest rate', '6.5%']]} />
+          <CalcGroup title="Rental income" rows={[['Avg. daily rate', '฿4,800'], ['Occupancy', '72%'], ['Management fee', '15%']]} />
+          <p className={styles.calcNote}><InfoIcon /> <span>Defaults reflect 2025 AMP-managed unit averages in Wongamat (2BR, sea view).</span></p>
+        </div>
+        <div className={styles.calcResults}>
+          <div className={styles.resultCards}>
+            <span><b>Cash yield p.a.</b><strong>5.7%</strong><small>Net of fees, taxes, CAM</small></span>
+            <span><b>Total cash to close</b><strong>฿4.8M</strong><small>Down + fees + legal</small></span>
+            <span><b>Monthly cash flow</b><strong>+฿70k</strong><small>After mortgage: ฿-20435/mo</small></span>
+          </div>
+          <div className={styles.breakdown}>
+            <h3>Upfront cost breakdown</h3>
+            {breakdown.map(([label, value]) => <div key={label}><span>{label}</span><b>{value}</b></div>)}
+          </div>
+          <div className={styles.chartPanel}>
+            <h3>5-year return projection</h3>
+            <p>Capital appreciation (7% YoY conservative) + cumulative net rental</p>
+            <div className={styles.chartBars}>{['Y1', 'Y2', 'Y3', 'Y4', 'Y5'].map((year, index) => <span key={year} style={{ height: `${42 + index * 18}%` }}>{year}</span>)}</div>
+            <strong>5-yr ROI: +211%</strong>
+          </div>
+        <div className={styles.reportCta}>
+            <span>Want a verified projection for a real unit?</span>
+            <p>We&apos;ll send a custom report based on actual comps in 24 hours.</p>
+          <Link href={href('/contact')} className={styles.coralPill}>Request projection</Link>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function CalcGroup({ title, rows }: { title: string; rows: string[][] }) {
+  const sliderWidths: Record<string, string> = {
+    'Purchase price': '18%',
+    'Down payment': '30%',
+    'Mortgage term': '41%',
+    'Interest rate': '54%',
+    'Avg. daily rate': '32%',
+    'Occupancy': '72%',
+    'Management fee': '50%',
+  };
+
+  return (
+    <div className={styles.calcGroup}>
+      <h3>{title}</h3>
+      {rows.map(([label, value]) => (
+        <div key={label} className={styles.sliderRow}>
+          <span><em>{label}</em><strong>{value}</strong></span>
+          <b className={styles.sliderTrack}><i style={{ width: sliderWidths[label] ?? '45%' }} /></b>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FinderPage() {
+  return (
+    <section className={styles.finderPage}>
+      <div className={styles.finderTop}>
+        <Logo />
+        <span>Step 1 of 7 <em>14%</em></span>
+        <div><b style={{ width: '14%' }} /></div>
+        <Link href={href()}>Exit</Link>
+      </div>
+      <div className={styles.finderGridPage}>
+        <div className={styles.questionPanel}>
+          <span className={styles.mono}>Smart Finder · 90-second brief</span>
+          <h1>What&apos;s your primary goal?</h1>
+          <p>This shapes everything — from zone to unit size.</p>
+          {['Investment — maximize yield & capital gain', 'Personal use — holiday home or primary residence', 'Both — I want to use it and earn income'].map((item) => (
+            <button key={item} type="button"><span aria-hidden="true" />{item}</button>
+          ))}
+          <button type="button" className={`${styles.fullCoral} ${styles.finderContinue}`}>Continue <ArrowIcon /></button>
+        </div>
+        <div className={styles.liveMatches}>
+          <span className={styles.mono}>Live matches · updates as you answer</span>
+          <h2>Your shortlist is shaping up</h2>
+          <p>4 strong matches</p>
+          {[projects[0], projects[1], projects[3], projects[4]].map((project) => (
+            <div key={project.slug} className={styles.matchCard}>
+              <img src={project.image} alt={project.name} loading="eager" />
+              <span><b>{project.name}</b><small>{project.area} · From {project.from}</small></span>
+              <em>97%</em>
+            </div>
+          ))}
+          <div className={styles.matchHint}>
+            <small>6 more questions</small>
+            <p>Answer the remaining questions to get your curated PDF brief within 30 minutes.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ComparePage() {
+  const selected = projects.slice(0, 3);
+  const rows = [
+    ['Starting price', ...selected.map((item) => item.from)],
+    ['Price per m²', '฿132,000', '฿98,000', '฿142,000'],
+    ['Bedrooms', 'Studio · 1BR · 2BR · Penthouse', 'Studio · 1BR · 2BR', '3BR Villa · 4BR Villa'],
+    ['Floors', '53 floors', '47 floors', '3 floors'],
+    ['Total units', '348', '412', '14'],
+    ['Completion', 'Q4 2026', 'Q2 2027', 'Ready to move'],
+    ['Status', 'Under construction', 'Pre-sale', 'Completed'],
+    ['Beach distance', '80m ✓ Best', '220m', '380m'],
+    ['Area', ...selected.map((item) => item.area)],
+    ['Developer', 'AMP Property Group', 'Sansiri × AMP', 'AMP Property Group'],
+  ];
+
+  return (
+    <>
+      <section className={`${styles.plainHero} ${styles.compareHero}`}>
+        <span className={styles.mono}>Compare · Side-by-side</span>
+        <div>
+          <h1>Compare 3 <em>investor-grade</em> projects</h1>
+          <div className={styles.compareActions}>
+            <button type="button">Clear all</button>
+            <button type="button"><DownloadIcon /> Export PDF</button>
+            <Link href={href('/contact')} className={styles.coralPill}>Get advisor brief <ArrowIcon /></Link>
+          </div>
+        </div>
+      </section>
+      <section className={styles.compareTable}>
+        <div className={styles.compareCards}>
+          <div className={styles.compareCorner} aria-hidden="true" />
+          {selected.map((project) => (
+            <article key={project.slug}>
+              <button type="button" aria-label={`Remove ${project.name}`}>×</button>
+              <img src={project.image} alt={project.name} loading="eager" />
+              <h3>{project.name}</h3>
+              <p>{project.area}</p>
+              <Link href={href(`/project/${project.slug}`)}>View <ArrowIcon /></Link>
+            </article>
+          ))}
+        </div>
+        {rows.map(([label, ...values]) => (
+          <div key={label} className={styles.compareRow}>
+            <b>{label}</b>
+            {values.map((value, index) => <span key={`${label}-${index}`}>{value}</span>)}
+          </div>
+        ))}
+        <Link href={href('/contact')} className={styles.fullCoral}>Ask an advisor to compare these</Link>
+      </section>
+    </>
+  );
+}
+
+function ContactPage() {
+  return (
+    <>
+      <section className={styles.contactHero}>
+        <img src={contactHeroImage} alt="Pattaya advisory office" loading="eager" />
+        <div>
+          <span className={styles.mono}>Contact · AMP Pattaya</span>
+          <h1>Talk to a human. <em>No scripts. No bots.</em></h1>
+          <p>Our multilingual team covers Thai, English, Russian, Mandarin and German. Pick a channel and someone will respond — personally.</p>
+        </div>
+      </section>
+      <section className={styles.contactGrid}>
+        <div className={styles.messageForm}>
+          <h2>Send us a message</h2>
+          <p>We reply within 30 minutes during office hours.</p>
+          <input placeholder="Your name *" />
+          <div>
+            <input placeholder="Email" />
+            <input placeholder="Phone (with code)" />
+          </div>
+          <textarea rows={5} placeholder="Tell us what you're looking for — budget, bedrooms, timeline, questions…" />
+          <span>Preferred contact channel</span>
+          <div className={styles.channelPills}>
+            <button type="button" className={styles.channelActive}>💬 WhatsApp</button>
+            <button type="button">LINE</button>
+            <button type="button">📧 Email</button>
+            <button type="button">📞 Call me</button>
+          </div>
+          <button type="button" className={styles.fullCoral}>Send message <ArrowIcon /></button>
+        </div>
+        <div className={styles.contactSide}>
+          <article className={styles.infoCard}>
+            <h3>Office &amp; hours</h3>
+            <p>⌖ 333/12 Pratumnak Road, Banglamung, Chonburi 20150</p>
+            <p>◷ Monday – Saturday, 9:00 – 19:00 ICT</p>
+            <p>☎ +66 38 123 4567</p>
+            <div>
+              <Link href={href('/contact')}>💬 WhatsApp</Link>
+              <Link href={href('/contact')}>LINE</Link>
+            </div>
+          </article>
+          <ContactAdvisorCard />
+        </div>
+      </section>
+    </>
+  );
+}
+
+function DetailPage({ kind }: { kind: 'project' | 'property' }) {
+  const project = kind === 'property' ? projects[1] : projects[0];
+
+  return (
+    <>
+      <section className={styles.detailHero}>
+        <img src={project.image} alt={project.name} loading="eager" />
+        <div>
+          <span className={styles.mono}>{kind === 'property' ? 'Verified resale · Unit A1203' : `${project.badge} · ${project.area}`}</span>
+          <h1>{kind === 'property' ? 'Sea-view 2BR residence with managed rental upside.' : project.name}</h1>
+          <p>{project.tone}</p>
+          <div className={styles.heroButtons}>
+            <Link href={href('/contact')} className={styles.primaryHero}>Book a viewing <ArrowIcon /></Link>
+            <Link href={href('/compare')} className={styles.secondaryHero}>Compare shortlist</Link>
+          </div>
+        </div>
+      </section>
+      <section className={styles.detailBody}>
+        <div className={styles.detailStats}>
+          <span><b>From</b>{project.from}</span>
+          <span><b>Yield</b>{project.yield}</span>
+          <span><b>Foreign quota</b>{project.quota}</span>
+          <span><b>Beach</b>{project.beach}</span>
+        </div>
+        <div className={styles.galleryGrid}>
+          {projects.slice(0, 4).map((item) => <img key={item.slug} src={item.image} alt={item.name} loading="eager" />)}
+        </div>
+        <div className={styles.detailColumns}>
+          <article>
+            <span className={styles.mono}>Advisor brief</span>
+            <h2>{kind === 'property' ? 'A ready unit for lifestyle plus rental management.' : 'Developer track record, quota, and exit liquidity in one view.'}</h2>
+            <p>The v3 preview follows the approved detail-page direction with a calm editorial hero, metric rail, image-led gallery, and advisor-first conversion path.</p>
+          </article>
+          <AdvisorPanel />
+        </div>
+      </section>
+    </>
+  );
+}
+
+function V3RouteContent({ route }: { route: V3PreviewRoute }) {
+  if (route === 'listing') return <ListingPage />;
+  if (route === 'area-guide') return <AreaGuidePage />;
+  if (route === 'calculator') return <CalculatorPage />;
+  if (route === 'finder') return <FinderPage />;
+  if (route === 'compare') return <ComparePage />;
+  if (route === 'contact') return <ContactPage />;
+  if (route === 'project-detail') return <DetailPage kind="project" />;
+  if (route === 'property-detail') return <DetailPage kind="property" />;
+  return <HomePage />;
+}
+
+export function V3PreviewPage({ route }: { route: V3PreviewRoute }) {
+  const finderOnly = route === 'finder';
+
+  return (
+    <main className={`${styles.page} amp-v3-preview-page`} data-testid="amp-public-v3-preview">
+      {finderOnly ? null : <ShellHeader route={route} />}
+      <V3RouteContent route={route} />
+      {finderOnly ? null : <ShellFooter />}
+    </main>
+  );
+}

--- a/admin-app/app/(site)/[locale]/v3-preview/_lib/v3-preview-data.ts
+++ b/admin-app/app/(site)/[locale]/v3-preview/_lib/v3-preview-data.ts
@@ -16,7 +16,7 @@ export type V3Project = {
   name: string;
   developer: string;
   from: string;
-  yield: string;
+  availability: string;
   quota: string;
   beach: string;
   image: string;
@@ -36,8 +36,13 @@ export type V3Area = {
 export type V3Advisor = {
   name: string;
   role: string;
-  rating: string;
   image: string;
+};
+
+export type V3ProcessNote = {
+  title: string;
+  body: string;
+  label: string;
 };
 
 export const previewRoutes = new Set([
@@ -75,108 +80,108 @@ export function resolveV3PreviewRoute(slug: string[] = []): V3PreviewRoute | nul
 
 export const projects: V3Project[] = [
   {
-    slug: 'skyharbor-residences',
-    badge: 'New launch',
+    slug: 'amp-skyharbor',
+    badge: 'Under construction',
     area: 'Wongamat',
     name: 'Skyharbor Residences',
-    developer: 'AMP Property Group · Q4 2026',
-    from: '฿6.9M',
-    yield: '6.8%',
-    quota: '32% of 49%',
-    beach: '80m',
+    developer: 'Project details subject to confirmation',
+    from: 'Price on request',
+    availability: 'Availability to verify',
+    quota: 'Project details subject to confirmation',
+    beach: 'Wongamat',
     image: 'https://images.unsplash.com/photo-1545324418-cc1a3fa10c00?w=1200&q=80&auto=format&fit=crop',
-    tone: 'Oceanfront tower with a refined arrival sequence and investor-grade unit mix.',
+    tone: 'Gallery-first project detail direction for owner review, with price, availability, and project details to confirm.',
   },
   {
     slug: 'jomtien-bay-tower',
-    badge: 'Best yield',
+    badge: 'Availability to verify',
     area: 'Jomtien',
     name: 'Jomtien Bay Tower',
-    developer: 'Sansiri × AMP · Q2 2027',
-    from: '฿4.0M',
-    yield: '7.4%',
-    quota: '18% of 49%',
-    beach: '220m',
+    developer: 'Project details subject to confirmation',
+    from: 'Price on request',
+    availability: 'Availability to verify',
+    quota: 'Project details subject to confirmation',
+    beach: 'Jomtien',
     image: 'https://images.unsplash.com/photo-1582719508461-905c673771fd?w=1200&q=80&auto=format&fit=crop',
-    tone: 'High-yield beach corridor with efficient plans and remote buyer support.',
+    tone: 'Project card treatment for visual review with commercial details to verify.',
   },
   {
     slug: 'pratumnak-villas',
-    badge: 'Move-in ready',
+    badge: 'Availability to verify',
     area: 'Pratumnak Hill',
     name: 'Pratumnak Villas',
-    developer: 'AMP Property Group · Ready to move',
-    from: '฿29M',
-    yield: '5.2%',
-    quota: '71% of 49%',
-    beach: '380m',
+    developer: 'Project details subject to confirmation',
+    from: 'Price on request',
+    availability: 'Availability to verify',
+    quota: 'Project details subject to confirmation',
+    beach: 'Pratumnak Hill',
     image: 'https://images.unsplash.com/photo-1512917774080-9991f1c4c750?w=1200&q=80&auto=format&fit=crop',
-    tone: 'Private hillside villas for buyers prioritizing space and quiet access.',
+    tone: 'Villa card treatment for visual review with commercial details to verify.',
   },
   {
     slug: 'na-jomtien-residence',
-    badge: 'Early bird -12%',
+    badge: 'Availability to verify',
     area: 'Na Jomtien',
     name: 'Na Jomtien Residence',
-    developer: 'Property Perfect · Q1 2028',
-    from: '฿4.5M',
-    yield: '6.9%',
-    quota: '8% of 49%',
-    beach: '50m',
+    developer: 'Project details subject to confirmation',
+    from: 'Price on request',
+    availability: 'Availability to verify',
+    quota: 'Project details subject to confirmation',
+    beach: 'Na Jomtien',
     image: 'https://images.unsplash.com/photo-1600596542815-ffad4c1539a9?w=1200&q=80&auto=format&fit=crop',
-    tone: 'Quiet beachfront plan with a slower lifestyle and early allocation window.',
+    tone: 'Project card treatment for visual review with commercial details to verify.',
   },
   {
     slug: 'central-marina-suites',
-    badge: 'Highest yield',
+    badge: 'Availability to verify',
     area: 'Central Pattaya',
     name: 'Central Marina Suites',
-    developer: 'AP Thailand · Q3 2026',
-    from: '฿3.0M',
-    yield: '8.1%',
-    quota: '41% of 49%',
-    beach: '450m',
+    developer: 'Project details subject to confirmation',
+    from: 'Price on request',
+    availability: 'Availability to verify',
+    quota: 'Project details subject to confirmation',
+    beach: 'Central Pattaya',
     image: 'https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=1200&q=80&auto=format&fit=crop',
-    tone: 'Urban rental thesis near shopping, restaurants, and short-stay demand.',
+    tone: 'City project card treatment for visual review with commercial details to verify.',
   },
   {
     slug: 'bang-saray-view',
-    badge: 'Quiet zone',
+    badge: 'Availability to verify',
     area: 'Bang Saray',
     name: 'Bang Saray View',
-    developer: 'Origin Property · Q4 2027',
-    from: '฿3.2M',
-    yield: '6.4%',
-    quota: '4% of 49%',
-    beach: '120m',
+    developer: 'Project details subject to confirmation',
+    from: 'Price on request',
+    availability: 'Availability to verify',
+    quota: 'Project details subject to confirmation',
+    beach: 'Bang Saray',
     image: 'https://images.unsplash.com/photo-1600210492486-724fe5c67fb0?w=1200&q=80&auto=format&fit=crop',
-    tone: 'Fishing-village atmosphere with lower density and long-hold positioning.',
+    tone: 'Coastal project card treatment for visual review with commercial details to verify.',
   },
   {
     slug: 'skyline-plaza-pattaya',
-    badge: 'Foreign quota full',
+    badge: 'Availability to verify',
     area: 'Central Pattaya',
     name: 'Skyline Plaza Pattaya',
-    developer: 'Sansiri · Ready to move',
-    from: '฿4.7M',
-    yield: '6%',
-    quota: '49% of 49%',
-    beach: '200m',
+    developer: 'Project details subject to confirmation',
+    from: 'Price on request',
+    availability: 'Availability to verify',
+    quota: 'Project details subject to confirmation',
+    beach: 'Central Pattaya',
     image: 'https://images.unsplash.com/photo-1613977257363-707ba9348227?w=1200&q=80&auto=format&fit=crop',
-    tone: 'Completed city project with strong walkability and limited foreign quota.',
+    tone: 'Resale-style card treatment for visual review with commercial details to verify.',
   },
   {
     slug: 'rayong-coast-villas',
-    badge: 'Beachfront villa',
+    badge: 'Availability to verify',
     area: 'Rayong',
     name: 'Rayong Coast Villas',
-    developer: 'AMP Property Group · Q2 2027',
-    from: '฿19M',
-    yield: '5.6%',
-    quota: '0% of 49%',
-    beach: 'Beachfront',
+    developer: 'Project details subject to confirmation',
+    from: 'Price on request',
+    availability: 'Availability to verify',
+    quota: 'Project details subject to confirmation',
+    beach: 'Rayong',
     image: 'https://images.unsplash.com/photo-1567496898669-ee935f5f647a?w=1200&q=80&auto=format&fit=crop',
-    tone: 'Beachfront villa inventory for lifestyle-first buyers beyond central Pattaya.',
+    tone: 'Villa card treatment for visual review with commercial details to verify.',
   },
 ];
 
@@ -184,7 +189,7 @@ export const areas: V3Area[] = [
   {
     slug: 'wongamat',
     label: '5-star beaches',
-    listings: '14 listings',
+    listings: 'Availability to verify',
     title: 'Wongamat',
     summary: 'Quiet luxury, resort hotels, private condos',
     thesis: '5-star quiet luxury',
@@ -193,7 +198,7 @@ export const areas: V3Area[] = [
   {
     slug: 'pratumnak-hill',
     label: 'Cosy Beach',
-    listings: '22 listings',
+    listings: 'Availability to verify',
     title: 'Pratumnak Hill',
     summary: 'Hillside villas',
     thesis: 'Private hillside living',
@@ -202,16 +207,16 @@ export const areas: V3Area[] = [
   {
     slug: 'jomtien',
     label: 'Jomtien Beach',
-    listings: '38 listings',
+    listings: 'Availability to verify',
     title: 'Jomtien',
-    summary: 'High-yield investor',
+    summary: 'Buyer journey to verify',
     thesis: 'Income-first beach corridor',
     image: 'https://images.unsplash.com/photo-1552733407-5d5c46c3bb3b?w=1200&q=80&auto=format&fit=crop',
   },
   {
     slug: 'central-pattaya',
     label: 'Pattaya Beach',
-    listings: '47 listings',
+    listings: 'Availability to verify',
     title: 'Central Pattaya',
     summary: 'Urban, walk-to-everything',
     thesis: 'Urban rental demand',
@@ -220,7 +225,7 @@ export const areas: V3Area[] = [
   {
     slug: 'na-jomtien',
     label: 'Na Jomtien',
-    listings: '19 listings',
+    listings: 'Availability to verify',
     title: 'Na Jomtien',
     summary: 'Quiet beachfront',
     thesis: 'Calm waterfront hold',
@@ -229,7 +234,7 @@ export const areas: V3Area[] = [
   {
     slug: 'bang-saray',
     label: 'Bang Saray',
-    listings: '11 listings',
+    listings: 'Availability to verify',
     title: 'Bang Saray',
     summary: 'Local fishing village',
     thesis: 'Low-density coastal life',
@@ -241,51 +246,50 @@ export const advisors: V3Advisor[] = [
   {
     name: 'Khun Apinya',
     role: 'Senior Advisor · TH · EN',
-    rating: '4.95',
     image: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&q=80&auto=format&fit=crop',
   },
   {
     name: 'Marcus Lee',
     role: 'Investor Lead · EN · CN',
-    rating: '4.92',
     image: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&q=80&auto=format&fit=crop',
   },
   {
     name: 'Sasha Volkov',
     role: 'Russian-speaking · RU · EN',
-    rating: '4.88',
     image: 'https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?w=200&q=80&auto=format&fit=crop',
   },
   {
     name: 'Nattapong S.',
     role: 'Property Manager · TH · EN',
-    rating: '4.97',
     image: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=200&q=80&auto=format&fit=crop',
   },
   {
     name: 'Lin Wei',
     role: 'Mandarin lead · CN · EN',
-    rating: '4.85',
     image: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=200&q=80&auto=format&fit=crop',
   },
 ];
 
-export const testimonials = [
+export const processNotes: V3ProcessNote[] = [
   {
-    quote: 'AMP walked me through foreign ownership rules in 20 minutes — and found a 7.2% net-yield 1BR three weeks later.',
-    author: 'Sven L. · Stockholm · 1BR Jomtien',
+    title: 'Discovery',
+    body: 'Capture buyer intent, preferred zones, budget range, and timing before any recommendation.',
+    label: 'Step one',
   },
   {
-    quote: "They're the only Pattaya brokerage that gave me a written rental-return forecast before I signed. Numbers held up after 12 months.",
-    author: 'David W. · Singapore · 2BR Wongamat',
+    title: 'Shortlist',
+    body: 'Prepare a project brief with price, availability, and project details marked for confirmation.',
+    label: 'Review pack',
   },
   {
-    quote: 'Sasha managed everything remotely. She filmed five viewings on FaceTime and helped my notary in Moscow.',
-    author: 'Anna M. · Moscow · Penthouse',
+    title: 'Viewing',
+    body: 'Coordinate questions, viewing notes, floor-plan requests, and advisor follow-up in one place.',
+    label: 'Advisor flow',
   },
   {
-    quote: '3 units, 2 years. Each one cash-flowing within 60 days of handover. The property management team is the real moat.',
-    author: 'James T. · Sydney · Portfolio investor',
+    title: 'Confirmation',
+    body: 'Confirm pricing, availability, ownership route, documents, and timelines before production use.',
+    label: 'Final check',
   },
 ];
 

--- a/admin-app/app/(site)/[locale]/v3-preview/_lib/v3-preview-data.ts
+++ b/admin-app/app/(site)/[locale]/v3-preview/_lib/v3-preview-data.ts
@@ -20,6 +20,7 @@ export type V3Project = {
   quota: string;
   beach: string;
   image: string;
+  gallery: string[];
   tone: string;
 };
 
@@ -90,6 +91,13 @@ export const projects: V3Project[] = [
     quota: 'Project details subject to confirmation',
     beach: 'Wongamat',
     image: 'https://images.unsplash.com/photo-1545324418-cc1a3fa10c00?w=1200&q=80&auto=format&fit=crop',
+    gallery: [
+      'https://images.unsplash.com/photo-1545324418-cc1a3fa10c00?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1571003123894-1f0594d2b5d9?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1600607687939-ce8a6c25118c?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1564013799919-ab600027ffc6?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1542718610-a1d656d1884c?w=1200&q=80&auto=format&fit=crop',
+    ],
     tone: 'Gallery-first project detail direction for owner review, with price, availability, and project details to confirm.',
   },
   {
@@ -103,6 +111,13 @@ export const projects: V3Project[] = [
     quota: 'Project details subject to confirmation',
     beach: 'Jomtien',
     image: 'https://images.unsplash.com/photo-1582719508461-905c673771fd?w=1200&q=80&auto=format&fit=crop',
+    gallery: [
+      'https://images.unsplash.com/photo-1582719508461-905c673771fd?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1600566753190-17f0baa2a6c3?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1571896349842-33c89424de2d?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1534438327276-14e5300c3a48?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1616594039964-ae9021a400a0?w=1200&q=80&auto=format&fit=crop',
+    ],
     tone: 'Project card treatment for visual review with commercial details to verify.',
   },
   {
@@ -116,6 +131,13 @@ export const projects: V3Project[] = [
     quota: 'Project details subject to confirmation',
     beach: 'Pratumnak Hill',
     image: 'https://images.unsplash.com/photo-1512917774080-9991f1c4c750?w=1200&q=80&auto=format&fit=crop',
+    gallery: [
+      'https://images.unsplash.com/photo-1512917774080-9991f1c4c750?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1631679706909-1844bbd07221?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1540541338287-41700207dee6?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1618221195710-dd6b41faaea6?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1600210492486-724fe5c67fb0?w=1200&q=80&auto=format&fit=crop',
+    ],
     tone: 'Villa card treatment for visual review with commercial details to verify.',
   },
   {
@@ -129,6 +151,13 @@ export const projects: V3Project[] = [
     quota: 'Project details subject to confirmation',
     beach: 'Na Jomtien',
     image: 'https://images.unsplash.com/photo-1600596542815-ffad4c1539a9?w=1200&q=80&auto=format&fit=crop',
+    gallery: [
+      'https://images.unsplash.com/photo-1600596542815-ffad4c1539a9?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1560185007-cde436f6a4d0?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1571003123894-1f0594d2b5d9?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=1200&q=80&auto=format&fit=crop',
+    ],
     tone: 'Project card treatment for visual review with commercial details to verify.',
   },
   {
@@ -142,6 +171,13 @@ export const projects: V3Project[] = [
     quota: 'Project details subject to confirmation',
     beach: 'Central Pattaya',
     image: 'https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=1200&q=80&auto=format&fit=crop',
+    gallery: [
+      'https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1617806118233-18e1de247200?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1564013799919-ab600027ffc6?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1534438327276-14e5300c3a48?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1600607687939-ce8a6c25118c?w=1200&q=80&auto=format&fit=crop',
+    ],
     tone: 'City project card treatment for visual review with commercial details to verify.',
   },
   {
@@ -155,6 +191,13 @@ export const projects: V3Project[] = [
     quota: 'Project details subject to confirmation',
     beach: 'Bang Saray',
     image: 'https://images.unsplash.com/photo-1600210492486-724fe5c67fb0?w=1200&q=80&auto=format&fit=crop',
+    gallery: [
+      'https://images.unsplash.com/photo-1600210492486-724fe5c67fb0?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1552733407-5d5c46c3bb3b?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1582610116397-edb318620f90?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1545569341-9eb8b30979d9?w=1200&q=80&auto=format&fit=crop',
+    ],
     tone: 'Coastal project card treatment for visual review with commercial details to verify.',
   },
   {
@@ -168,6 +211,13 @@ export const projects: V3Project[] = [
     quota: 'Project details subject to confirmation',
     beach: 'Central Pattaya',
     image: 'https://images.unsplash.com/photo-1613977257363-707ba9348227?w=1200&q=80&auto=format&fit=crop',
+    gallery: [
+      'https://images.unsplash.com/photo-1613977257363-707ba9348227?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1616594039964-ae9021a400a0?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1571003123894-1f0594d2b5d9?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1564013799919-ab600027ffc6?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1542718610-a1d656d1884c?w=1200&q=80&auto=format&fit=crop',
+    ],
     tone: 'Resale-style card treatment for visual review with commercial details to verify.',
   },
   {
@@ -181,6 +231,13 @@ export const projects: V3Project[] = [
     quota: 'Project details subject to confirmation',
     beach: 'Rayong',
     image: 'https://images.unsplash.com/photo-1567496898669-ee935f5f647a?w=1200&q=80&auto=format&fit=crop',
+    gallery: [
+      'https://images.unsplash.com/photo-1567496898669-ee935f5f647a?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1540541338287-41700207dee6?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1618221195710-dd6b41faaea6?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1600210492486-724fe5c67fb0?w=1200&q=80&auto=format&fit=crop',
+      'https://images.unsplash.com/photo-1631679706909-1844bbd07221?w=1200&q=80&auto=format&fit=crop',
+    ],
     tone: 'Villa card treatment for visual review with commercial details to verify.',
   },
 ];

--- a/admin-app/app/(site)/[locale]/v3-preview/_lib/v3-preview-data.ts
+++ b/admin-app/app/(site)/[locale]/v3-preview/_lib/v3-preview-data.ts
@@ -1,0 +1,302 @@
+export type V3PreviewRoute =
+  | 'home'
+  | 'listing'
+  | 'area-guide'
+  | 'calculator'
+  | 'finder'
+  | 'compare'
+  | 'contact'
+  | 'project-detail'
+  | 'property-detail';
+
+export type V3Project = {
+  slug: string;
+  badge: string;
+  area: string;
+  name: string;
+  developer: string;
+  from: string;
+  yield: string;
+  quota: string;
+  beach: string;
+  image: string;
+  tone: string;
+};
+
+export type V3Area = {
+  slug: string;
+  label: string;
+  listings: string;
+  title: string;
+  summary: string;
+  thesis: string;
+  image: string;
+};
+
+export type V3Advisor = {
+  name: string;
+  role: string;
+  rating: string;
+  image: string;
+};
+
+export const previewRoutes = new Set([
+  'listing',
+  'buy',
+  'projects',
+  'new-projects',
+  'area-guide',
+  'areas',
+  'calculator',
+  'invest',
+  'finder',
+  'smart-finder',
+  'compare',
+  'contact',
+  'project',
+  'property',
+]);
+
+export function resolveV3PreviewRoute(slug: string[] = []): V3PreviewRoute | null {
+  const [first] = slug;
+
+  if (!first) return 'home';
+  if (first === 'listing' || first === 'buy' || first === 'projects' || first === 'new-projects') return 'listing';
+  if (first === 'area-guide' || first === 'areas') return 'area-guide';
+  if (first === 'calculator' || first === 'invest') return 'calculator';
+  if (first === 'finder' || first === 'smart-finder') return 'finder';
+  if (first === 'compare') return 'compare';
+  if (first === 'contact') return 'contact';
+  if (first === 'project') return 'project-detail';
+  if (first === 'property') return 'property-detail';
+
+  return null;
+}
+
+export const projects: V3Project[] = [
+  {
+    slug: 'skyharbor-residences',
+    badge: 'New launch',
+    area: 'Wongamat',
+    name: 'Skyharbor Residences',
+    developer: 'AMP Property Group · Q4 2026',
+    from: '฿6.9M',
+    yield: '6.8%',
+    quota: '32% of 49%',
+    beach: '80m',
+    image: 'https://images.unsplash.com/photo-1545324418-cc1a3fa10c00?w=1200&q=80&auto=format&fit=crop',
+    tone: 'Oceanfront tower with a refined arrival sequence and investor-grade unit mix.',
+  },
+  {
+    slug: 'jomtien-bay-tower',
+    badge: 'Best yield',
+    area: 'Jomtien',
+    name: 'Jomtien Bay Tower',
+    developer: 'Sansiri × AMP · Q2 2027',
+    from: '฿4.0M',
+    yield: '7.4%',
+    quota: '18% of 49%',
+    beach: '220m',
+    image: 'https://images.unsplash.com/photo-1582719508461-905c673771fd?w=1200&q=80&auto=format&fit=crop',
+    tone: 'High-yield beach corridor with efficient plans and remote buyer support.',
+  },
+  {
+    slug: 'pratumnak-villas',
+    badge: 'Move-in ready',
+    area: 'Pratumnak Hill',
+    name: 'Pratumnak Villas',
+    developer: 'AMP Property Group · Ready to move',
+    from: '฿29M',
+    yield: '5.2%',
+    quota: '71% of 49%',
+    beach: '380m',
+    image: 'https://images.unsplash.com/photo-1512917774080-9991f1c4c750?w=1200&q=80&auto=format&fit=crop',
+    tone: 'Private hillside villas for buyers prioritizing space and quiet access.',
+  },
+  {
+    slug: 'na-jomtien-residence',
+    badge: 'Early bird -12%',
+    area: 'Na Jomtien',
+    name: 'Na Jomtien Residence',
+    developer: 'Property Perfect · Q1 2028',
+    from: '฿4.5M',
+    yield: '6.9%',
+    quota: '8% of 49%',
+    beach: '50m',
+    image: 'https://images.unsplash.com/photo-1600596542815-ffad4c1539a9?w=1200&q=80&auto=format&fit=crop',
+    tone: 'Quiet beachfront plan with a slower lifestyle and early allocation window.',
+  },
+  {
+    slug: 'central-marina-suites',
+    badge: 'Highest yield',
+    area: 'Central Pattaya',
+    name: 'Central Marina Suites',
+    developer: 'AP Thailand · Q3 2026',
+    from: '฿3.0M',
+    yield: '8.1%',
+    quota: '41% of 49%',
+    beach: '450m',
+    image: 'https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=1200&q=80&auto=format&fit=crop',
+    tone: 'Urban rental thesis near shopping, restaurants, and short-stay demand.',
+  },
+  {
+    slug: 'bang-saray-view',
+    badge: 'Quiet zone',
+    area: 'Bang Saray',
+    name: 'Bang Saray View',
+    developer: 'Origin Property · Q4 2027',
+    from: '฿3.2M',
+    yield: '6.4%',
+    quota: '4% of 49%',
+    beach: '120m',
+    image: 'https://images.unsplash.com/photo-1600210492486-724fe5c67fb0?w=1200&q=80&auto=format&fit=crop',
+    tone: 'Fishing-village atmosphere with lower density and long-hold positioning.',
+  },
+  {
+    slug: 'skyline-plaza-pattaya',
+    badge: 'Foreign quota full',
+    area: 'Central Pattaya',
+    name: 'Skyline Plaza Pattaya',
+    developer: 'Sansiri · Ready to move',
+    from: '฿4.7M',
+    yield: '6%',
+    quota: '49% of 49%',
+    beach: '200m',
+    image: 'https://images.unsplash.com/photo-1613977257363-707ba9348227?w=1200&q=80&auto=format&fit=crop',
+    tone: 'Completed city project with strong walkability and limited foreign quota.',
+  },
+  {
+    slug: 'rayong-coast-villas',
+    badge: 'Beachfront villa',
+    area: 'Rayong',
+    name: 'Rayong Coast Villas',
+    developer: 'AMP Property Group · Q2 2027',
+    from: '฿19M',
+    yield: '5.6%',
+    quota: '0% of 49%',
+    beach: 'Beachfront',
+    image: 'https://images.unsplash.com/photo-1567496898669-ee935f5f647a?w=1200&q=80&auto=format&fit=crop',
+    tone: 'Beachfront villa inventory for lifestyle-first buyers beyond central Pattaya.',
+  },
+];
+
+export const areas: V3Area[] = [
+  {
+    slug: 'wongamat',
+    label: '5-star beaches',
+    listings: '14 listings',
+    title: 'Wongamat',
+    summary: 'Quiet luxury, resort hotels, private condos',
+    thesis: '5-star quiet luxury',
+    image: 'https://images.unsplash.com/photo-1545569341-9eb8b30979d9?w=1200&q=80&auto=format&fit=crop',
+  },
+  {
+    slug: 'pratumnak-hill',
+    label: 'Cosy Beach',
+    listings: '22 listings',
+    title: 'Pratumnak Hill',
+    summary: 'Hillside villas',
+    thesis: 'Private hillside living',
+    image: 'https://images.unsplash.com/photo-1499793983690-e29da59ef1c2?w=1200&q=80&auto=format&fit=crop',
+  },
+  {
+    slug: 'jomtien',
+    label: 'Jomtien Beach',
+    listings: '38 listings',
+    title: 'Jomtien',
+    summary: 'High-yield investor',
+    thesis: 'Income-first beach corridor',
+    image: 'https://images.unsplash.com/photo-1552733407-5d5c46c3bb3b?w=1200&q=80&auto=format&fit=crop',
+  },
+  {
+    slug: 'central-pattaya',
+    label: 'Pattaya Beach',
+    listings: '47 listings',
+    title: 'Central Pattaya',
+    summary: 'Urban, walk-to-everything',
+    thesis: 'Urban rental demand',
+    image: 'https://images.unsplash.com/photo-1552465011-b4e21bf6e79a?w=1200&q=80&auto=format&fit=crop',
+  },
+  {
+    slug: 'na-jomtien',
+    label: 'Na Jomtien',
+    listings: '19 listings',
+    title: 'Na Jomtien',
+    summary: 'Quiet beachfront',
+    thesis: 'Calm waterfront hold',
+    image: 'https://images.unsplash.com/photo-1582610116397-edb318620f90?w=1200&q=80&auto=format&fit=crop',
+  },
+  {
+    slug: 'bang-saray',
+    label: 'Bang Saray',
+    listings: '11 listings',
+    title: 'Bang Saray',
+    summary: 'Local fishing village',
+    thesis: 'Low-density coastal life',
+    image: 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=1200&q=80&auto=format&fit=crop',
+  },
+];
+
+export const advisors: V3Advisor[] = [
+  {
+    name: 'Khun Apinya',
+    role: 'Senior Advisor · TH · EN',
+    rating: '4.95',
+    image: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&q=80&auto=format&fit=crop',
+  },
+  {
+    name: 'Marcus Lee',
+    role: 'Investor Lead · EN · CN',
+    rating: '4.92',
+    image: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&q=80&auto=format&fit=crop',
+  },
+  {
+    name: 'Sasha Volkov',
+    role: 'Russian-speaking · RU · EN',
+    rating: '4.88',
+    image: 'https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?w=200&q=80&auto=format&fit=crop',
+  },
+  {
+    name: 'Nattapong S.',
+    role: 'Property Manager · TH · EN',
+    rating: '4.97',
+    image: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=200&q=80&auto=format&fit=crop',
+  },
+  {
+    name: 'Lin Wei',
+    role: 'Mandarin lead · CN · EN',
+    rating: '4.85',
+    image: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=200&q=80&auto=format&fit=crop',
+  },
+];
+
+export const testimonials = [
+  {
+    quote: 'AMP walked me through foreign ownership rules in 20 minutes — and found a 7.2% net-yield 1BR three weeks later.',
+    author: 'Sven L. · Stockholm · 1BR Jomtien',
+  },
+  {
+    quote: "They're the only Pattaya brokerage that gave me a written rental-return forecast before I signed. Numbers held up after 12 months.",
+    author: 'David W. · Singapore · 2BR Wongamat',
+  },
+  {
+    quote: 'Sasha managed everything remotely. She filmed five viewings on FaceTime and helped my notary in Moscow.',
+    author: 'Anna M. · Moscow · Penthouse',
+  },
+  {
+    quote: '3 units, 2 years. Each one cash-flowing within 60 days of handover. The property management team is the real moat.',
+    author: 'James T. · Sydney · Portfolio investor',
+  },
+];
+
+export const faqs = [
+  'Can foreigners own property in Thailand?',
+  'Do I need to be in Thailand to buy?',
+  'How are funds transferred?',
+  'What ongoing costs should I expect?',
+  'How does AMP make money?',
+  'What happens after I sign?',
+];
+
+export const heroImage = 'https://images.unsplash.com/photo-1508009603885-50cf7c579365?w=1200&q=80&auto=format&fit=crop';
+export const contactHeroImage = 'https://images.unsplash.com/photo-1542718610-a1d656d1884c?w=1400&q=80&auto=format&fit=crop';

--- a/admin-app/app/(site)/[locale]/v3-preview/page.tsx
+++ b/admin-app/app/(site)/[locale]/v3-preview/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { V3PreviewPage } from './_components/V3PreviewPage';
+
+export const revalidate = 300;
+
+type PageProps = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  await params;
+
+  return {
+    title: 'AMP Public v3 Preview | AMP Pattaya',
+    description: 'English-only AMP Pattaya public frontend v3 preview based on the approved design direction.',
+    alternates: {
+      canonical: '/en/v3-preview',
+    },
+    robots: {
+      index: false,
+      follow: false,
+      googleBot: {
+        index: false,
+        follow: false,
+      },
+    },
+    openGraph: {
+      title: 'AMP Public v3 Preview | AMP Pattaya',
+      description: 'English-only AMP Pattaya public frontend v3 preview based on the approved design direction.',
+      url: '/en/v3-preview',
+      type: 'website',
+      locale: 'en_US',
+      siteName: 'AMP Pattaya',
+    },
+  };
+}
+
+export default async function AmpPublicV3PreviewPage({ params }: PageProps) {
+  const { locale } = await params;
+
+  if (locale !== 'en') {
+    notFound();
+  }
+
+  return <V3PreviewPage route="home" />;
+}

--- a/admin-app/app/(site)/[locale]/v3-preview/v3-preview.module.css
+++ b/admin-app/app/(site)/[locale]/v3-preview/v3-preview.module.css
@@ -65,6 +65,10 @@
   background: rgba(248, 244, 234, 0.18);
 }
 
+.headerHome .mobileNav summary span {
+  background: #f8f4ea;
+}
+
 .headerHome .nav a:hover,
 .headerHome .navActive {
   background: rgba(248, 244, 234, 0.1);
@@ -592,8 +596,8 @@
 
 .searchFields a {
   display: grid;
-  height: 56.75px;
-  min-height: 0;
+  height: auto;
+  min-height: 64px;
   padding: 7px 18px;
   border-left: 1px solid var(--line-soft);
 }
@@ -613,6 +617,8 @@
 .searchFields strong {
   color: var(--ink);
   font-size: 15px;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
 }
 
 .searchButton {
@@ -814,7 +820,7 @@
 
 .cardStats {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1px;
   overflow: hidden;
   border: 1px solid var(--line-soft);
@@ -828,6 +834,8 @@
   background: var(--bone);
   font-size: 13px;
   font-weight: 800;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
 }
 
 .cardStats b {
@@ -1046,6 +1054,18 @@
   color: var(--ink-4);
   font-size: 13px;
   font-style: normal;
+  line-height: 1.55;
+}
+
+.testimonialGrid small {
+  display: inline-flex;
+  margin-top: 16px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: var(--bone);
+  color: var(--coral);
+  font-size: 11px;
+  font-weight: 800;
 }
 
 .advisorPanel {
@@ -1445,7 +1465,7 @@
 }
 
 .projectCardCompact .cardStats {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   position: relative;
   gap: 12px;
   margin-top: 10px;
@@ -1459,7 +1479,7 @@
   padding: 0;
   background: transparent;
   font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 400;
   line-height: 27px;
 }
@@ -2682,73 +2702,250 @@
   background: #06c755;
 }
 
-.detailHero {
+.detailGalleryPage {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 22px 40px 18px;
+}
+
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  color: var(--ink-3) !important;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.detailMainGallery {
   position: relative;
-  display: grid;
-  min-height: 620px;
-  color: #f8f4ea;
+  height: min(596px, 46vw);
+  min-height: 430px;
+  margin-top: 22px;
   overflow: hidden;
+  border-radius: 18px;
+  background: var(--ink);
 }
 
-.detailHero img {
-  position: absolute;
-  inset: 0;
-}
-
-.detailHero::after {
+.detailMainGallery::after {
   position: absolute;
   inset: 0;
   content: "";
-  background: linear-gradient(90deg, rgba(7, 18, 18, 0.82), rgba(7, 18, 18, 0.24));
+  background: linear-gradient(180deg, transparent 48%, rgba(20, 32, 31, 0.48) 100%);
+  pointer-events: none;
 }
 
-.detailHero div {
+.detailMainGallery img,
+.detailThumbStrip img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.galleryArrowLeft,
+.galleryArrowRight,
+.favoriteButton {
+  position: absolute;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.galleryArrowLeft,
+.galleryArrowRight {
+  top: 50%;
+  width: 45px;
+  height: 45px;
+  font-size: 30px;
+  transform: translateY(-50%);
+}
+
+.galleryArrowLeft {
+  left: 16px;
+}
+
+.galleryArrowRight {
+  right: 16px;
+}
+
+.favoriteButton {
+  top: 16px;
+  right: 16px;
+  width: 44px;
+  height: 44px;
+  color: var(--coral);
+}
+
+.galleryDots {
+  position: absolute;
+  z-index: 2;
+  right: 0;
+  bottom: 16px;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+}
+
+.galleryDots span {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.45);
+}
+
+.galleryDots .galleryDotActive {
+  width: 22px;
+  background: #fff;
+}
+
+.detailThumbStrip {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.detailThumbStrip button {
+  height: 148px;
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  background: var(--paper);
+  cursor: pointer;
+}
+
+.detailThumbStrip .thumbActive {
+  border: 2px solid var(--teal);
+}
+
+.detailTitleRow {
   position: relative;
-  z-index: 1;
-  align-self: end;
-  max-width: 760px;
-  padding: 120px 64px 90px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 240px 380px;
+  align-items: start;
+  gap: 28px;
+  margin-top: 32px;
 }
 
-.detailHero h1 {
-  font-size: 78px;
-  line-height: 0.98;
+.detailTitleCopy {
+  min-width: 0;
 }
 
-.detailHero p {
-  color: rgba(248, 244, 234, 0.76);
+.detailMeta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 8px;
+}
+
+.detailMeta span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: #f1dfbe;
+  color: #9b7440;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.detailMeta em {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--ink-3);
+  font-size: 13px;
+  font-style: normal;
+}
+
+.detailTitleCopy h1 {
+  margin: 0;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 54px;
+  font-weight: 400;
+  line-height: 1.02;
+}
+
+.detailPriceBlock {
+  display: grid;
+  gap: 6px;
+  justify-items: end;
+  padding-top: 4px;
+  text-align: right;
+}
+
+.detailPriceBlock strong {
+  color: var(--ink);
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 34px;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.detailPriceBlock span {
+  color: var(--ink-4);
+  font-size: 12px;
+}
+
+.detailTitleRow .leadCard {
+  margin-top: 0;
+  padding: 26px;
+  border-color: var(--line-soft);
+  background: var(--paper);
+  color: var(--ink);
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.detailTitleRow .leadCard h3 {
+  color: var(--ink);
+}
+
+.detailTitleRow .leadCard p,
+.detailTitleRow .leadCard small,
+.detailTitleRow .leadCard em {
+  color: var(--ink-3);
+}
+
+.detailTitleRow .leadCard input,
+.detailTitleRow .leadCard select {
+  border-color: var(--line);
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.detailTitleRow .leadCard input::placeholder {
+  color: var(--ink-4);
+}
+
+.detailGalleryPage .detailStats {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 24px;
 }
 
 .detailBody {
-  padding-top: 60px;
+  padding-top: 34px;
   padding-bottom: 80px;
 }
 
-.detailStats {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
 .galleryGrid {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr;
-  grid-auto-rows: 210px;
-  gap: 14px;
-  margin-top: 30px;
-}
-
-.galleryGrid img {
-  border-radius: 16px;
-}
-
-.galleryGrid img:first-child {
-  grid-row: span 2;
+  display: none;
 }
 
 .detailColumns {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 390px;
   gap: 28px;
-  margin-top: 30px;
+  margin-top: 0;
 }
 
 .detailColumns > article {
@@ -2779,7 +2976,8 @@
   .contactGrid,
   .calculatorGrid,
   .finderGridPage,
-  .detailColumns {
+  .detailColumns,
+  .detailTitleRow {
     grid-template-columns: 1fr;
   }
 
@@ -2818,6 +3016,20 @@
   .leadCard {
     max-width: 560px;
     margin-top: 0;
+  }
+
+  .detailMainGallery {
+    height: 520px;
+    min-height: 420px;
+  }
+
+  .detailTitleRow .leadCard {
+    max-width: none;
+  }
+
+  .detailPriceBlock {
+    justify-items: start;
+    text-align: left;
   }
 
   .searchPanel {
@@ -2918,6 +3130,10 @@
     font-size: 15px;
   }
 
+  .leadFields {
+    grid-template-columns: 1fr;
+  }
+
   .heroStats {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -2948,7 +3164,8 @@
   .areaGuideLayout,
   .calculatorGrid,
   .compareTable,
-  .detailBody {
+  .detailBody,
+  .detailGalleryPage {
     padding-right: 20px;
     padding-left: 20px;
   }
@@ -3051,6 +3268,49 @@
 
   .galleryGrid img:first-child {
     grid-row: span 1;
+  }
+
+  .detailMainGallery {
+    height: 360px;
+    min-height: 320px;
+    border-radius: 16px;
+  }
+
+  .galleryArrowLeft,
+  .galleryArrowRight {
+    width: 38px;
+    height: 38px;
+    font-size: 25px;
+  }
+
+  .favoriteButton {
+    width: 40px;
+    height: 40px;
+  }
+
+  .detailThumbStrip {
+    display: flex;
+    overflow-x: auto;
+    padding-bottom: 4px;
+    scroll-snap-type: x mandatory;
+  }
+
+  .detailThumbStrip button {
+    min-width: 156px;
+    height: 92px;
+    scroll-snap-align: start;
+  }
+
+  .detailTitleCopy h1 {
+    font-size: 42px;
+  }
+
+  .detailPriceBlock strong {
+    font-size: 30px;
+  }
+
+  .detailGalleryPage .detailStats {
+    grid-template-columns: 1fr;
   }
 
   .detailHero div {

--- a/admin-app/app/(site)/[locale]/v3-preview/v3-preview.module.css
+++ b/admin-app/app/(site)/[locale]/v3-preview/v3-preview.module.css
@@ -1,0 +1,3072 @@
+.page {
+  --bone: #f8f4ea;
+  --paper: #fff;
+  --ink: #14201f;
+  --ink-2: #2a3736;
+  --ink-3: #5b6764;
+  --ink-4: #8a938f;
+  --line: #d8cdb4;
+  --line-soft: #e7ddc4;
+  --coral: #d96a4e;
+  --teal: #0e3a3a;
+  --teal-pale: #d9e4e0;
+  --champagne: #c9a677;
+  min-height: 100vh;
+  width: 100%;
+  overflow-x: hidden;
+  background: var(--bone);
+  color: var(--ink);
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.page *,
+.page *::before,
+.page *::after {
+  box-sizing: border-box;
+}
+
+.page a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.page button,
+.page input,
+.page textarea {
+  font: inherit;
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  border-bottom: 1px solid var(--line-soft);
+  background: rgba(248, 244, 234, 0.92);
+  backdrop-filter: saturate(160%) blur(14px);
+}
+
+.headerHome {
+  border-bottom-color: rgba(248, 244, 234, 0.08);
+  background: rgba(20, 32, 31, 0.78);
+  color: #f8f4ea;
+}
+
+.headerHome .nav a,
+.headerHome .plainPill {
+  color: rgba(248, 244, 234, 0.82);
+}
+
+.headerHome .outlinePill {
+  border-color: rgba(248, 244, 234, 0.24);
+  color: #f8f4ea;
+}
+
+.headerHome .headerDivider {
+  background: rgba(248, 244, 234, 0.18);
+}
+
+.headerHome .nav a:hover,
+.headerHome .navActive {
+  background: rgba(248, 244, 234, 0.1);
+  color: #fff !important;
+}
+
+.headerInner {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  max-width: 1440px;
+  min-height: 63px;
+  margin: 0 auto;
+  padding: 12px 40px;
+}
+
+.brand,
+.logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: max-content;
+}
+
+.logo svg {
+  flex: 0 0 auto;
+}
+
+.logo span {
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 1;
+  letter-spacing: 0.04em;
+}
+
+.logo em {
+  font-style: italic;
+}
+
+.nav {
+  display: flex;
+  flex: 1;
+  gap: 2px;
+  margin-left: 8px;
+}
+
+.nav a,
+.plainPill,
+.outlinePill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  color: var(--ink-3);
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.nav a {
+  min-height: 37px;
+  padding: 8px 13px;
+}
+
+.nav a:hover,
+.navActive {
+  background: rgba(20, 32, 31, 0.05);
+  color: var(--ink) !important;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.plainPill {
+  height: 32px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  gap: 5px;
+}
+
+.outlinePill {
+  gap: 7px;
+  height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--ink);
+}
+
+.headerDivider {
+  width: 1px;
+  height: 16px;
+  background: var(--line-soft);
+}
+
+.coralPill,
+.primaryHero,
+.fullCoral,
+.primaryLight {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--coral);
+  color: #fff !important;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.coralPill {
+  height: 34px;
+  padding: 0 14px;
+  font-size: 13px;
+}
+
+.mobileNav {
+  display: none;
+  margin-left: auto;
+}
+
+.mobileNav summary {
+  display: grid;
+  gap: 4px;
+  width: 38px;
+  height: 38px;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.mobileNav summary::-webkit-details-marker {
+  display: none;
+}
+
+.mobileNav summary span {
+  height: 2px;
+  border-radius: 999px;
+  background: var(--ink);
+}
+
+.mobileNav div {
+  position: absolute;
+  top: 64px;
+  right: 16px;
+  display: grid;
+  min-width: 220px;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid var(--line-soft);
+  border-radius: 16px;
+  background: var(--paper);
+  box-shadow: 0 22px 50px rgba(20, 32, 31, 0.16);
+}
+
+.mobileNav a {
+  padding: 12px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.mobileNav a:hover {
+  background: var(--bone);
+}
+
+.hero {
+  position: relative;
+  min-height: 848px;
+  height: 848px;
+  margin-top: -66px;
+  overflow: visible;
+  background: var(--ink);
+  color: #f8f4ea;
+}
+
+.heroImage,
+.heroOverlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.heroImage {
+  object-fit: cover;
+  opacity: 0.55;
+}
+
+.heroOverlay {
+  background:
+    linear-gradient(180deg, rgba(20, 32, 31, 0.55) 0%, rgba(20, 32, 31, 0.4) 30%, rgba(20, 32, 31, 0.95) 100%),
+    radial-gradient(at 80% 20%, rgba(217, 106, 78, 0.18), transparent 50%);
+}
+
+.heroGrid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 796px) 460px;
+  gap: 56px;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 145px 64px 112px;
+}
+
+.heroCopy {
+  max-width: 796px;
+}
+
+.livePill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border: 1px solid rgba(248, 244, 234, 0.22);
+  border-radius: 999px;
+  background: rgba(248, 244, 234, 0.06);
+  color: rgba(248, 244, 234, 0.86);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  line-height: 1.5;
+}
+
+.livePill::before {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--coral);
+  content: "";
+}
+
+.hero h1,
+.plainHero h1,
+.contactHero h1,
+.detailHero h1 {
+  margin: 26px 0 0;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+.hero h1 {
+  max-width: 796px;
+  color: #f8f4ea;
+  font-size: 86.4px;
+  line-height: 0.98;
+}
+
+.hero h1 em {
+  color: var(--champagne);
+  font-style: italic;
+}
+
+.heroCopy p {
+  max-width: 540px;
+  margin: 24px 0 0;
+  color: rgba(248, 244, 234, 0.78);
+  font-size: 17px;
+  line-height: 1.55;
+}
+
+.heroButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 36px;
+}
+
+.primaryHero,
+.secondaryHero,
+.secondaryDark,
+.primaryLight {
+  min-height: 52px;
+  padding: 0 28px;
+  font-size: 15px;
+}
+
+.secondaryHero {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(248, 244, 234, 0.3);
+  border-radius: 999px;
+  background: rgba(248, 244, 234, 0.08);
+  color: #f8f4ea !important;
+  font-weight: 500;
+}
+
+.secondaryDark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.heroStats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 40px;
+  max-width: 796px;
+  min-height: 82px;
+  margin: 56px 0 0;
+  padding-top: 28px;
+  border-top: 1px solid rgba(248, 244, 234, 0.14);
+}
+
+.heroStats div {
+  padding: 0;
+  background: transparent;
+}
+
+.heroStats dt {
+  color: #fff;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 32px;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.heroStats dd {
+  margin: 4px 0 0;
+  color: rgba(248, 244, 234, 0.55);
+  font-size: 11.5px;
+}
+
+.leadCard {
+  position: relative;
+  align-self: start;
+  margin-top: 88px;
+  padding: 26px;
+  border: 1px solid rgba(248, 244, 234, 0.16);
+  border-radius: 16px;
+  background: rgba(20, 32, 31, 0.55);
+  color: #f8f4ea;
+  box-shadow: 0 24px 60px -20px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(20px);
+}
+
+.mono {
+  color: var(--champagne);
+  font-family: var(--font-mono), "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.leadCard h3,
+.advisorPanel h3,
+.shortlistPreview h3,
+.finalCta h3,
+.infoCard h3,
+.breakdown h3,
+.chartPanel h3 {
+  margin: 10px 0 0;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 34px;
+  font-weight: 400;
+  line-height: 1.05;
+  letter-spacing: 0;
+}
+
+.leadCard h3 {
+  color: #f8f4ea;
+  font-size: 24px;
+  line-height: 36px;
+}
+
+.leadCard p {
+  position: absolute;
+  top: 58px;
+  right: 26px;
+  display: flex;
+  justify-content: space-between;
+  width: auto;
+  margin: 0;
+  color: rgba(248, 244, 234, 0.68);
+  font-size: 11px;
+  line-height: 16.5px;
+}
+
+.leadCard p span {
+  color: #22c55e;
+}
+
+.leadCard input,
+.leadCard select {
+  width: 100%;
+  height: 46px;
+  margin-top: 8px;
+  padding: 0 16px;
+  border: 1px solid rgba(248, 244, 234, 0.18);
+  border-radius: 11px;
+  background: rgba(248, 244, 234, 0.1);
+  color: #f8f4ea;
+  outline: 0;
+}
+
+.leadCard input::placeholder {
+  color: rgba(248, 244, 234, 0.55);
+}
+
+.leadFields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.chipGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chipGrid span {
+  padding: 9px 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--paper);
+  color: var(--ink-3);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.chipGrid .selectedChip {
+  border-color: var(--teal);
+  background: var(--teal-pale);
+  color: var(--teal);
+}
+
+.leadCard small {
+  display: block;
+  margin-top: 14px;
+  color: rgba(248, 244, 234, 0.74);
+  font-size: 13px;
+}
+
+.fullCoral,
+.fullTeal {
+  width: 100%;
+  min-height: 52px;
+  margin-top: 14px;
+  font-size: 15px;
+}
+
+.leadCard .fullCoral {
+  min-height: 48px;
+}
+
+.fullTeal {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--teal);
+  color: #fff !important;
+  font-weight: 800;
+}
+
+.leadCard em {
+  display: block;
+  margin-top: 9px;
+  color: rgba(248, 244, 234, 0.45);
+  font-size: 12px;
+  font-style: normal;
+  text-align: center;
+}
+
+.searchPanel {
+  position: absolute;
+  z-index: 2;
+  right: 40px;
+  bottom: 0;
+  left: 40px;
+  max-width: 1360px;
+  margin: 0 auto;
+  padding: 14px;
+  transform: translateY(68%);
+  border: 1px solid var(--line-soft);
+  border-radius: 22px;
+  background: var(--paper);
+  box-shadow: 0 24px 70px rgba(20, 32, 31, 0.14);
+}
+
+.searchTabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 12px;
+  padding: 0 0 0 6px;
+}
+
+.searchTabs a {
+  padding: 5px 14px;
+  border-radius: 999px;
+  color: var(--ink-3);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.searchTabs .tabActive {
+  background: var(--teal);
+  color: #fff;
+}
+
+.searchFields {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr)) auto;
+  gap: 1px;
+  padding: 0;
+}
+
+.searchFields a {
+  display: grid;
+  height: 56.75px;
+  min-height: 0;
+  padding: 7px 18px;
+  border-left: 1px solid var(--line-soft);
+}
+
+.searchFields a:first-child {
+  border-left: 0;
+}
+
+.searchFields span {
+  color: var(--ink-4);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.searchFields strong {
+  color: var(--ink);
+  font-size: 15px;
+}
+
+.searchButton {
+  align-items: center;
+  justify-content: center;
+  min-width: 150px;
+  border-radius: 16px;
+  background: var(--coral);
+  color: #fff !important;
+  font-weight: 500;
+}
+
+.section,
+.trustSection,
+.faqSection,
+.listingPage,
+.plainHero,
+.areaGuideLayout,
+.calculatorGrid,
+.compareTable,
+.detailBody {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding-right: 40px;
+  padding-left: 40px;
+}
+
+.section {
+  padding-top: 132px;
+  padding-bottom: 80px;
+}
+
+.sectionIntro {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 30px;
+  margin-bottom: 42px;
+}
+
+.sectionIntro div {
+  max-width: 760px;
+}
+
+.sectionIntro h2,
+.darkBand h2,
+.finderCopy h2,
+.faqSection h2,
+.detailBody h2,
+.messageForm h2 {
+  margin: 10px 0 0;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 58px;
+  font-weight: 400;
+  line-height: 1.02;
+  letter-spacing: 0;
+}
+
+.sectionIntro h2 em {
+  color: var(--coral);
+  font-style: italic;
+}
+
+.sectionIntro p,
+.darkBand p,
+.finderCopy p,
+.plainHero p,
+.detailHero p,
+.contactHero p,
+.messageForm p {
+  margin: 14px 0 0;
+  color: var(--ink-3);
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.outlineAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0 18px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--paper);
+  color: var(--ink) !important;
+  font-size: 14px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.projectGridThree,
+.listingGrid {
+  display: grid;
+  min-width: 0;
+  gap: 20px;
+}
+
+.projectGridThree {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.projectCard,
+.projectCardCompact,
+.areaCard,
+.advisorPanel,
+.shortlistPreview,
+.infoCard,
+.calcPanel,
+.compareTable,
+.messageForm,
+.contactSide > *,
+.detailColumns > * {
+  border: 1px solid var(--line-soft);
+  border-radius: 16px;
+  background: var(--paper);
+}
+
+.projectCard,
+.projectCardCompact {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--ink);
+}
+
+.imageFrame {
+  position: relative;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+}
+
+.imageFrame img,
+.areaCard img,
+.areaHeroImage img,
+.projectMini img,
+.matchCard img,
+.compareCards img,
+.detailHero img,
+.galleryGrid img,
+.contactHero img {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  object-fit: cover;
+}
+
+.imageAction {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  background: rgba(248, 244, 234, 0.9);
+  color: var(--ink);
+}
+
+.cardBody {
+  display: grid;
+  gap: 10px;
+  padding: 18px 20px 20px;
+}
+
+.cardMeta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--coral);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.cardMeta em {
+  color: var(--ink-3);
+  font-style: normal;
+}
+
+.cardBody h3 {
+  margin: 0;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 28px;
+  font-weight: 400;
+  line-height: 1.06;
+}
+
+.cardBody small {
+  color: var(--ink-4);
+  font-size: 13px;
+}
+
+.cardStats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+}
+
+.cardStats span {
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+  background: var(--bone);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.cardStats b {
+  color: var(--ink-4);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.darkBand {
+  display: grid;
+  grid-template-columns: 0.85fr 1.15fr;
+  gap: 70px;
+  padding: 92px 40px;
+  background: var(--ink);
+  color: #f8f4ea;
+}
+
+.darkBand > * {
+  max-width: 1440px;
+}
+
+.darkBand h2 {
+  max-width: 620px;
+  color: #f8f4ea;
+}
+
+.darkBand p {
+  max-width: 540px;
+  color: rgba(248, 244, 234, 0.72);
+}
+
+.primaryLight {
+  margin-top: 32px;
+  background: #f8f4ea;
+  color: var(--ink) !important;
+}
+
+.thesisGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.thesisGrid article {
+  padding: 24px;
+  border: 1px solid rgba(248, 244, 234, 0.14);
+  border-radius: 16px;
+  background: rgba(248, 244, 234, 0.06);
+}
+
+.thesisGrid span {
+  color: #fff;
+  font-weight: 900;
+}
+
+.thesisGrid small {
+  color: var(--champagne);
+  font-size: 12px;
+}
+
+.areaGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.areaCard {
+  position: relative;
+  min-height: 328px;
+  overflow: hidden;
+  padding: 24px;
+  color: #fff !important;
+}
+
+.areaCard::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(180deg, rgba(20, 32, 31, 0.12), rgba(20, 32, 31, 0.78));
+}
+
+.areaCard img {
+  position: absolute;
+  inset: 0;
+}
+
+.areaCard > span,
+.areaCard small,
+.areaCard h3,
+.areaCard p {
+  position: relative;
+  z-index: 1;
+}
+
+.areaCard span {
+  display: inline-block;
+  color: var(--champagne);
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.areaCard small {
+  float: right;
+  color: rgba(255, 255, 255, 0.74);
+  font-size: 12px;
+}
+
+.areaCard h3 {
+  margin: 190px 0 4px;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 48px;
+  font-weight: 400;
+  line-height: 0.98;
+}
+
+.areaCard p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.74);
+}
+
+.finderBand {
+  display: grid;
+  grid-template-columns: 1.15fr 0.85fr;
+  gap: 60px;
+  padding: 90px 96px;
+  background: #f0e4cf;
+}
+
+.finderCopy h2 {
+  max-width: 760px;
+}
+
+.finderCopy p {
+  max-width: 560px;
+}
+
+.shortlistPreview {
+  max-width: 460px;
+  padding: 28px;
+  box-shadow: 0 18px 60px rgba(20, 32, 31, 0.09);
+}
+
+.matchRow,
+.advisorRow,
+.projectMini,
+.matchCard {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  border-top: 1px solid var(--line-soft);
+}
+
+.matchRow b {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: var(--bone);
+  color: var(--teal);
+}
+
+.matchRow span {
+  flex: 1;
+  font-weight: 800;
+}
+
+.matchRow em,
+.advisorRow em {
+  color: var(--ink-3);
+  font-size: 12px;
+  font-style: normal;
+}
+
+.trustSection {
+  padding-top: 90px;
+  padding-bottom: 70px;
+}
+
+.trustGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(340px, 0.75fr);
+  gap: 34px;
+}
+
+.testimonialGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.testimonialGrid blockquote {
+  margin: 0;
+  padding: 24px;
+  border: 1px solid var(--line-soft);
+  border-radius: 16px;
+  background: var(--paper);
+}
+
+.testimonialGrid p {
+  margin: 0;
+  color: var(--ink-2);
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 24px;
+  line-height: 1.2;
+}
+
+.testimonialGrid cite {
+  display: block;
+  margin-top: 22px;
+  color: var(--ink-4);
+  font-size: 13px;
+  font-style: normal;
+}
+
+.advisorPanel {
+  padding: 28px;
+}
+
+.advisorRow img {
+  width: 44px;
+  height: 44px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  object-fit: cover;
+}
+
+.advisorRow span {
+  display: grid;
+  flex: 1;
+  gap: 3px;
+}
+
+.advisorRow b {
+  font-size: 14px;
+}
+
+.advisorRow small {
+  color: var(--ink-4);
+  font-size: 12px;
+}
+
+.faqSection {
+  padding-top: 30px;
+  padding-bottom: 70px;
+}
+
+.faqList {
+  border-top: 1px solid var(--line-soft);
+}
+
+.faqList details {
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.faqList summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px 0;
+  cursor: pointer;
+  color: var(--ink);
+  font-size: 18px;
+  font-weight: 800;
+  list-style: none;
+}
+
+.faqList summary::-webkit-details-marker {
+  display: none;
+}
+
+.faqList p {
+  max-width: 760px;
+  margin: 0 0 22px;
+  color: var(--ink-3);
+  line-height: 1.6;
+}
+
+.finalCta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 30px;
+  padding: 70px 88px;
+  background: #f0e4cf;
+}
+
+.finalCta h3 {
+  max-width: 720px;
+  font-size: 54px;
+}
+
+.finalActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.finalActions a:not(.coralPill) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 52px;
+  padding: 0 20px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--paper);
+  font-weight: 800;
+}
+
+.footer {
+  background: #10201d;
+  color: rgba(248, 244, 234, 0.82);
+}
+
+.footerGrid {
+  display: grid;
+  grid-template-columns: 1.45fr repeat(4, minmax(0, 1fr));
+  gap: 54px;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 60px 40px 48px;
+}
+
+.footerBrand p,
+.footerColumn p {
+  color: rgba(248, 244, 234, 0.68);
+  font-size: 14px;
+  line-height: 1.62;
+}
+
+.footerColumn {
+  display: grid;
+  align-content: start;
+  gap: 12px;
+}
+
+.footerColumn span {
+  color: rgba(248, 244, 234, 0.5);
+  font-family: var(--font-mono), "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.footerColumn a {
+  color: rgba(248, 244, 234, 0.86);
+  font-size: 14px;
+}
+
+.socials {
+  display: flex;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+.socials a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  background: rgba(248, 244, 234, 0.11);
+}
+
+.footerBottom {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 20px 40px;
+  border-top: 1px solid rgba(248, 244, 234, 0.1);
+  color: rgba(248, 244, 234, 0.54);
+  font-size: 12px;
+}
+
+.listingPage {
+  max-width: none;
+  padding-top: 0;
+  padding-right: 0;
+  padding-bottom: 70px;
+  padding-left: 0;
+}
+
+.listingHeader {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  min-height: 174px;
+  margin-bottom: 0;
+  padding: 32px 40px 20px;
+  background: #fdfaf2;
+}
+
+.listingHeader h1,
+.plainHero h1 {
+  margin: 10px 0 0;
+  font-size: 44px;
+  line-height: 1.05;
+}
+
+.listingHeader h1 em,
+.plainHero h1 em {
+  font-style: italic;
+}
+
+.listingHeader h1 {
+  margin-top: 1px;
+}
+
+.filterToggle {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  margin-top: 18px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--paper);
+  color: var(--ink-2);
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.sortTabs {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sortTabs button,
+.sortTabs select,
+.filterGroup button,
+.resetButton {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--paper);
+  color: var(--ink-3);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.sortTabs button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 38px;
+}
+
+.viewSwitch {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 34px;
+  padding: 4px;
+  border-radius: 999px;
+  background: var(--line-soft);
+}
+
+.viewSwitch button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink-3);
+  font-size: 16px;
+  line-height: 1;
+}
+
+.viewSwitch .viewActive {
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.sortSelect {
+  justify-content: space-between;
+  width: 145px;
+  height: 38px;
+  padding: 0 14px 0 18px;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 400 !important;
+}
+
+.catalogue {
+  display: grid;
+  grid-template-columns: 288px minmax(0, 1fr);
+  gap: 0;
+  max-width: none;
+  border-top: 1px solid var(--line-soft);
+}
+
+.filters {
+  position: sticky;
+  top: 66px;
+  align-self: start;
+  display: grid;
+  gap: 22px;
+  max-height: calc(100vh - 65px);
+  padding: 28px 24px;
+  border: 0;
+  border-right: 1px solid var(--line-soft);
+  border-radius: 0;
+  background: transparent;
+  overflow-y: auto;
+}
+
+.filterGroup {
+  display: grid;
+  gap: 0;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.filterGroup button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  text-align: left;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.filterRow {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 4px;
+  color: var(--ink-3);
+  font-size: 13px;
+}
+
+.filterRow input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--teal);
+}
+
+.filterRow span {
+  min-width: 0;
+}
+
+.filterRow em {
+  color: var(--ink-4);
+  font-style: normal;
+}
+
+.resetButton {
+  justify-self: start;
+  height: 36px;
+  padding: 0 15px;
+  border-color: var(--line-soft) !important;
+  color: var(--ink-2) !important;
+  font-weight: 500 !important;
+}
+
+.priceRange {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 4px 0;
+  color: var(--ink-3);
+  font-size: 12px;
+}
+
+.rangeTrack {
+  position: relative;
+  height: 28px;
+}
+
+.rangeTrack::before {
+  position: absolute;
+  top: 12px;
+  right: 4px;
+  left: 4px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--teal);
+  content: "";
+}
+
+.rangeTrack span {
+  position: absolute;
+  top: 7px;
+  right: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--teal);
+}
+
+.listingGrid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+  padding: 28px 24px;
+}
+
+.projectCardCompact .cardStats {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  position: relative;
+  gap: 12px;
+  margin-top: 10px;
+  border: 0;
+  border-top: 1px solid var(--line);
+  border-radius: 0;
+}
+
+.projectCardCompact .cardStats span {
+  min-height: 43px;
+  padding: 0;
+  background: transparent;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 27px;
+}
+
+.projectCardCompact .cardBody {
+  gap: 8px;
+  padding: 18px 20px 16px;
+}
+
+.projectCardCompact .cardMeta {
+  position: absolute;
+  z-index: 2;
+  top: 20px;
+  right: 20px;
+  left: 20px;
+  color: var(--coral);
+}
+
+.projectCardCompact .cardMeta em {
+  position: absolute;
+  top: 211px;
+  left: -8px;
+  color: #fff;
+}
+
+.projectCardCompact .imageAction {
+  color: var(--coral);
+}
+
+.projectCardCompact .cardStats b {
+  font-family: var(--font-mono), "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9.5px;
+  font-weight: 500;
+  line-height: 14.25px;
+}
+
+.projectCardCompact .cardBody h3 {
+  font-size: 24px;
+  line-height: 1.15;
+}
+
+.compareChip {
+  position: absolute;
+  right: 19px;
+  bottom: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 75px;
+  height: 30px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--ink);
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 18px;
+}
+
+.plainHero {
+  padding-top: 64px;
+  padding-bottom: 48px;
+}
+
+.plainHero p {
+  max-width: 540px;
+  margin-top: 12px;
+  font-size: 15px;
+}
+
+.compareHero {
+  padding-top: 35px;
+  padding-bottom: 24px;
+}
+
+.compareHero > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.compareHero h1 em {
+  font-style: italic;
+}
+
+.compareHero h1 {
+  font-size: 52px;
+  line-height: 1.04;
+}
+
+.compareActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.compareActions button {
+  min-height: 42px;
+  padding: 0 18px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--paper);
+  color: var(--ink);
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.areaGuideLayout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 28px;
+  padding-bottom: 80px;
+}
+
+.areaMenu {
+  display: grid;
+  align-self: start;
+  gap: 0;
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.areaMenu button {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 72px;
+  margin-bottom: 4px;
+  border: 0;
+  border-top: 0;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  padding: 12px 16px;
+  text-align: left;
+}
+
+.areaMenu button:first-child {
+  border-top: 0;
+}
+
+.areaMenuActive {
+  background: var(--ink) !important;
+  color: #f8f4ea !important;
+}
+
+.areaMenuActive small {
+  color: rgba(248, 244, 234, 0.7);
+}
+
+.areaMenu img {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.areaMenu span {
+  display: grid;
+  gap: 3px;
+}
+
+.areaMenu small {
+  color: var(--ink-4);
+}
+
+.areaDetail {
+  display: grid;
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.areaHeroImage {
+  position: relative;
+  min-height: 460px;
+  overflow: hidden;
+  border-radius: 20px;
+  color: #fff;
+  padding: 38px 28px 24px;
+}
+
+.areaHeroImage::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(180deg, transparent 40%, rgba(20, 32, 31, 0.7) 100%);
+}
+
+.areaHeroImage img {
+  position: absolute;
+  inset: 0;
+}
+
+.areaHeroImage span,
+.areaHeroImage h2,
+.areaHeroImage p {
+  position: relative;
+  z-index: 1;
+}
+
+.areaHeroImage span {
+  position: absolute;
+  bottom: 99px;
+  left: 28px;
+  color: var(--champagne);
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.areaHeroImage h2 {
+  position: absolute;
+  bottom: 49px;
+  left: 28px;
+  margin: 0;
+  color: #f8f4ea;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 48px;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.areaHeroImage p {
+  position: absolute;
+  bottom: 25px;
+  left: 28px;
+  max-width: 520px;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.areaCopy {
+  display: grid;
+  grid-template-columns: minmax(0, 708px) 320px;
+  gap: 20px 24px;
+  padding: 28px 0 0;
+}
+
+.areaCopy h3 {
+  grid-column: 1;
+  margin: 0 0 8px;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 32px;
+  font-weight: 400;
+}
+
+.areaCopy > p {
+  grid-column: 1;
+  max-width: 760px;
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.metricGrid,
+.detailStats,
+.resultCards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.areaCopy .metricGrid {
+  grid-column: 1;
+  gap: 14px;
+  margin-top: 4px;
+}
+
+.projectListTitle {
+  grid-column: 1;
+  margin: 8px 0 0;
+  color: var(--ink);
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.areaCopy .metricGrid span {
+  gap: 6px;
+  padding: 16px 18px;
+  border-radius: 12px;
+  background: var(--paper);
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 20px;
+  font-weight: 400;
+}
+
+.areaCopy .metricGrid b {
+  font-family: var(--font-mono), "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.08em;
+}
+
+.metricGrid span,
+.detailStats span,
+.resultCards span {
+  display: grid;
+  gap: 8px;
+  padding: 18px;
+  border: 1px solid var(--line-soft);
+  border-radius: 14px;
+  background: var(--bone);
+  font-size: 22px;
+  font-weight: 800;
+}
+
+.metricGrid b,
+.detailStats b,
+.resultCards b {
+  color: var(--ink-4);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.projectMini {
+  grid-column: 1;
+  gap: 14px;
+  padding: 14px 16px;
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+}
+
+.projectMini img {
+  width: 64px;
+  height: 48px;
+  border-radius: 8px;
+}
+
+.projectMini span {
+  display: grid;
+  flex: 1;
+}
+
+.projectMini small {
+  color: var(--ink-4);
+}
+
+.projectMini em {
+  display: grid;
+  font-style: normal;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 18px;
+  font-weight: 400;
+  text-align: right;
+}
+
+.areaCta {
+  grid-column: 2;
+  grid-row: 1 / span 4;
+  min-height: 283px;
+  padding: 24px;
+  border-radius: 16px;
+  background: var(--ink);
+  color: #f8f4ea;
+}
+
+.areaCta h4 {
+  margin: 0 0 12px;
+  color: #f8f4ea;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 1.1;
+}
+
+.areaCta p {
+  color: rgba(248, 244, 234, 0.72);
+}
+
+.areaCtaLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--champagne);
+  font-size: 12px;
+}
+
+.areaCta .outlineAction {
+  width: 100%;
+  margin-top: 10px;
+  border-color: rgba(248, 244, 234, 0.2);
+  background: transparent;
+  color: #f8f4ea !important;
+}
+
+.calculatorGrid {
+  display: grid;
+  align-items: start;
+  grid-template-columns: 553px minmax(0, 1fr);
+  gap: 32px;
+  padding-top: 10px;
+  padding-bottom: 80px;
+}
+
+.toolHero {
+  padding-top: 40px;
+  padding-bottom: 24px;
+}
+
+.toolHero h1 {
+  font-size: 64px;
+  font-style: normal;
+  line-height: 1.02;
+}
+
+.toolHero h1 em {
+  font-style: italic;
+}
+
+.calcPanel {
+  padding: 28px;
+}
+
+.calcPanel {
+  display: grid;
+  gap: 26px;
+}
+
+.calcNote {
+  display: flex;
+  gap: 8px;
+  margin: 0;
+  padding: 12px;
+  border-radius: 10px;
+  background: #fdfaf2;
+  color: var(--ink-4);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.calcNote svg {
+  flex: 0 0 auto;
+  margin-top: 2px;
+}
+
+.calcGroup {
+  display: grid;
+  gap: 18px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.calcGroup h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.sliderRow {
+  display: grid;
+  gap: 10px;
+}
+
+.sliderRow > span {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.sliderRow em {
+  color: var(--ink-4);
+  font-size: 12px;
+  font-style: normal;
+}
+
+.sliderRow strong {
+  color: var(--ink);
+  font-family: var(--font-mono), "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.sliderTrack {
+  position: relative;
+  display: block;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--line-soft);
+}
+
+.sliderTrack i {
+  position: absolute;
+  top: 1px;
+  bottom: 1px;
+  left: 0;
+  display: block;
+  border-radius: inherit;
+  background: var(--teal);
+}
+
+.sliderTrack i::after {
+  position: absolute;
+  top: 50%;
+  right: -7px;
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: var(--teal);
+  content: "";
+  transform: translateY(-50%);
+}
+
+.calcGroup input,
+.messageForm input,
+.messageForm textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--paper);
+  color: var(--ink);
+  outline: 0;
+}
+
+.calcGroup input {
+  height: 48px;
+  padding: 0 14px;
+  font-weight: 800;
+}
+
+.calcResults {
+  display: grid;
+  gap: 24px;
+  padding: 0;
+}
+
+.resultCards {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 32px;
+  padding: 32px;
+  border-radius: 16px;
+  background: var(--ink);
+}
+
+.resultCards span {
+  display: block;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #f8f4ea;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.resultCards b {
+  display: block;
+  color: rgba(248, 244, 234, 0.6);
+  font-family: var(--font-mono), "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.resultCards strong {
+  display: block;
+  margin-top: 8px;
+  color: #f8f4ea;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 38px;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.resultCards span:first-child strong {
+  color: var(--champagne);
+  font-size: 60px;
+}
+
+.resultCards small {
+  display: block;
+  margin-top: 6px;
+  color: rgba(248, 244, 234, 0.64);
+  font-size: 11px;
+}
+
+.breakdown,
+.chartPanel,
+.reportCta {
+  padding: 28px;
+  border: 1px solid var(--line-soft);
+  border-radius: 16px;
+  background: var(--paper);
+}
+
+.breakdown h3,
+.chartPanel h3 {
+  margin: 0 0 20px;
+  font-size: 24px;
+  line-height: 1.2;
+}
+
+.breakdown div {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 14px;
+  padding: 0 0 13px;
+  border-top: 0;
+  font-size: 13px;
+}
+
+.breakdown div:not(:last-child)::before,
+.breakdown div:not(:last-child)::after {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 6px;
+  border-radius: 999px;
+  content: "";
+}
+
+.breakdown div:not(:last-child)::before {
+  width: 100%;
+  background: var(--line);
+}
+
+.breakdown div:not(:last-child)::after {
+  width: 92.25%;
+  background: var(--ink);
+}
+
+.breakdown div:nth-of-type(2)::after {
+  width: 6.15%;
+  background: var(--coral);
+}
+
+.breakdown div:nth-of-type(3)::after {
+  width: 0.9%;
+  background: var(--champagne);
+}
+
+.breakdown div:nth-of-type(4)::after {
+  width: 0.75%;
+  background: var(--teal);
+}
+
+.breakdown div:last-child {
+  align-items: baseline;
+  margin-bottom: 0;
+  padding-top: 14px;
+  padding-bottom: 0;
+  border-top: 1px solid var(--line-soft);
+}
+
+.breakdown b {
+  font-family: var(--font-mono), "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 500;
+}
+
+.breakdown div:last-child b {
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 24px;
+  font-weight: 400;
+}
+
+.chartBars {
+  display: flex;
+  align-items: end;
+  gap: 10px;
+  height: 180px;
+  margin-top: 20px;
+  padding: 16px;
+  border-radius: 14px;
+  background: var(--paper);
+}
+
+.chartBars span {
+  display: flex;
+  flex: 1;
+  align-items: end;
+  justify-content: center;
+  min-height: 40px;
+  border-radius: 10px 10px 0 0;
+  background: linear-gradient(180deg, var(--coral), var(--champagne));
+  color: #fff;
+  font-size: 12px;
+  font-weight: 900;
+}
+
+.chartPanel strong {
+  display: block;
+  margin-top: 14px;
+  color: var(--teal);
+  font-size: 20px;
+}
+
+.reportCta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.reportCta span {
+  font-weight: 900;
+}
+
+.reportCta p {
+  flex: 1;
+  color: var(--ink-3);
+}
+
+.finderPage {
+  min-height: 100vh;
+  padding: 0;
+  background: var(--bone);
+  color: var(--ink);
+}
+
+.finderTop {
+  display: grid;
+  grid-template-columns: 1fr 400px 1fr;
+  align-items: center;
+  gap: 18px;
+  max-width: none;
+  min-height: 78px;
+  margin: 0 auto;
+  padding: 18px 40px;
+  border-bottom: 1px solid var(--line-soft);
+  background: var(--bone);
+}
+
+.finderTop > span,
+.finderTop a {
+  color: var(--ink-2);
+  font-size: 14px;
+}
+
+.finderTop .logo {
+  grid-column: 1;
+  grid-row: 1;
+  justify-self: start;
+}
+
+.finderTop > span:not(.logo) {
+  align-self: start;
+  justify-self: start;
+  grid-column: 2;
+  grid-row: 1;
+  font-family: var(--font-mono), "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.finderTop > span em {
+  margin-left: auto;
+  font-style: normal;
+}
+
+.finderTop div {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: end;
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--line-soft);
+}
+
+.finderTop b {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--coral);
+}
+
+.finderTop a {
+  justify-self: end;
+  min-width: 68px;
+  padding: 9px 16px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  text-align: center;
+}
+
+.finderGridPage {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(420px, 460px);
+  gap: 0;
+  max-width: none;
+  min-height: calc(100vh - 78px);
+  margin: 0;
+}
+
+.questionPanel,
+.liveMatches {
+  padding: 74px 80px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.liveMatches {
+  padding-right: 40px;
+  padding-left: 40px;
+}
+
+.questionPanel h1 {
+  margin: 14px 0 0;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 57.6px;
+  font-weight: 400;
+  line-height: 1.03;
+}
+
+.questionPanel p {
+  color: var(--ink-3);
+}
+
+.liveMatches {
+  background: var(--ink);
+  color: #f8f4ea;
+}
+
+.liveMatches p {
+  color: rgba(248, 244, 234, 0.68);
+}
+
+.questionPanel button:not(.fullCoral) {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 14px;
+  width: 100%;
+  min-height: 58px;
+  margin-top: 12px;
+  padding: 0 18px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--paper);
+  color: var(--ink);
+  cursor: pointer;
+  text-align: left;
+}
+
+.questionPanel p + button {
+  margin-top: 46px;
+}
+
+.questionPanel button:not(.fullCoral) span {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+  border: 2px solid var(--line);
+  border-radius: 999px;
+}
+
+.optionSelected {
+  border-color: var(--champagne) !important;
+  background: rgba(201, 166, 119, 0.18) !important;
+}
+
+.finderContinue {
+  background: #d8cdb4;
+  color: var(--ink-4) !important;
+}
+
+.liveMatches h2 {
+  margin: 12px 0 0;
+  color: #f8f4ea;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 32px;
+  font-weight: 400;
+  line-height: 1.08;
+}
+
+.matchCard {
+  position: relative;
+  align-items: center;
+  min-height: 96px;
+  margin-top: 12px;
+  padding: 12px 14px;
+  border: 1px solid rgba(248, 244, 234, 0.12);
+  border-radius: 10px;
+  background: rgba(248, 244, 234, 0.06);
+}
+
+.matchCard img {
+  width: 72px;
+  height: 72px;
+  border-radius: 10px;
+}
+
+.matchCard span {
+  display: grid;
+  flex: 1;
+}
+
+.matchCard small {
+  color: rgba(248, 244, 234, 0.5);
+}
+
+.matchCard em {
+  color: var(--champagne);
+  font-style: normal;
+  font-weight: 900;
+}
+
+.matchCard::after {
+  position: absolute;
+  right: 18px;
+  bottom: 14px;
+  left: 96px;
+  height: 4px;
+  border-radius: 999px;
+  background: #7ed8a0;
+  content: "";
+}
+
+.matchHint {
+  margin-top: 28px;
+  padding: 18px 19px;
+  border-radius: 12px;
+  background: rgba(217, 106, 78, 0.08);
+}
+
+.matchHint small {
+  color: var(--coral);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.matchHint p {
+  margin: 8px 0 0;
+  color: rgba(248, 244, 234, 0.68);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.compareTable {
+  max-width: none;
+  margin-bottom: 80px;
+  padding: 0 40px 40px;
+  border-radius: 0;
+  border-right: 0;
+  border-left: 0;
+}
+
+.compareCards {
+  display: grid;
+  grid-template-columns: 200px repeat(3, minmax(0, 1fr));
+  gap: 0;
+  margin-bottom: 0;
+  border: 1px solid var(--line-soft);
+  border-bottom: 0;
+  border-radius: 18px 18px 0 0;
+  overflow: hidden;
+}
+
+.compareCards article {
+  position: relative;
+  overflow: hidden;
+  min-height: 358px;
+  padding: 18px;
+  border-left: 1px solid var(--line-soft);
+  border-radius: 0;
+  background: var(--paper);
+}
+
+.compareCorner {
+  background: var(--bone);
+}
+
+.compareCards img {
+  display: block;
+  height: auto;
+  aspect-ratio: 16 / 10;
+  border-radius: 12px;
+}
+
+.compareCards h3,
+.compareCards p,
+.compareCards a {
+  display: block;
+  margin: 0;
+}
+
+.compareCards h3 {
+  margin-top: 12px;
+  padding-top: 0;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.compareCards p {
+  padding-top: 4px;
+  color: var(--ink-4);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.compareCards article > button {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 1;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--paper);
+  color: var(--ink-3);
+  cursor: pointer;
+}
+
+.compareCards a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  margin-top: 10px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.compareRow {
+  display: grid;
+  grid-template-columns: 200px repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  border-top: 1px solid var(--line-soft);
+  border-right: 1px solid var(--line-soft);
+  border-left: 1px solid var(--line-soft);
+}
+
+.compareRow b,
+.compareRow span {
+  padding: 18px 22px;
+}
+
+.compareRow b {
+  background: var(--bone);
+  color: var(--ink-3);
+  font-size: 13px;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.compareRow span {
+  background: rgba(255, 255, 255, 0.56);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+.compareTable > .fullCoral {
+  max-width: none;
+  border-radius: 0 0 18px 18px;
+}
+
+.contactHero {
+  position: relative;
+  overflow: hidden;
+  min-height: 405px;
+  padding: 80px 40px;
+  background: var(--ink);
+  color: #f8f4ea;
+}
+
+.contactHero img {
+  position: absolute;
+  inset: 0;
+  opacity: 0.2;
+}
+
+.contactHero div {
+  position: relative;
+  z-index: 1;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+.contactHero h1 {
+  max-width: 720px;
+  color: #f8f4ea;
+  font-size: 72px;
+  line-height: 1.02;
+}
+
+.contactHero h1 em {
+  color: var(--champagne);
+  font-style: italic;
+}
+
+.contactHero p {
+  max-width: 560px;
+  color: rgba(248, 244, 234, 0.75);
+}
+
+.contactGrid {
+  display: grid;
+  align-items: start;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 64px 40px 80px;
+}
+
+.messageForm {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.messageForm h2 {
+  margin: 0;
+  font-size: 40px;
+}
+
+.messageForm > div:not(.channelPills) {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.messageForm input {
+  height: 50px;
+  padding: 0 16px;
+}
+
+.messageForm textarea {
+  min-height: 140px;
+  padding: 14px 16px;
+  resize: vertical;
+}
+
+.messageForm > span {
+  margin-top: 4px;
+  color: var(--ink-3);
+  font-size: 13px;
+}
+
+.channelPills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.channelPills button {
+  height: 36px;
+  padding: 0 14px;
+  border: 1.5px solid var(--line);
+  border-radius: 999px;
+  background: var(--paper);
+  color: var(--ink-3);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.channelActive {
+  border-color: var(--teal) !important;
+  background: var(--teal-pale) !important;
+  color: var(--teal) !important;
+}
+
+.contactSide {
+  display: grid;
+  gap: 20px;
+}
+
+.infoCard,
+.contactAdvisorCard {
+  padding: 28px;
+}
+
+.infoCard p {
+  color: var(--ink-2);
+  font-size: 14px;
+}
+
+.contactAdvisorCard h3 {
+  margin: 0 0 18px;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 24px;
+  font-weight: 400;
+}
+
+.infoCard div {
+  display: flex;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.infoCard a {
+  display: inline-flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border-radius: 999px;
+  background: #25d366;
+  color: #fff !important;
+  font-weight: 900;
+}
+
+.infoCard a:last-child {
+  background: #06c755;
+}
+
+.detailHero {
+  position: relative;
+  display: grid;
+  min-height: 620px;
+  color: #f8f4ea;
+  overflow: hidden;
+}
+
+.detailHero img {
+  position: absolute;
+  inset: 0;
+}
+
+.detailHero::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(90deg, rgba(7, 18, 18, 0.82), rgba(7, 18, 18, 0.24));
+}
+
+.detailHero div {
+  position: relative;
+  z-index: 1;
+  align-self: end;
+  max-width: 760px;
+  padding: 120px 64px 90px;
+}
+
+.detailHero h1 {
+  font-size: 78px;
+  line-height: 0.98;
+}
+
+.detailHero p {
+  color: rgba(248, 244, 234, 0.76);
+}
+
+.detailBody {
+  padding-top: 60px;
+  padding-bottom: 80px;
+}
+
+.detailStats {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.galleryGrid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  grid-auto-rows: 210px;
+  gap: 14px;
+  margin-top: 30px;
+}
+
+.galleryGrid img {
+  border-radius: 16px;
+}
+
+.galleryGrid img:first-child {
+  grid-row: span 2;
+}
+
+.detailColumns {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 390px;
+  gap: 28px;
+  margin-top: 30px;
+}
+
+.detailColumns > article {
+  padding: 30px;
+}
+
+.detailColumns p {
+  color: var(--ink-3);
+  line-height: 1.65;
+}
+
+@media (max-width: 1120px) {
+  .headerInner {
+    padding: 14px 24px;
+  }
+
+  .nav,
+  .headerActions {
+    display: none;
+  }
+
+  .mobileNav {
+    display: block;
+  }
+
+  .heroGrid,
+  .trustGrid,
+  .contactGrid,
+  .calculatorGrid,
+  .finderGridPage,
+  .detailColumns {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    height: auto;
+    min-height: auto;
+  }
+
+  .heroGrid {
+    gap: 30px;
+    padding: 156px 36px 36px;
+  }
+
+  .hero h1 {
+    font-size: 76px;
+  }
+
+  .sectionIntro h2,
+  .darkBand h2,
+  .finderCopy h2,
+  .faqSection h2,
+  .detailBody h2,
+  .messageForm h2,
+  .finalCta h3 {
+    font-size: 52px;
+  }
+
+  .listingHeader h1,
+  .plainHero h1,
+  .questionPanel h1,
+  .contactHero h1,
+  .detailHero h1 {
+    font-size: 62px;
+  }
+
+  .leadCard {
+    max-width: 560px;
+    margin-top: 0;
+  }
+
+  .searchPanel {
+    position: relative;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    margin: 0 36px 48px;
+    transform: none;
+  }
+
+  .searchFields {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .searchButton {
+    min-height: 64px;
+  }
+
+  .projectGridThree,
+  .listingGrid,
+  .areaGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .darkBand,
+  .finderBand,
+  .areaGuideLayout,
+  .catalogue {
+    grid-template-columns: 1fr;
+  }
+
+  .areaCopy {
+    grid-template-columns: 1fr;
+  }
+
+  .areaCopy h3,
+  .areaCopy > p,
+  .areaCopy .metricGrid,
+  .projectListTitle,
+  .projectMini,
+  .areaCta {
+    grid-column: 1;
+  }
+
+  .filters {
+    position: static;
+  }
+
+  .footerGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .headerInner {
+    min-height: 62px;
+    padding: 12px 16px;
+  }
+
+  .logo span {
+    font-size: 19px;
+  }
+
+  .hero {
+    min-height: auto;
+    margin-top: -62px;
+  }
+
+  .heroGrid {
+    padding: 132px 20px 30px;
+  }
+
+  .hero h1 {
+    font-size: 52px;
+    line-height: 0.96;
+  }
+
+  .sectionIntro h2,
+  .darkBand h2,
+  .finderCopy h2,
+  .faqSection h2,
+  .detailBody h2,
+  .messageForm h2,
+  .finalCta h3 {
+    font-size: 40px;
+  }
+
+  .listingHeader h1,
+  .plainHero h1,
+  .questionPanel h1,
+  .contactHero h1,
+  .detailHero h1 {
+    font-size: 46px;
+  }
+
+  .heroCopy p {
+    font-size: 15px;
+  }
+
+  .heroStats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .searchPanel {
+    position: relative;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    margin: 0 20px 24px;
+    transform: none;
+  }
+
+  .searchFields {
+    grid-template-columns: 1fr;
+  }
+
+  .searchFields a {
+    border-top: 1px solid var(--line-soft);
+    border-left: 0;
+  }
+
+  .section,
+  .trustSection,
+  .faqSection,
+  .listingPage,
+  .plainHero,
+  .areaGuideLayout,
+  .calculatorGrid,
+  .compareTable,
+  .detailBody {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .section {
+    padding-top: 70px;
+  }
+
+  .sectionIntro,
+  .listingHeader,
+  .finalCta,
+  .reportCta,
+  .footerBottom {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .projectGridThree,
+  .listingGrid,
+  .areaGrid,
+  .testimonialGrid,
+  .metricGrid,
+  .detailStats,
+  .resultCards,
+  .compareCards {
+    grid-template-columns: 1fr;
+  }
+
+  .cardStats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .darkBand,
+  .finderBand,
+  .finalCta {
+    padding: 64px 20px;
+  }
+
+  .areaCard h3 {
+    font-size: 38px;
+  }
+
+  .areaMenu {
+    grid-template-columns: 1fr;
+  }
+
+  .areaHeroImage {
+    min-height: 360px;
+    padding: 24px;
+  }
+
+  .areaHeroImage h2 {
+    font-size: 42px;
+  }
+
+  .areaCopy {
+    grid-template-columns: 1fr;
+    padding-top: 24px;
+  }
+
+  .areaCopy h3,
+  .areaCopy > p,
+  .areaCopy .metricGrid,
+  .projectMini,
+  .areaCta {
+    grid-column: 1;
+  }
+
+  .areaCta {
+    grid-row: auto;
+  }
+
+  .contactHero,
+  .contactGrid,
+  .finderPage {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .messageForm > div:not(.channelPills) {
+    grid-template-columns: 1fr;
+  }
+
+  .compareRow {
+    grid-template-columns: 1fr;
+  }
+
+  .compareCorner {
+    display: none;
+  }
+
+  .compareRow b {
+    background: var(--paper);
+  }
+
+  .galleryGrid {
+    grid-template-columns: 1fr;
+    grid-auto-rows: 220px;
+  }
+
+  .galleryGrid img:first-child {
+    grid-row: span 1;
+  }
+
+  .detailHero div {
+    padding: 110px 20px 54px;
+  }
+
+  .finderTop {
+    grid-template-columns: 1fr auto;
+  }
+
+  .finderTop div {
+    grid-column: 1 / -1;
+  }
+
+  .footerGrid {
+    grid-template-columns: 1fr;
+    padding: 48px 20px 38px;
+  }
+}

--- a/admin-app/app/(site)/[locale]/v3-preview/v3-preview.module.css
+++ b/admin-app/app/(site)/[locale]/v3-preview/v3-preview.module.css
@@ -1,22 +1,47 @@
 .page {
   --bone: #f8f4ea;
+  --sand: #efe6d2;
+  --sand-soft: #f3ead9;
+  --sand-200: #e4d6b7;
   --paper: #fff;
+  --paper-warm: #fdfaf2;
   --ink: #14201f;
   --ink-2: #2a3736;
   --ink-3: #5b6764;
   --ink-4: #8a938f;
+  --ink-5: #b6b8b1;
   --line: #d8cdb4;
   --line-soft: #e7ddc4;
-  --coral: #d96a4e;
   --teal: #0e3a3a;
+  --teal-2: #1a5854;
+  --teal-3: #2c7a73;
   --teal-pale: #d9e4e0;
+  --coral: #d96a4e;
+  --coral-2: #c4533a;
+  --coral-pale: #fae0d4;
   --champagne: #c9a677;
+  --champagne-2: #a88656;
+  --champagne-pale: #f0e3cc;
+
+  --r-xs: 4px;
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 16px;
+  --r-xl: 22px;
+  --r-2xl: 28px;
+  --r-pill: 999px;
+
+  --shadow-sm: 0 1px 2px rgba(20,32,31,.06), 0 1px 1px rgba(20,32,31,.04);
+  --shadow-md: 0 6px 18px -8px rgba(20,32,31,.18), 0 2px 6px rgba(20,32,31,.06);
+  --shadow-lg: 0 24px 48px -20px rgba(20,32,31,.25), 0 8px 18px -10px rgba(20,32,31,.08);
+  --shadow-card: 0 1px 2px rgba(20,32,31,.04), 0 4px 12px -4px rgba(20,32,31,.06);
+
   min-height: 100vh;
   width: 100%;
   overflow-x: hidden;
   background: var(--bone);
   color: var(--ink);
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: var(--font-sans), ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .page *,
@@ -192,6 +217,71 @@
   padding: 0 14px;
   font-size: 13px;
 }
+
+/* ─── Buttons ─── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 44px;
+  padding: 0 20px;
+  border-radius: var(--r-pill);
+  border: 1px solid transparent;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  transition: all .15s ease;
+  white-space: nowrap;
+  text-decoration: none;
+  font-family: var(--font-sans), sans-serif;
+}
+.btn-sm { height: 36px; padding: 0 14px; font-size: 13px; }
+.btn-lg { height: 52px; padding: 0 28px; font-size: 15px; }
+.btn-xl { height: 60px; padding: 0 32px; font-size: 16px; }
+
+.btn-primary { background: var(--ink); color: var(--bone); }
+.btn-primary:hover { background: var(--teal); }
+
+.btn-coral { background: var(--coral); color: #fff !important; }
+.btn-coral:hover { background: var(--coral-2); }
+
+.btn-teal { background: var(--teal); color: var(--bone); }
+.btn-teal:hover { background: var(--teal-2); }
+
+.btn-ghost { background: transparent; color: var(--ink); border: 1px solid var(--line); }
+.btn-ghost:hover { background: var(--paper); border-color: var(--ink-3); }
+
+.btn-paper { background: var(--paper); color: var(--ink); border: 1px solid var(--line); }
+.btn-paper:hover { background: var(--paper-warm); }
+
+.btn-quiet { background: transparent; color: var(--ink); }
+.btn-quiet:hover { background: rgba(20,32,31,.06); }
+
+.btn-block { width: 100%; }
+
+/* ─── Tags / Badges ─── */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  padding: 0 10px;
+  border-radius: var(--r-pill);
+  font-size: 11.5px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  background: var(--sand);
+  color: var(--ink-2);
+  border: none;
+}
+.tag-sm { height: 20px; padding: 0 8px; font-size: 10.5px; }
+.tag-coral { background: var(--coral-pale); color: var(--coral-2); }
+.tag-champagne { background: var(--champagne-pale); color: var(--champagne-2); }
+.tag-teal { background: var(--teal-pale); color: var(--teal); }
+.tag-dark { background: var(--ink); color: var(--bone); }
+.tag-paper { background: var(--paper); color: var(--ink); border: 1px solid var(--line); }
 
 .mobileNav {
   display: none;
@@ -1348,7 +1438,7 @@
 
 .catalogue {
   display: grid;
-  grid-template-columns: 288px minmax(0, 1fr);
+  grid-template-columns: 260px 1fr 420px;
   gap: 0;
   max-width: none;
   border-top: 1px solid var(--line-soft);
@@ -1459,7 +1549,8 @@
 }
 
 .listingGrid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 20px;
   padding: 28px 24px;
 }
@@ -2793,11 +2884,14 @@
   gap: 6px;
 }
 
-.galleryDots span {
+.galleryDots span,
+.galleryDots button {
   width: 7px;
   height: 7px;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.45);
+  border: 0;
+  padding: 0;
 }
 
 .galleryDots .galleryDotActive {
@@ -2938,7 +3032,13 @@
 }
 
 .galleryGrid {
-  display: none;
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  grid-template-rows: 260px 260px;
+  gap: 8px;
+  border-radius: 16px;
+  overflow: hidden;
+  margin-top: 22px;
 }
 
 .detailColumns {
@@ -3328,5 +3428,697 @@
   .footerGrid {
     grid-template-columns: 1fr;
     padding: 48px 20px 38px;
+  }
+}
+
+/* ─── Trust Bar ─── */
+.trustBar {
+  background: var(--sand-soft);
+  color: var(--ink);
+  padding: 32px 40px;
+  border-top: 1px solid var(--line-soft);
+  border-bottom: 1px solid var(--line-soft);
+}
+.trustBarInner {
+  max-width: 1440px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px 24px;
+}
+.trustBarItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ink-2);
+}
+.trustBarBullet {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--coral);
+  display: inline-block;
+}
+
+/* ─── Foreign Quota Status ─── */
+.quotaSection {
+  background: var(--paper-warm);
+  border-top: 1px solid var(--line-soft);
+  border-bottom: 1px solid var(--line-soft);
+  padding: 88px 40px;
+}
+.quotaGrid {
+  max-width: 1440px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 56px;
+  align-items: center;
+}
+.quotaGrid h2 {
+  margin: 14px 0 0;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 44px;
+  font-weight: 400;
+  line-height: 1.08;
+  color: var(--ink);
+}
+.quotaGrid h2 em {
+  color: var(--coral);
+  font-style: italic;
+}
+.quotaGrid p {
+  margin: 20px 0 0;
+  font-size: 15px;
+  color: var(--ink-3);
+  line-height: 1.6;
+}
+.quotaCard {
+  background: var(--paper);
+  border-radius: 16px;
+  padding: 28px;
+  border: 1px solid var(--line-soft);
+  box-shadow: var(--shadow-card);
+}
+.quotaCard h4 {
+  margin: 0 0 18px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.quotaList {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.quotaItem {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.quotaItem > div {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: var(--ink-2);
+}
+.quotaItem .mono {
+  font-family: var(--font-mono), monospace;
+  font-size: 12px;
+  color: var(--ink-3);
+}
+.progressTrack {
+  height: 4px;
+  background: var(--line-soft);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.progressBar {
+  height: 100%;
+  background: var(--line);
+  border-radius: 999px;
+}
+
+/* ─── Contact Page Updates ─── */
+.channelGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-top: 40px;
+}
+.channelCard {
+  padding: 22px;
+  background: var(--paper);
+  border-radius: 14px;
+  border: 1px solid var(--line-soft);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  cursor: pointer;
+  box-shadow: var(--shadow-card);
+  transition: all .2s;
+}
+.channelCard:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+.channelCardIcon {
+  width: 46px;
+  height: 46px;
+  border-radius: 12px;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.channelCardText div:first-child {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ink);
+}
+.channelCardText div:last-child {
+  font-size: 12px;
+  color: var(--ink-4);
+  margin-top: 2px;
+}
+.officeBox {
+  margin-top: 40px;
+  padding: 24px;
+  background: var(--sand-soft);
+  border-radius: 14px;
+  border: 1px solid var(--line-soft);
+}
+.officeBox h3 {
+  margin: 8px 0 0;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 28px;
+  font-weight: 400;
+  line-height: 1.1;
+  color: var(--ink);
+}
+.officeBox p {
+  margin: 8px 0 0;
+  font-size: 13.5px;
+  color: var(--ink-3);
+  line-height: 1.5;
+}
+.teamSection {
+  padding: 80px 40px;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+.teamGrid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 16px;
+  margin-top: 28px;
+}
+.teamCard {
+  padding: 22px;
+  background: var(--paper);
+  border-radius: 14px;
+  border: 1px solid var(--line-soft);
+  text-align: center;
+  box-shadow: var(--shadow-card);
+  transition: all .2s;
+}
+.teamCard:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+.teamCardAvatar {
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin: 0 auto 14px;
+}
+.teamCard h4 {
+  margin: 0;
+  font-family: var(--font-serif), "Instrument Serif", Georgia, serif;
+  font-size: 22px;
+  font-weight: 400;
+  color: var(--ink);
+}
+.teamCardRole {
+  font-size: 12px;
+  color: var(--ink-4);
+  margin-top: 4px;
+}
+.teamCardMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--ink-3);
+}
+.teamCardLanguages {
+  margin-top: 10px;
+  font-size: 11px;
+  color: var(--ink-4);
+}
+
+@media (max-width: 1120px) {
+  .quotaGrid {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+  .quotaSection {
+    padding: 64px 20px;
+  }
+  .teamGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .teamSection {
+    padding: 64px 20px;
+  }
+  .channelGrid {
+    grid-template-columns: 1fr;
+  }
+}
+@media (max-width: 600px) {
+  .teamGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ─── V3 Round 2 Parity Styles ─── */
+
+.breadcrumbs {
+  font-size: 13px;
+  color: var(--ink-3);
+  margin-bottom: 16px;
+}
+.breadcrumbs a {
+  color: var(--ink-3);
+  text-decoration: none;
+}
+.breadcrumbs a:hover {
+  color: var(--teal);
+  text-decoration: underline;
+}
+.activeBreadcrumb {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.galleryGrid img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.galleryGrid img:first-child {
+  grid-row: span 2;
+}
+@media (max-width: 760px) {
+  .galleryGrid {
+    grid-template-columns: 1fr !important;
+    grid-template-rows: auto !important;
+    height: auto !important;
+  }
+  .galleryGrid img:first-child {
+    grid-row: auto !important;
+  }
+}
+
+.tabRail {
+  display: flex;
+  gap: 8px;
+  border-bottom: 1px solid var(--line-soft);
+  padding-bottom: 0px;
+  margin-bottom: 24px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.tabRailActive {
+  border: 0;
+  background: transparent;
+  border-bottom: 3px solid var(--teal);
+  color: var(--teal);
+  font-weight: 700;
+  padding: 10px 16px;
+  cursor: pointer;
+  font-size: 14px;
+}
+.tabRailInactive {
+  border: 0;
+  background: transparent;
+  color: var(--ink-4);
+  padding: 10px 16px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: color 0.15s ease;
+}
+.tabRailInactive:hover {
+  color: var(--ink-2);
+}
+.tabContent {
+  background: var(--paper-warm);
+  border-radius: 12px;
+  padding: 24px;
+  border: 1px solid var(--line-soft);
+}
+
+.unitTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 16px;
+  font-size: 14px;
+}
+.unitTable th,
+.unitTable td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid var(--line-soft);
+}
+.unitTable th {
+  font-weight: 600;
+  color: var(--ink-2);
+  background: var(--sand-soft);
+}
+.unitTable td {
+  color: var(--ink);
+}
+
+.detailSidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: sticky;
+  top: 84px;
+  height: fit-content;
+}
+@media (max-width: 1120px) {
+  .detailSidebar {
+    position: static;
+  }
+}
+.advisorSidebarCard {
+  padding: 24px;
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  background: var(--paper);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--shadow-card);
+}
+.advisorDetailHeader {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.advisorAvatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+.advisorSidebarCard h4 {
+  margin: 0 0 2px;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--ink);
+}
+.advisorSidebarCard small {
+  color: var(--ink-4);
+  font-size: 12px;
+  display: block;
+}
+.advisorRating {
+  font-size: 11.5px;
+  color: var(--champagne-2);
+  font-weight: 600;
+  margin-top: 3px;
+}
+.advisorActions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.propertySpecs {
+  background: var(--paper);
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: var(--shadow-card);
+}
+.propertySpecs h3 {
+  margin: 0 0 16px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--ink);
+}
+.specsGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.specsGrid span {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13.5px;
+  color: var(--ink-2);
+  border-bottom: 1px solid var(--line-soft);
+  padding-bottom: 8px;
+}
+.specsGrid span:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+.specsGrid b {
+  color: var(--ink-3);
+  font-weight: 500;
+}
+.floorplanTeaser {
+  background: var(--paper);
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: var(--shadow-card);
+  text-align: center;
+}
+.floorplanTeaser h4 {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ink);
+}
+.floorplanSvg {
+  width: 100%;
+  max-width: 220px;
+  height: auto;
+  margin: 0 auto 12px;
+  background: var(--bone);
+  border-radius: 8px;
+  padding: 8px;
+}
+.floorplanTeaser small {
+  font-size: 11px;
+  color: var(--ink-4);
+  display: block;
+}
+.propertyActions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.investmentBlock {
+  background: var(--paper-warm);
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  padding: 24px;
+  margin-top: 24px;
+}
+.investmentBlock h3 {
+  margin: 0 0 8px;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--ink);
+}
+.investmentBlock p {
+  margin: 0 0 20px;
+  font-size: 13.5px;
+  color: var(--ink-3);
+}
+.investmentGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.investmentGrid div {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px;
+  background: var(--paper);
+  border-radius: 8px;
+  border: 1px solid var(--line-soft);
+  text-align: center;
+}
+.investmentGrid span {
+  font-size: 11px;
+  color: var(--ink-4);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.investmentGrid strong {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ink);
+}
+.costBlock {
+  margin-top: 32px;
+}
+.costBlock h3 {
+  margin: 0 0 8px;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--ink);
+}
+.costBlock p {
+  margin: 0 0 16px;
+  font-size: 13.5px;
+  color: var(--ink-3);
+}
+
+.budgetSliderContainer {
+  margin: 32px 0;
+  padding: 24px;
+  background: var(--paper-warm);
+  border-radius: 14px;
+  border: 1px solid var(--line-soft);
+}
+.budgetValueRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.budgetValueRow span {
+  font-size: 14px;
+  color: var(--ink-3);
+}
+.budgetValueRow strong {
+  font-size: 24px;
+  font-family: var(--font-serif), serif;
+  color: var(--teal);
+}
+.usdConversionRow {
+  font-size: 13px;
+  color: var(--ink-4);
+  margin-bottom: 20px;
+}
+.rangeInput {
+  width: 100%;
+  height: 6px;
+  background: var(--line-soft);
+  border-radius: 999px;
+  outline: none;
+  accent-color: var(--teal);
+  cursor: pointer;
+}
+.sliderMinMax {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--ink-4);
+  margin-top: 8px;
+}
+.previousAnswers {
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+.previousAnswers span.mono {
+  font-size: 11px;
+  color: var(--ink-4);
+  display: block;
+  margin-bottom: 8px;
+}
+.answerTags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.mapSidebar {
+  position: sticky;
+  top: 66px;
+  align-self: start;
+  height: calc(100vh - 66px);
+  padding: 16px;
+  border-left: 1px solid var(--line-soft);
+  background: var(--paper-warm);
+}
+.mapPanel {
+  position: relative;
+  background: var(--paper);
+  border: 1.5px solid var(--line-soft);
+  border-radius: 16px;
+  height: 100%;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+.mapSvg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.mapPin {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  background: var(--paper);
+  border: 1.5px solid var(--teal);
+  color: var(--teal);
+  border-radius: 20px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+  z-index: 10;
+}
+.mapPin:hover,
+.mapPinActive {
+  background: var(--teal) !important;
+  color: var(--bone) !important;
+  border-color: var(--teal) !important;
+  transform: translate(-50%, -50%) scale(1.08);
+  box-shadow: var(--shadow-md);
+  z-index: 20;
+}
+.mapPin small {
+  display: none;
+  font-size: 9px;
+  font-weight: 500;
+  margin-top: 2px;
+  opacity: 0.8;
+}
+.mapPin:hover small,
+.mapPinActive small {
+  display: block;
+}
+.cardHoverWrapper {
+  transition: all 0.2s ease;
+  border-radius: 8px;
+  border: 1.5px solid transparent;
+}
+.cardHoverActive {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+  border-color: var(--teal);
+}
+
+@media (max-width: 1120px) {
+  .catalogue {
+    grid-template-columns: 1fr !important;
+  }
+  .mapSidebar {
+    display: none !important;
+  }
+  .listingGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+}
+@media (max-width: 760px) {
+  .listingGrid {
+    grid-template-columns: 1fr !important;
   }
 }

--- a/admin-app/components/layout/Header.tsx
+++ b/admin-app/components/layout/Header.tsx
@@ -166,6 +166,15 @@ function isV2PreviewPath(pathname: string): boolean {
   return normalizePathForSurface(pathname) === '/v2-preview';
 }
 
+function isV3PreviewPath(pathname: string): boolean {
+  const normalized = normalizePathForSurface(pathname);
+  return normalized === '/v3-preview' || normalized.startsWith('/v3-preview/');
+}
+
+function isPreviewPath(pathname: string): boolean {
+  return isV2PreviewPath(pathname) || isV3PreviewPath(pathname);
+}
+
 export function SiteHeader({
   locale,
   dict: dictProp,
@@ -217,7 +226,7 @@ export function SiteHeader({
 
   /** Strip /<locale> prefix from pathname to compare with nav item hrefs */
   const pathWithoutLocale = pathname?.replace(new RegExp(`^/${locale}`), '') || '/';
-  const isV2PreviewSurface = isV2PreviewPath(pathWithoutLocale);
+  const isPreviewSurface = isPreviewPath(pathWithoutLocale);
   function isActive(href: string): boolean {
     if (href === '/') return pathWithoutLocale === '/' || pathWithoutLocale === '';
     if (href === '/area-guide') {
@@ -298,7 +307,7 @@ export function SiteHeader({
           </nav>
 
           <div className="header-actions">
-            {shortlistCta && !isV2PreviewSurface ? (
+            {shortlistCta && !isPreviewSurface ? (
               <Link
                 href={resolveCtaHref(locale, shortlistCta)}
                 prefetch={false}

--- a/admin-app/components/layout/PublicClientEnhancements.tsx
+++ b/admin-app/components/layout/PublicClientEnhancements.tsx
@@ -54,6 +54,15 @@ function isV2PreviewPath(pathname: string): boolean {
   return normalizePathForSurface(pathname) === '/v2-preview';
 }
 
+function isV3PreviewPath(pathname: string): boolean {
+  const normalized = normalizePathForSurface(pathname);
+  return normalized === '/v3-preview' || normalized.startsWith('/v3-preview/');
+}
+
+function isPreviewPath(pathname: string): boolean {
+  return isV2PreviewPath(pathname) || isV3PreviewPath(pathname);
+}
+
 export function PublicClientEnhancements() {
   const pathname = usePathname() ?? '/';
   const [showAnalytics, setShowAnalytics] = useState(false);
@@ -62,7 +71,7 @@ export function PublicClientEnhancements() {
   const [showAiWidget, setShowAiWidget] = useState(false);
   const showFloatingWhatsApp = shouldRenderFloatingWhatsApp(pathname);
   const pathWithoutLocale = pathname.replace(/^\/(en|th)(?=\/|$)/, '') || '/';
-  const isPreviewSurface = isV2PreviewPath(pathWithoutLocale);
+  const isPreviewSurface = isPreviewPath(pathWithoutLocale);
   const isCalmerSurface = pathWithoutLocale === '/' || pathWithoutLocale === '/projects' || isPreviewSurface;
 
   useEffect(() => {

--- a/admin-app/middleware.ts
+++ b/admin-app/middleware.ts
@@ -18,7 +18,10 @@ const NON_LOCALIZED_ROUTE_PREFIXES = [
   '/home-composer',
   '/telemetry',
 ] as const;
-const ENGLISH_ONLY_PREVIEW_BLOCKED_PATHS = new Set(['/th/v2-preview', '/th/v2-preview/']);
+const ENGLISH_ONLY_PREVIEW_BLOCKED_PREFIXES = [
+  '/th/v2-preview',
+  '/th/v3-preview',
+];
 
 function isLocale(value: string | undefined): value is Locale {
   return (LOCALES as readonly string[]).includes(value ?? '');
@@ -26,6 +29,10 @@ function isLocale(value: string | undefined): value is Locale {
 
 function hasRoutePrefix(pathname: string, prefix: string): boolean {
   return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+function isEnglishOnlyPreviewBlockedPath(pathname: string): boolean {
+  return ENGLISH_ONLY_PREVIEW_BLOCKED_PREFIXES.some((prefix) => hasRoutePrefix(pathname, prefix));
 }
 
 const PUBLIC_FILE = /\.[^/]+$/;
@@ -151,8 +158,8 @@ export function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  // AMP Public v2 Phase 1 is English-only. Force a real HTTP 404 for the Thai preview path.
-  if (ENGLISH_ONLY_PREVIEW_BLOCKED_PATHS.has(pathname)) {
+  // AMP public previews are English-only. Force a real HTTP 404 for Thai preview paths.
+  if (isEnglishOnlyPreviewBlockedPath(pathname)) {
     const response = new NextResponse(null, { status: 404 });
     response.headers.set('x-next-pathname', pathname);
     response.headers.set('Cache-Control', 'no-store');


### PR DESCRIPTION
## Summary

Adds a separate AMP Pattaya V3 design preview route for owner/design review without replacing production public routes or the existing V2 preview.

## Preview URL

- `/en/v3-preview`

## Route behavior

- `/en/v3-preview` = 200
- `/en/v3-preview/` = 200
- `/th/v3-preview` = 404
- `/th/v3-preview/` = 404

## Validation

- Targeted Vitest: 3 files / 22 tests
- `git diff --cached --check`: pass
- `npm run build`: pass
- Visual QA: 1440 / 768 / 390 pass

## Safety

- no deploy
- no VPS/SSH
- no secrets/env access
- no production route replacement
- no backend/API/schema/database changes
- no admin CMS changes
- no analytics/tracking changes
- no LeadForm submit contract changes

## Note

Design-preview only, not production-ready implementation. Owner review is required before any production route replacement.